### PR TITLE
Phase 0 · Specify the PCA algorithm and its diagnostics

### DIFF
--- a/docs/algorithms/pca.md
+++ b/docs/algorithms/pca.md
@@ -1,0 +1,238 @@
+# PCA — algorithm specification
+
+Status: **normative**. This document fixes the conventions the implementation must follow. Where an implementation and this document disagree, one of them is a bug; decide which before changing either.
+
+Every quantity a PCA model can display in the application is defined here. If a quantity is not defined here, it is not reported.
+
+---
+
+## 1. Notation
+
+| Symbol | Meaning |
+| --- | --- |
+| $X$ | Data matrix, $n \times p$. Rows are samples, columns are variables. Never transposed silently. |
+| $n$ | Number of samples |
+| $p$ | Number of variables |
+| $a$ | Number of retained components |
+| $r$ | Rank available for decomposition |
+| $T$ | Scores, $n \times a$ |
+| $P$ | Loadings, $p \times a$ |
+| $\lambda_k$ | Variance associated with component $k$ |
+
+---
+
+## 2. What PCA does and does not do
+
+**PCA fits the matrix it is given. It performs no centring and no scaling of its own.**
+
+Centring and scaling are explicit pipeline steps (`MeanCentre`, `Autoscale`) and appear as nodes in the pipeline graph. This follows from the project's central rule that the pipeline is the complete record of what was done: preprocessing hidden inside an estimator would be absent from the recipe and therefore absent from the lineage.
+
+Two consequences to be aware of:
+
+- **This differs from `scikit-learn`.** `sklearn.decomposition.PCA` centres internally and unconditionally. Parity comparisons must therefore feed it an already-centred matrix, where its own centring is a no-op. Feeding raw data to both and comparing is an invalid test.
+- **Fitting PCA on uncentred data is legal here and usually wrong.** The first component then largely captures the mean spectrum. The application must warn when a PCA node has no centring step upstream. The warning is a UI affordance, not a silent correction.
+
+Recommended default for spectral data: mean centring, no scaling. Autoscaling is appropriate when variables carry different units or wildly different variances, which is uncommon for a single spectral block.
+
+---
+
+## 3. Algorithm
+
+**Singular value decomposition**, computed on the matrix as supplied:
+
+$$X = U \Sigma V^{\top}$$
+
+with singular values $\sigma_1 \ge \sigma_2 \ge \dots \ge \sigma_r \ge 0$.
+
+**Why SVD rather than NIPALS.** SVD is deterministic, needs no convergence tolerance, is numerically stable for near-collinear spectra, and returns the full component set in one pass. NIPALS earns its place in two situations: extracting a few components from a matrix too large to decompose whole, and tolerating missing values. Neither applies — the performance envelope keeps $X$ in memory, and missing values are rejected (§9).
+
+**Randomised or truncated SVD is not used.** It is not deterministic without a fixed seed, and a decomposition whose result depends on a random draw is not something a parity report can stand behind.
+
+The decomposition is computed by LAPACK through `numpy.linalg.svd` with `full_matrices=False`.
+
+---
+
+## 4. Outputs
+
+$$P = V_{[:,\,1:a]} \qquad T = X P \qquad \lambda_k = \frac{\sigma_k^{2}}{n-1}$$
+
+- **Loadings** $P$ — orthonormal columns, $P^{\top}P = I_a$.
+- **Scores** $T$ — equal to $U_{[:,1:a]} \Sigma_{[1:a]}$, but computed as $XP$ so that the same code path projects new samples.
+- **$\lambda_k$** — the variance captured by component $k$. The divisor is $n-1$, matching the sample-variance convention used everywhere else in the project.
+
+**All $r$ singular values are retained on the fitted model**, not only the first $a$. Both the explained-variance denominator (§6) and the SPE limit (§8) require the residual eigenvalues, and recomputing them later would mean re-decomposing.
+
+### Projecting new samples
+
+$$T_{\text{new}} = X_{\text{new}} P$$
+
+$X_{\text{new}}$ must have been through the identical preprocessing chain, using parameters estimated on the calibration set — the calibration mean, not the new set's mean. This is a property of the pipeline executor; it is stated here because getting it wrong produces plausible and entirely wrong scores.
+
+---
+
+## 5. Sign convention
+
+The signs of $U$ and $V$ are jointly arbitrary: negating column $k$ of both leaves $X$ unchanged. A convention is required or results are irreproducible across platforms and LAPACK builds.
+
+**Rule.** For each component $k$, let $j^{*} = \arg\max_j |P_{jk}|$, the position of the largest-magnitude loading. If $P_{j^{*}k} < 0$, negate both $P_{[:,k]}$ and $T_{[:,k]}$. Ties in $|P_{jk}|$ are broken by taking the smallest index $j$.
+
+The rule is applied to the **loadings**, because for spectral data the loading is the interpretable, spectrum-shaped vector, and its orientation is what an analyst reads.
+
+This differs from `scikit-learn`'s default `svd_flip(..., u_based_decision=True)`, which decides from $U$. Signs may therefore differ from `sklearn` per component even when both are correct.
+
+**Comparisons must be sign-invariant.** Before comparing a component against a reference, align it: if $\langle P_{[:,k]}^{\text{ours}},\, P_{[:,k]}^{\text{ref}} \rangle < 0$, negate both $P_{[:,k]}$ and $T_{[:,k]}$ of one side. Comparing absolute values instead is not acceptable — it would pass a result whose loading and score signs disagree with each other, which is a real error.
+
+---
+
+## 6. Explained variance
+
+$$\mathrm{EV}_k = \frac{\lambda_k}{\sum_{j=1}^{r} \lambda_j} \qquad \mathrm{CEV}_a = \sum_{k=1}^{a} \mathrm{EV}_k$$
+
+**The denominator sums over all $r$ components, not the $a$ retained ones.** Normalising by the retained components would make cumulative explained variance always reach 100%, which is both useless and a mistake seen in the wild.
+
+The denominator equals the total variance of the matrix PCA was fitted to:
+
+$$\sum_{j=1}^{r} \lambda_j = \frac{1}{n-1}\lVert X \rVert_F^{2}$$
+
+For centred $X$ this is the sum of the column variances. For uncentred $X$ it is not, which is a further reason the application warns about missing centring: explained variance is reported against a total that includes the mean.
+
+Reported as a fraction internally; formatted as a percentage in the UI.
+
+---
+
+## 7. Hotelling's $T^{2}$
+
+Distance within the model plane.
+
+$$T^{2}_i = \sum_{k=1}^{a} \frac{t_{ik}^{2}}{\lambda_k}$$
+
+Equivalently $t_i \Lambda^{-1} t_i^{\top}$ with $\Lambda = \mathrm{diag}(\lambda_1 \dots \lambda_a)$. Components are weighted by their variance, so a large score on a minor component contributes more than the same score on a major one.
+
+### Confidence limits
+
+Two limits, because they answer different questions. **Which one is drawn must be stated in the plot legend, never left implicit.**
+
+**Calibration samples** — samples used to fit the model. Their scores are not independent of the model, so the exact limit is the beta distribution:
+
+$$T^{2}_{\alpha} = \frac{(n-1)^{2}}{n} \, B_{\alpha}\!\left(\frac{a}{2},\ \frac{n-a-1}{2}\right)$$
+
+**New samples** — projected onto an existing model:
+
+$$T^{2}_{\alpha} = \frac{a\,(n^{2}-1)}{n\,(n-a)} \, F_{\alpha}(a,\ n-a)$$
+
+$\alpha$ defaults to 0.05, giving a 95% limit. $n$ and $a$ are always those of the **calibration** model, including when the limit is applied to new samples.
+
+The two converge as $n$ grows. They differ noticeably for small $n$, which is the common case in chemometrics, so both are implemented rather than approximating one with the other.
+
+Requires $n > a + 1$ for the beta form and $n > a$ for the F form. Outside those, no limit is defined and none is drawn.
+
+---
+
+## 8. Squared prediction error (SPE, also written $Q$)
+
+Distance from the model plane.
+
+$$\hat{x}_i = t_i P^{\top} \qquad e_i = x_i - \hat{x}_i \qquad \mathrm{SPE}_i = \lVert e_i \rVert^{2} = \sum_{j=1}^{p} e_{ij}^{2}$$
+
+Reported as the sum of squares, **not** the mean and not the root. Other packages report the root or the mean; converting is trivial but silent disagreement is not.
+
+### Confidence limit — Jackson–Mudholkar
+
+With $\theta_m = \sum_{k=a+1}^{r} \lambda_k^{m}$ for $m \in \{1,2,3\}$ and $h_0 = 1 - \dfrac{2\theta_1\theta_3}{3\theta_2^{2}}$:
+
+$$\mathrm{SPE}_{\alpha} = \theta_1 \left[ \frac{c_{\alpha}\sqrt{2\theta_2 h_0^{2}}}{\theta_1} + 1 + \frac{\theta_2 h_0 (h_0-1)}{\theta_1^{2}} \right]^{1/h_0}$$
+
+where $c_{\alpha}$ is the standard normal deviate at the upper $\alpha$ tail ($c_{0.05} \approx 1.645$).
+
+**This is why all $r$ eigenvalues are retained (§4).** $\theta_m$ sums over the *discarded* components. A model that kept only the first $a$ eigenvalues cannot compute its own SPE limit.
+
+**Box's $\chi^2$ approximation is not used** as the default, but is recorded here because other packages use it and the difference will show up in comparisons:
+
+$$\mathrm{SPE}_{\alpha} = g\,\chi^{2}_{\alpha}(h), \qquad g = \frac{\theta_2}{\theta_1}, \qquad h = \frac{\theta_1^{2}}{\theta_2}$$
+
+**Degenerate case.** When $a = r$ the residual is zero by construction: $\mathrm{SPE}_i = 0$ for all $i$, $\theta_m = 0$, and no limit exists. Report SPE as exactly zero and draw no limit. Do not report a limit computed from an empty sum.
+
+---
+
+## 9. Rank, and $n\_components$ beyond it
+
+Available rank:
+
+$$r = \min(n - 1,\ p) \quad \text{when the data are centred}, \qquad r = \min(n,\ p) \quad \text{otherwise}$$
+
+Centring removes one degree of freedom, which is why the centred case loses a component. Since PCA does not centre (§2), the implementation cannot infer which case applies from the matrix alone; it takes the effective rank from the SVD, counting singular values above a tolerance of $\max(n,p) \cdot \varepsilon \cdot \sigma_1$ with $\varepsilon$ the float64 machine epsilon.
+
+**If $a > r$, raise an error naming both numbers. Do not silently return fewer components.** Silent truncation makes downstream array shapes unpredictable and hides a user mistake — asking for 40 components from 30 samples is a misunderstanding worth surfacing, not rounding away.
+
+---
+
+## 10. Missing values
+
+**Rejected.** PCA requires a complete matrix. A `NaN` anywhere raises an error naming the offending rows and columns.
+
+Missing data is handled upstream, explicitly: exclude the sample, exclude the variable, or add an imputation step to the pipeline. Each of those appears in the recipe and therefore in the lineage.
+
+Imputing inside PCA — or quietly using NIPALS's tolerance for gaps — would mean two datasets that differ in their missing entries produce results that look equally trustworthy, with nothing in the record showing that one was partly invented.
+
+---
+
+## 11. Numerical policy
+
+- Computation in **float64**, regardless of the storage dtype. Data may be held as float32 for memory; it is promoted before decomposition and results are returned as float64.
+- **The caller's array is never modified.**
+- **No random state.** SVD is deterministic, so PCA takes no seed. Any future component that needs randomness must take an explicit seed.
+- Eigenvalues below the §9 rank tolerance are treated as exactly zero when forming $\theta_m$, to keep the SPE limit from being driven by numerical noise.
+
+---
+
+## 12. Reported quantities
+
+| Name | Symbol | Defined in |
+| --- | --- | --- |
+| `scores` | $T$ | §4 |
+| `loadings` | $P$ | §4 |
+| `eigenvalues` | $\lambda_k$ | §4 |
+| `explained_variance` | $\mathrm{EV}_k$ | §6 |
+| `cumulative_explained_variance` | $\mathrm{CEV}_a$ | §6 |
+| `hotelling_t2` | $T^{2}_i$ | §7 |
+| `hotelling_t2_limit` | $T^{2}_{\alpha}$ | §7 |
+| `spe` | $\mathrm{SPE}_i$ | §8 |
+| `spe_limit` | $\mathrm{SPE}_{\alpha}$ | §8 |
+
+`explained_variance` maps to the field of the same name on `Metrics` in the schema; the diagnostics travel with the fitted model artifact.
+
+---
+
+## 13. Known divergences from other packages
+
+Recorded so the parity report can classify them as *differs by documented convention* rather than as failures.
+
+| Area | Here | Elsewhere |
+| --- | --- | --- |
+| Centring | Explicit pipeline step | `sklearn` centres internally and unconditionally |
+| Sign rule | Largest-magnitude **loading** | `sklearn` decides from $U$ by default |
+| SPE scale | Sum of squares | Some packages report the mean or its root |
+| SPE limit | Jackson–Mudholkar | Some packages use Box's $\chi^{2}$ |
+| $T^2$ limit | Beta for calibration, F for new samples | Some packages use the F form for both |
+| Rank overflow | Error | Some packages silently truncate |
+
+---
+
+## 14. Parity references
+
+Comparison targets, all reproducible without a commercial licence:
+
+- `scikit-learn` `PCA` — scores, loadings, explained variance, on pre-centred input.
+- R `prcomp(center = FALSE)` and `mdatools` — scores, loadings, and the $T^{2}$ and SPE limits, which `sklearn` does not provide.
+- Published values for the reference datasets.
+
+Tolerances and the claim tiers are defined by the parity harness, not here.
+
+---
+
+## 15. Deliberately not specified here
+
+- Tolerance values and comparison mechanics — parity harness.
+- How the number of components is chosen — a UI and workflow question, not an algorithmic one.
+- Contribution plots — deferred until there is a diagnostic view that needs them.
+- Robust or kernel PCA — out of scope for 1.0.

