### PR TITLE
Phase 0 · Continuous integration pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+# Least privilege: the workflow only needs to read the repository.
+permissions:
+  contents: read
+
+# A new push to the same ref supersedes the run in flight.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: check (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      # Report every failing version, not just the first.
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      # --locked fails if uv.lock is out of date with pyproject.toml, so a
+      # dependency change cannot land without its lockfile.
+      - name: Sync environment
+        run: uv sync --locked --python ${{ matrix.python-version }}
+
+      - name: Lint
+        run: uv run ruff check
+
+      - name: Formatting
+        run: uv run ruff format --check
+
+      - name: Type check
+        run: uv run mypy
+
+      - name: Tests
+        run: uv run pytest

--- a/feature_list.json
+++ b/feature_list.json
@@ -96,15 +96,15 @@
         "scaffold"
       ],
       "user_visible_behavior": "Every pull request shows a green check, and a broken lint, type or test turns it red before merge.",
-      "status": "in_progress",
+      "status": "passing",
       "verification": [
         "Open a pull request into dev and confirm the workflow runs on Python 3.12 and 3.13.",
         "Confirm the run includes ruff check, ruff format --check, mypy and pytest.",
         "Push a commit with a deliberate lint error and confirm the check goes red.",
         "Revert it and confirm the check returns green."
       ],
-      "evidence": "",
-      "notes": "Must exist before the parity tests, since their whole value is running on every commit. Started 2026-08-22 on feature/2_ci-pipeline."
+      "evidence": "2026-08-22, PR #15 into dev, commit 1ff265a. Observed the full gate cycle on the PR, not locally: (1) green - runs/32518425893, check (py3.12) and check (py3.13) both conclusion=success; (2) red - pushed a deliberate unused-import error, runs/32518478528, both jobs conclusion=failure, confirming the gate actually blocks; (3) green again after dropping that commit - runs/32518536838, both conclusion=success. Matrix confirmed running 3.12 and 3.13 as separate jobs.",
+      "notes": "Workflow at .github/workflows/ci.yml. Triggers on push and pull_request for main and dev - the issue said main only, but dev is the integration branch, so that is where checks need to run. uv sync --locked blocks a dependency change landing without its lockfile. fail-fast: false reports every failing version. Concurrency grouped by ref. permissions: contents: read."
     },
     {
       "id": "reference-datasets",

--- a/feature_list.json
+++ b/feature_list.json
@@ -96,7 +96,7 @@
         "scaffold"
       ],
       "user_visible_behavior": "Every pull request shows a green check, and a broken lint, type or test turns it red before merge.",
-      "status": "not_started",
+      "status": "in_progress",
       "verification": [
         "Open a pull request into dev and confirm the workflow runs on Python 3.12 and 3.13.",
         "Confirm the run includes ruff check, ruff format --check, mypy and pytest.",
@@ -104,7 +104,7 @@
         "Revert it and confirm the check returns green."
       ],
       "evidence": "",
-      "notes": "Must exist before the parity tests, since their whole value is running on every commit."
+      "notes": "Must exist before the parity tests, since their whole value is running on every commit. Started 2026-08-22 on feature/2_ci-pipeline."
     },
     {
       "id": "reference-datasets",


### PR DESCRIPTION
Adds `.github/workflows/ci.yml`, running lint, formatting, type checking and tests on Python 3.12 and 3.13.

This is also the first pull request under the workflow recorded in `CLAUDE.md` — feature branches now reach `dev` through a pull request rather than a local merge, with CI as the gate.

## What it runs

| Step | Command |
| --- | --- |
| Sync | `uv sync --locked --python <version>` |
| Lint | `uv run ruff check` |
| Formatting | `uv run ruff format --check` |
| Type check | `uv run mypy` |
| Tests | `uv run pytest` |

## Choices worth noting

- **Triggers include `dev`, not only `main`.** The issue said pushes to `main`, but `dev` is the integration branch under the branching model, so that is where checks actually need to run.
- **`uv sync --locked`** fails when `uv.lock` is out of date with `pyproject.toml`, so a dependency change cannot land without its lockfile.
- **`fail-fast: false`** so a failure reports on every Python version rather than only the first.
- **Concurrency grouped by ref**, so a new push supersedes the run in flight.
- **`permissions: contents: read`** — the workflow needs nothing more.

## Verification

All four commands pass locally on this branch. The meaningful check is the negative one, which happens on this pull request: a deliberate lint error must turn it red, and reverting must turn it green again. Evidence goes into `feature_list.json` once observed here.

Closes #2