--- a/feature_list.json
+++ b/feature_list.json
@@ -56,7 +56,7 @@
       "issue": 3,
       "depends_on": [],
       "user_visible_behavior": "docs/algorithms/pca.md defines every quantity a PCA model will ever display, including the Hotelling T-squared and SPE limits.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "Open docs/algorithms/pca.md.",
         "Confirm the algorithm (SVD or NIPALS) is chosen with a reason.",
@@ -64,8 +64,8 @@
         "Confirm explained variance, Hotelling T-squared and SPE/Q each have a formula and a stated confidence limit with its distribution and degrees of freedom.",
         "Confirm missing-value policy and behaviour when n_components exceeds rank are covered."
       ],
-      "evidence": "",
-      "notes": "Documentation only. Blocks #7 and #11."
+      "evidence": "2026-08-22, branch feature/3_pca-spec. docs/algorithms/pca.md reviewed against the issue #3 checklist, each item mapped to a section: algorithm choice with reason -> section 3; centring/scaling convention and default -> section 2; sign convention and sign-invariant comparison -> section 5; explained variance and cumulative form -> section 6; Hotelling T2 with beta and F limits, distributions and degrees of freedom -> section 7; SPE with the Jackson-Mudholkar limit -> section 8; missing-value policy -> section 10; n_components beyond rank -> section 9. Section 12 lists every reported quantity with its defining section, so the 'one written definition per displayed quantity' exit condition is checkable.",
+      "notes": "Decisions worth knowing: SVD not NIPALS, and not randomised SVD, because a decomposition that depends on a random draw cannot back a parity report. PCA performs no centring of its own - centring is a pipeline node, so it appears in the lineage; this diverges from scikit-learn and means parity tests must feed sklearn pre-centred data. Sign rule keys on the largest-magnitude loading, not on U as sklearn does. All r eigenvalues are retained because the SPE limit sums over the discarded ones. Two T2 limits (beta for calibration samples, F for new) rather than approximating one with the other, since n is typically small in chemometrics. Section 13 lists six known divergences from other packages for the parity report to classify."
     },
     {
       "id": "scaffold",


### PR DESCRIPTION
Adds `docs/algorithms/pca.md`. Documentation only — no code.

`PROPOSAL.md` §10 says *"PLS" is not a specification*; the same holds for PCA. This fixes the conventions before the kernel exists, so the kernel has something to be correct against.

## Decisions worth reviewing

- **SVD, not NIPALS** — deterministic, no convergence tolerance, stable on near-collinear spectra. NIPALS earns its place only for matrices too large to decompose whole or for tolerating missing values; neither applies here. **Randomised SVD is explicitly excluded**: a decomposition that depends on a random draw cannot back a parity report.
- **PCA performs no centring of its own.** Centring and scaling are pipeline nodes, so they appear in the recipe and therefore in the lineage. This diverges from `scikit-learn`, which centres internally and unconditionally — so parity tests must feed it pre-centred data, and comparing raw input against both is an invalid test. The application warns when a PCA node has no centring upstream; it does not silently correct.
- **Sign rule keys on the largest-magnitude loading**, not on $U$ as `sklearn` does, because the loading is the spectrum-shaped vector an analyst actually reads. Comparisons align signs by inner product rather than comparing absolute values — the latter would pass a result whose score and loading signs disagree with each other.
- **All $r$ eigenvalues are retained on the fitted model**, because the SPE limit sums over the *discarded* components. A model keeping only the first $a$ cannot compute its own limit.
- **Two Hotelling $T^2$ limits** — beta for calibration samples, F for new ones — rather than approximating one with the other. They diverge at small $n$, which is the common case in chemometrics. Which limit is drawn must appear in the plot legend.
- **SPE is a sum of squares**, not a mean or a root, and uses Jackson–Mudholkar rather than Box's $\chi^2$.
- **Asking for more components than the rank is an error**, not silent truncation.

## Divergences recorded

§13 lists six places this deliberately differs from other packages, so the parity report can classify them as *differs by documented convention* rather than as failures.

## Verification

Each item of the issue checklist maps to a section — recorded in `feature_list.json` under `evidence`. §12 lists every reported quantity against its defining section, which makes the "one written definition per displayed quantity" exit condition checkable rather than a judgement call.

Closes #3