### PR TITLE
Evaluate chemotools: rejected for the runtime, adopted as a dev-only reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ Follow this on every session. It exists because the failure mode in a long solo 
 
 When scaffolding, use these — they are the recorded stack, and deviating from them is a decision worth surfacing:
 
-- **Backend:** Python, `uv` for environment and dependency management, FastAPI, Pydantic, NumPy, SciPy, pandas, scikit-learn. Lint with `ruff`, type-check with `mypy`, test with `pytest`.
+- **Backend:** Python, `uv` for environment and dependency management, FastAPI, Pydantic, NumPy, SciPy, pandas. Lint with `ruff`, type-check with `mypy`, test with `pytest`.
+- **`scikit-learn` and `chemotools` are development dependencies, not runtime ones**, and must not be added to `[project.dependencies]`. They are the open reference implementations the parity fixtures are generated against; a kernel that imported either would be a wrapper around the thing we claim parity with. `chemotools` was evaluated in Phase 0 (#13) and rejected for the runtime for that reason plus its weight — it requires scikit-learn and installs 20 MB, 17 MB of it bundled example data. It is adopted as a reference for SNV, MSC and the baselines, which have no other. The evidence is in `docs/decisions/0001-chemotools.md`.
 - **Frontend:** Node.js with `pnpm`, Vite, React, TypeScript, Tailwind CSS, shadcn/ui, TanStack Query, Plotly.js. Test with `vitest`, end-to-end with `playwright`.
 - **Data:** SQLite via SQLAlchemy for metadata, pipelines, experiments, metrics and lineage. Files (datasets, processed arrays, model artifacts, reports) live in the project directory on disk; the database stores references, never contents.
 - **Packaging:** PyInstaller, three-platform GitHub Actions matrix.
@@ -76,5 +77,7 @@ At the end of a phase: open a pull request from `dev` into `main`, merge it, tag
 The repository's release branch is named `main` — there is no `master`.
 
 ## Documents
+
+Decisions that were taken with evidence and should not be re-argued from preference live in `docs/decisions/`, numbered and dated. Read the relevant one before revisiting a dependency or a convention it covers.
 
 `PROPOSAL.md` is canonical and git-diffable. A designed HTML rendering of the same content is published as an artifact at https://claude.ai/code/artifact/3d5f2071-b55a-4197-aa97-409146fbb488 — when `PROPOSAL.md` changes materially, the artifact should be republished to that same URL so the two do not drift.

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -172,9 +172,10 @@ The original draft named **SpectroChemPy** and **process-improve** as core depen
 
 **What is used instead:**
 
-- **NumPy / SciPy / pandas / scikit-learn** — the numerical foundation. `PLSRegression`, `PCA`, cross-validation, pipelines and metrics come from scikit-learn, which is well-tested, widely trusted and already the lingua franca.
-- **`chemotools`** (subject to evaluation in Phase 0) — scikit-learn-compatible spectral preprocessing transformers. If it holds up under the parity tests in §10, it drops directly into a `Pipeline` and saves writing preprocessing from scratch.
-- **Purpose-written kernels** for the remainder: SNV, MSC, baseline correction, Hotelling T², SPE/Q, VIP scores, and any preprocessing `chemotools` does not cover. This is on the order of a few hundred lines of textbook mathematics. Owning it means owning its tests, its numerical conventions and its documentation — which for a project whose credibility rests on numerical trust is a feature, not a burden.
+- **NumPy / SciPy / pandas** — the numerical foundation the kernels are built on.
+- **`scikit-learn`** — the **reference implementation the parity fixtures are generated against, and a development dependency only**. It is not on the application's code path. *This is a change from the draft, which said `PLSRegression`, `PCA`, cross-validation and metrics would come from scikit-learn.* Phase 0 wrote them instead, to the specifications in `docs/algorithms/`, because a kernel built on scikit-learn cannot then be compared against scikit-learn — and the parity report in §10 is the thing this project is asking to be trusted on. What was gained is not accuracy but evidence: coefficients, predictions, scores, loadings, eigenvalues, RMSECV and the rest now agree with an independent implementation to the last bits, and the disagreements that remain are documented conventions rather than accidents.
+- **`chemotools`** — **evaluated in Phase 0 and rejected as a runtime dependency; adopted as a dev-only reference implementation** for SNV, MSC and the three baseline methods, which have no other external reference. It is not shipped: it requires scikit-learn, which is dev-only here, and installs 20 MB of which 17 MB is example datasets the application would never read. The full evidence, per transform, is in [`docs/decisions/0001-chemotools.md`](docs/decisions/0001-chemotools.md).
+- **Purpose-written kernels** for everything scientifically load-bearing: preprocessing, PCA, PLS, the metrics, the cross-validation protocol, Hotelling T², SPE/Q and VIP scores. This is on the order of a few thousand lines of textbook mathematics. Owning it means owning its tests, its numerical conventions and its documentation — which for a project whose credibility rests on numerical trust is a feature, not a burden.
 - **Format readers** — this is where third-party libraries genuinely earn their place (§6).
 
 The dependency rule for the project: *take a dependency for the tedious and well-solved (file formats, numerics primitives); own the scientifically load-bearing and small.*
@@ -304,7 +305,9 @@ React · TypeScript · Vite · Tailwind CSS · shadcn/ui · TanStack Query · Pl
 *Change from v1:* Zustand is dropped for now. For a single-user local application, TanStack Query covers server state and React's own state covers the rest. A dedicated client-state library can be added the moment there is state that genuinely needs it — shipping two state systems by default is a cost with no current benefit.
 
 ### Backend
-Python · FastAPI · Pydantic · NumPy · SciPy · pandas · scikit-learn · `chemotools` (pending Phase 0 evaluation) · format readers per §6
+Python · FastAPI · Pydantic · NumPy · SciPy · pandas · format readers per §6
+
+*Not shipped:* scikit-learn and `chemotools` are development dependencies — reference implementations the parity fixtures are generated against, never on the application's code path (§7).
 
 *Change from v1:* SpectroChemPy and process-improve removed (§7).
 

--- a/docs/decisions/0001-chemotools-evidence.py
+++ b/docs/decisions/0001-chemotools-evidence.py
@@ -1,0 +1,252 @@
+"""Regenerate the measurements in `0001-chemotools.md`.
+
+    CHEMOMETRICS_DOWNLOAD_DATASETS=1 uv run --with chemotools==0.4.3 python \
+        docs/decisions/0001-chemotools-evidence.py
+
+`chemotools` is deliberately **not** a dependency of this project — that is what
+the decision record decides — so this script is run with `uv run --with`, which
+installs it into a throwaway environment and leaves `pyproject.toml` alone. It
+is committed because a decision whose numbers cannot be re-derived is a
+preference with a table attached.
+
+It asserts nothing. Every number it prints is quoted in the record beside the
+reading it was given, and a rerun that disagrees is a finding about the record.
+"""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from collections.abc import Callable
+
+import numpy as np
+
+# chemotools 0.4.3 emits FutureWarnings for three modules that have moved and
+# SyntaxWarnings from docstrings in its own source. Both are quoted in the
+# record as maintenance evidence; silenced here so the numbers are readable.
+warnings.filterwarnings("ignore")
+
+from chemotools.baseline import (  # noqa: E402
+    AsLs,
+    PolynomialCorrection,
+    RubberbandCorrection,
+)
+from chemotools.derivative import SavitzkyGolay  # noqa: E402
+from chemotools.outliers import HotellingT2, QResiduals  # noqa: E402
+from chemotools.scale import NormScaler  # noqa: E402
+from chemotools.scatter import (  # noqa: E402
+    MultiplicativeScatterCorrection,
+    StandardNormalVariate,
+)
+from sklearn.decomposition import PCA as SklearnPCA  # noqa: E402
+
+from chemometrics_workbench.datasets import (  # noqa: E402
+    load_corn,
+    load_gasoline,
+    load_tecator,
+)
+from chemometrics_workbench.decomposition import PCA  # noqa: E402
+from chemometrics_workbench.preprocessing import (  # noqa: E402
+    BaselineCorrectTransformer,
+    MSCTransformer,
+    NormaliseTransformer,
+    SavitzkyGolayTransformer,
+    SNVTransformer,
+)
+
+LOADERS = {"corn": load_corn, "gasoline": load_gasoline, "tecator": load_tecator}
+
+# The same block the #9 and #10 preprocessing references were generated on. A
+# window of 5 leaves four of its eight columns as edge columns, which is what
+# makes the Savitzky-Golay comparison a test of the edge convention.
+BLOCK = (slice(0, 5), slice(0, 8))
+SAVGOL_WINDOW, SAVGOL_POLYORDER = 5, 2
+N_COMPONENTS = 5
+
+
+def difference(ours: np.ndarray, theirs: np.ndarray) -> tuple[float, float]:
+    """Largest absolute difference, and the same relative to the reference's scale."""
+    ours = np.asarray(ours, dtype=np.float64)
+    theirs = np.asarray(theirs, dtype=np.float64)
+    largest = float(np.abs(ours - theirs).max())
+    scale = max(float(np.abs(theirs).max()), np.finfo(np.float64).tiny)
+    return largest, largest / scale
+
+
+def report(label: str, ours: np.ndarray, theirs: np.ndarray) -> None:
+    absolute, relative = difference(ours, theirs)
+    print(f"  {label:<46} abs {absolute:.3e}   relative {relative:.3e}")
+
+
+def heading(text: str) -> None:
+    print()
+    print("=" * 78)
+    print(text)
+    print("=" * 78)
+
+
+def refused(label: str, call: Callable[[], object]) -> None:
+    """Print what a kernel does with input it should refuse."""
+    try:
+        result = call()
+        values = np.unique(np.asarray(result, dtype=np.float64))[:3]
+        print(f"  {label:<12} accepted it and returned {values}")
+    except Exception as error:
+        message = str(error).replace("\n", " ")[:100]
+        print(f"  {label:<12} {type(error).__name__}: {message}")
+
+
+blocks = {name: loader().spectra[BLOCK] for name, loader in LOADERS.items()}
+spectra = {name: loader().spectra for name, loader in LOADERS.items()}
+
+
+heading("1. SNV")
+for name, block in blocks.items():
+    theirs = StandardNormalVariate().fit_transform(block)
+    report(f"{name}: ours ddof=1 (our default)", SNVTransformer(1).fit_transform(block), theirs)
+    report(
+        f"{name}: ours ddof=0 (their convention)", SNVTransformer(0).fit_transform(block), theirs
+    )
+
+
+heading("2. MSC")
+for name, block in blocks.items():
+    for reference in ("mean", "median"):
+        ours = MSCTransformer(reference).fit_transform(block)  # type: ignore[arg-type]
+        theirs = MultiplicativeScatterCorrection(method=reference).fit_transform(block)
+        report(f"{name}: reference={reference}", ours, theirs)
+
+print()
+print("  Does the fitted reference travel to a held-out block, or is it re-estimated?")
+for name, full in spectra.items():
+    calibration, held_out = full[:20], full[20:30]
+    ours_fitted = MSCTransformer("mean").fit(calibration)
+    theirs_fitted = MultiplicativeScatterCorrection().fit(calibration)
+    ours_held = ours_fitted.transform(held_out)
+    theirs_held = theirs_fitted.transform(held_out)
+    ours_refit = MSCTransformer("mean").fit(held_out).transform(held_out)
+    theirs_refit = MultiplicativeScatterCorrection().fit(held_out).transform(held_out)
+    print(
+        f"  {name}: refitting on the new block changes the result -- "
+        f"ours {not np.allclose(ours_held, ours_refit)}, "
+        f"chemotools {not np.allclose(theirs_held, theirs_refit)}"
+    )
+    report(f"{name}: held-out block", ours_held, theirs_held)
+
+
+heading("3. Savitzky-Golay derivatives")
+print(f"  chemotools signature: {inspect.signature(SavitzkyGolay.__init__)}")
+print()
+for name, block in blocks.items():
+    for deriv in (0, 1, 2):
+        ours = SavitzkyGolayTransformer(
+            window_length=SAVGOL_WINDOW, polyorder=SAVGOL_POLYORDER, deriv=deriv
+        ).fit_transform(block)
+        theirs = SavitzkyGolay(
+            window_length=SAVGOL_WINDOW, polyorder=SAVGOL_POLYORDER, deriv=deriv, mode="interp"
+        ).fit_transform(block)
+        report(f"{name}: deriv={deriv}, their mode='interp'", ours, theirs)
+
+print()
+print("  Their default mode is 'nearest'; ours fixes 'interp'. Full spectra, window 11:")
+for name, full in spectra.items():
+    for deriv in (1, 2):
+        ours = SavitzkyGolayTransformer(window_length=11, polyorder=2, deriv=deriv).fit_transform(
+            full
+        )
+        theirs = SavitzkyGolay(window_length=11, polyorder=2, deriv=deriv).fit_transform(full)
+        report(f"{name}: deriv={deriv}, whole spectrum", ours, theirs)
+        report(f"{name}: deriv={deriv}, interior only", ours[:, 5:-5], theirs[:, 5:-5])
+
+
+heading("4. Baselines")
+for name, full in spectra.items():
+    block = full[:5]
+    report(
+        f"{name}: AsLS lam=1e5 p=0.01",
+        BaselineCorrectTransformer("asls", lam=1e5, p=0.01, max_iter=20).fit_transform(block),
+        AsLs(lam=1e5, penalty=0.01, nr_iterations=20).fit_transform(block),
+    )
+    report(
+        f"{name}: rubberband",
+        BaselineCorrectTransformer("rubberband").fit_transform(block),
+        RubberbandCorrection().fit_transform(block),
+    )
+    report(
+        f"{name}: polynomial order=2",
+        BaselineCorrectTransformer("polynomial", order=2).fit_transform(block),
+        PolynomialCorrection(order=2).fit_transform(block),
+    )
+print()
+for cls in (AsLs, PolynomialCorrection, RubberbandCorrection):
+    print(f"  {cls.__name__}{inspect.signature(cls.__init__)}")
+
+
+heading("5. Normalisation")
+for name, block in blocks.items():
+    for norm, order in (("l1", 1), ("l2", 2)):
+        ours = NormaliseTransformer(norm).fit_transform(block)  # type: ignore[arg-type]
+        report(f"{name}: norm={norm}", ours, NormScaler(l_norm=order).fit_transform(block))
+print()
+refused("chemotools", lambda: NormScaler(l_norm=np.inf).fit_transform(blocks["corn"]))
+print("  ^ our 'max' and 'area' norms have no equivalent: l_norm must be an integer >= 1.")
+
+
+heading("6. Contract behaviour")
+block = blocks["corn"]
+as_float32 = block.astype(np.float32)
+print(
+    f"  float32 in -> ours {SNVTransformer().fit_transform(as_float32).dtype}, "
+    f"chemotools {StandardNormalVariate().fit_transform(as_float32).dtype}"
+)
+
+untouched = block.copy()
+StandardNormalVariate().fit_transform(block)
+SNVTransformer().fit_transform(block)
+print(f"  the caller's array is still intact: {np.array_equal(block, untouched)}")
+
+with_nan = block.copy()
+with_nan[1, 2] = np.nan
+print("  a missing value:")
+refused("ours", lambda: SNVTransformer().fit_transform(with_nan))
+refused("chemotools", lambda: StandardNormalVariate().fit_transform(with_nan))
+
+print("  a narrower matrix at transform:")
+ours_fitted, theirs_fitted = SNVTransformer().fit(block), StandardNormalVariate().fit(block)
+refused("ours", lambda: ours_fitted.transform(block[:, :4]))
+refused("chemotools", lambda: theirs_fitted.transform(block[:, :4]))
+
+constant = np.full((3, 8), 0.7)
+print("  a constant spectrum, whose standard deviation is 1.16e-16 rather than 0.0:")
+refused("ours", lambda: SNVTransformer().fit_transform(constant))
+refused("chemotools", lambda: StandardNormalVariate().fit_transform(constant))
+
+
+heading("7. Outside this decision: the limits #11 is blocked on (see #28)")
+for name, full in spectra.items():
+    centred = full - full.mean(axis=0)
+    ours = PCA(N_COMPONENTS).fit(centred)
+    theirs_model = SklearnPCA(n_components=N_COMPONENTS, svd_solver="full").fit(centred)
+    n = centred.shape[0]
+
+    t2 = HotellingT2(theirs_model, confidence=0.95).fit(centred)
+    q = QResiduals(theirs_model, confidence=0.95, method="jackson-mudholkar").fit(centred)
+    our_spe_limit = ours.spe_limit(0.05)
+    their_spe_limit = float(q.critical_value_)
+    our_t2_limit = ours.hotelling_t2_limit(0.05, "new")
+    their_t2_limit = float(t2.critical_value_)
+
+    print(f"  {name}:")
+    print(
+        f"    SPE limit  ours {our_spe_limit:.17g}  theirs {their_spe_limit:.17g}  "
+        f"relative {abs(our_spe_limit - their_spe_limit) / their_spe_limit:.3e}"
+    )
+    print(
+        f"    T2 limit   ours {our_t2_limit:.10g} (new-sample F form)  "
+        f"theirs {their_t2_limit:.10g}  ratio {our_t2_limit / their_t2_limit:.6f}  "
+        f"(n+1)/n = {(n + 1) / n:.6f}"
+    )
+    print(f"    ours calibration (beta) form: {ours.hotelling_t2_limit(0.05, 'calibration'):.10g}")
+    for method in ("chi-square", "percentile"):
+        variant = QResiduals(theirs_model, confidence=0.95, method=method).fit(centred)
+        print(f"    their Q limit, method={method:<11} {float(variant.critical_value_):.6e}")

--- a/docs/decisions/0001-chemotools.md
+++ b/docs/decisions/0001-chemotools.md
@@ -1,0 +1,142 @@
+# 0001 — `chemotools`: rejected as a runtime dependency, adopted as a dev-only reference
+
+**Date:** 2026-08-22
+**Status:** accepted
+**Issue:** [#13](https://github.com/millermuttu/Chemometrics-Workbench/issues/13)
+**Decides:** `PROPOSAL.md` §7, which listed `chemotools` as provisional pending exactly this evaluation.
+
+---
+
+## Decision
+
+**Per transform, not wholesale:**
+
+| Transform | `chemotools` equivalent | Decision |
+| --- | --- | --- |
+| SNV | `scatter.StandardNormalVariate` | **Reference only.** Bit-identical to ours at `ddof=0`. |
+| MSC | `scatter.MultiplicativeScatterCorrection` | **Reference only.** Agrees to 1e-10 relative. |
+| AsLS baseline | `baseline.AsLs` | **Reference only.** Agrees to 1e-9 relative. |
+| Rubberband baseline | `baseline.RubberbandCorrection` | **Reference only.** Bit-identical. |
+| Polynomial baseline | `baseline.PolynomialCorrection` | **Reference only.** Agrees to 1.5e-14 relative. |
+| Savitzky–Golay, derivatives | `derivative.SavitzkyGolay` | **Neither.** Redundant: it wraps `scipy.signal.savgol_filter`, which is already our reference. |
+| Normalise `l1`, `l2` | `scale.NormScaler` | **Neither.** Redundant with `sklearn.preprocessing.normalize`, already our reference, and `max` and `area` are not expressible. |
+| Mean centring, autoscaling | none | Not offered; `StandardScaler` is already the reference. |
+| Range selection | `feature_selection.RangeCut` | **Neither.** A slice. |
+
+**No `chemotools` code runs in the application.** It is not added to `dependencies`; the transforms above stay ours. What is adopted is its use as an **open, versioned reference implementation in the dev group**, alongside `scikit-learn` and `rdata`, for the five quantities that today have **no external reference at all** and are checked only against their defining identities.
+
+Wiring that into the fixture is deliberately *not* part of this evaluation — it is [#27](https://github.com/millermuttu/Chemometrics-Workbench/issues/27). This record decides; that issue implements.
+
+---
+
+## Evidence
+
+Every number below is reproduced by [`0001-chemotools-evidence.py`](0001-chemotools-evidence.py), which is committed beside this record:
+
+```bash
+CHEMOMETRICS_DOWNLOAD_DATASETS=1 uv run --with chemotools==0.4.3 python \
+    docs/decisions/0001-chemotools-evidence.py
+```
+
+`uv run --with` installs `chemotools` into a throwaway environment, so re-deriving the evidence does not add it to the project. A rerun that disagrees with the tables below is a finding about this record.
+
+They come from `chemotools` 0.4.3 against our kernels on the **same fixture blocks the #9 and #10 reference values were generated on** — the 5 × 8 block of each of corn, gasoline and tecator — with the baselines run on the first five full spectra, since an eight-variable baseline is not a baseline.
+
+### Numerical agreement
+
+| Comparison | corn | gasoline | tecator |
+| --- | --- | --- | --- |
+| SNV, ours `ddof=0` | 0.0 | 0.0 | 0.0 |
+| SNV, ours `ddof=1` (our default) | 1.26e-01 | 1.26e-01 | 1.22e-01 |
+| MSC, reference = mean | 3.9e-12 | 7.1e-16 | 1.0e-10 |
+| MSC, reference = median | 2.3e-12 | 5.5e-15 | 1.1e-10 |
+| AsLS, `lam=1e5`, `p=0.01` | 8.6e-10 | 7.4e-11 | 7.6e-10 |
+| Rubberband | 0.0 | 0.0 | 0.0 |
+| Polynomial, order 2 | 3.5e-15 | 5.3e-16 | 1.5e-14 |
+| Normalise `l1`, `l2` | 0.0 | 0.0 | 0.0 |
+| Savitzky–Golay, `mode="interp"`, deriv 0/1/2 | ≤6.8e-17 | ≤6.8e-17 | ≤3.2e-15 |
+
+Differences are the largest absolute difference relative to the largest reference value, so they are comparable with the harness's identical-within-float threshold of 32 ulp ≈ 7.1e-15.
+
+Three of these are worth reading carefully:
+
+- **The SNV difference is a convention, not a defect.** `chemotools` uses the population standard deviation; ours defaults to `ddof=1`, the sample convention used for eigenvalues in `pca.md` §4 and for SEC and SEP in `metrics-and-validation.md` §5. At `ddof=0` the two are bit-identical, which is exactly the relationship we already have with `StandardScaler` and already record as a deliberate divergence.
+- **MSC agrees to 1e-10, not to the last bits**, and the gap is real rather than noise: it is 1e-16 on gasoline and 1e-10 on tecator, which is the signature of a differently-arranged regression rather than a different formula. Good enough to be a reference at the preprocessing tolerance class only if that class is widened, which it must not be — #27 must give MSC an honest tolerance or record the difference, not tighten the number.
+- **AsLS agrees to 1e-9** across a different solver (`chemotools` offers a banded solver and defaults to it; ours solves the sparse system), a different iteration cap (theirs 100, ours 20) and a different convergence rule. That two independent implementations of Eilers and Boelens land this close is the strongest evidence in this table, and it is the entry our fixture most lacked.
+
+### Edge handling
+
+`chemotools`'s `SavitzkyGolay` **defaults to `mode="nearest"`**, where ours fixes `mode="interp"` and does not expose it (`smoothing-and-baselines.md` §3). On the full spectra with an 11-point window the two agree to 1e-16 in the interior and diverge by up to 2.3e-02 within a half-window of each end — on gasoline's first derivative that is 30% of the largest value. Set `mode="interp"` explicitly and the whole spectrum agrees to 3e-15.
+
+This is the single most important edge finding, and it cuts **for** our position rather than against it: the mode is a per-call parameter there and a property of the software here, because a recipe recording "Savitzky–Golay, 11, 2, 1" is only reproducible if the mode is not a hidden default that can change under it.
+
+The 5 × 8 fixture block is half edge columns at a window of 5, which is why the block comparison shows 1e-3 differences and the interior comparison shows 1e-16. A reference generated only over the interior would not have caught this.
+
+### Documented conventions
+
+Conventions are documented per class in numpydoc docstrings, with formulas, and the source is readable. Two conventions are *not* stated where it matters: `StandardNormalVariate` does not say which `ddof` it uses, and `SavitzkyGolay`'s `mode` default of `"nearest"` differs from `scipy.signal.savgol_filter`'s own default of `"interp"` without saying why. Both had to be established by reading the source or by measurement, which is the same work our own specification documents exist to save a reader.
+
+### dtype and copy behaviour
+
+Equivalent to ours, and good:
+
+| Check | ours | `chemotools` |
+| --- | --- | --- |
+| float32 in → float64 out | yes | yes |
+| Caller's array modified | no | no |
+| NaN | `ValueError` naming row and column | `ValueError` (via `sklearn.check_array`) |
+| Narrower matrix at `transform` | `ValueError` naming both counts | `ValueError` naming both counts |
+| Constant spectrum (zero spread) | `ValueError` naming the samples | **returns `NaN` silently** |
+
+The last row is the only real difference and it is the one that matters for an application: `preprocessing.py`'s rule is that zero is judged relative to the magnitude of the data and refused, because a NaN that reaches a model surfaces three screens later as an unexplained failure.
+
+### Maintenance activity
+
+| | |
+| --- | --- |
+| Version evaluated | 0.4.3, released 2026-06-30 |
+| Latest activity | last push 2026-08-03, three weeks before this evaluation |
+| History | created 2023-01-26; eight releases between 2026-03-06 and 2026-06-30 |
+| Licence | MIT |
+| Stars / forks / open issues | 82 / 20 / 39 |
+| Contributors | 8, of which one has 543 commits, one is dependabot, and the remaining six total 6 |
+
+Actively maintained, and **effectively a single-maintainer project**. `PROPOSAL.md` §7 already dropped `process-improve` from the core for exactly that reason — "core numerical results should not depend on it" — and consistency requires the same judgement here. As a *reference* implementation the risk profile is different: a pinned version that we compare against cannot break the application, and if it were abandoned tomorrow the recorded numbers would remain valid, exactly as with `rdata`.
+
+The eight releases in four months also came with visible churn: importing the package emits `FutureWarning`s for three modules that have moved or split, `SavitzkyGolay` carries three deprecated constructor arguments, and two modules describe themselves as experimental with an API that may change.
+
+### Dependency weight
+
+**This is what decides the runtime question.**
+
+- `chemotools` requires `scikit-learn>=1.6`. scikit-learn is **dev-only** here by deliberate decision — it is the reference our kernels are compared against, and a kernel built on it would be a wrapper around the thing we claim parity with. Adopting `chemotools` at runtime moves scikit-learn, `joblib` and `threadpoolctl` into the shipped application.
+- Installed size is **20 MB, of which 17 MB is example datasets bundled inside the package** (`chemotools/datasets/data/*.csv`). The application would never read one of them, and `PROPOSAL.md` §14's three-platform PyInstaller bundle would carry all of it.
+- Against that: the transforms it would replace are already written, tested, specified and green, and total a few hundred lines.
+
+---
+
+## Why this and not the alternatives
+
+**Adopt at runtime and delete our kernels.** Rejected. It inverts the dependency rule in `PROPOSAL.md` §7 — *take a dependency for the tedious and well-solved; own the scientifically load-bearing and small* — for code that is precisely small and load-bearing. It would also put scikit-learn and 17 MB of unused CSVs into the desktop bundle, and hand the project's numerical conventions (SNV's `ddof`, Savitzky–Golay's edge mode) to a single-maintainer package's defaults, in a project whose entire claim is that those conventions are fixed and documented.
+
+**Reject outright.** Rejected too, and this is the answer that would have been easy. Five of our transforms — SNV, MSC and all three baselines — have **no external reference at all** and are tested only against their defining identities. `chemotools` is an open, MIT-licensed, version-pinnable implementation that agrees with four of the five to between 0 and 1e-9. Refusing it would leave those five entries `unsourced` for no better reason than that the same package was wrong for a different job.
+
+**Adopt for SNV only.** Rejected as too narrow: the same argument that makes it a good reference for SNV makes it a good reference for MSC and the baselines, and the baselines are where we have the least independent evidence.
+
+---
+
+## Consequences
+
+- `PROPOSAL.md` §7 and the §14 stack summary no longer describe `chemotools` as provisional; `CLAUDE.md`'s toolchain section records the decision so it is not re-litigated.
+- `chemotools` is **not** in `[project.dependencies]` and must not be added there. Adding it to the dev group and sourcing the five entries is [#27](https://github.com/millermuttu/Chemometrics-Workbench/issues/27).
+- The parity report (#14) may describe SNV, MSC and the baselines as compared against an independent implementation **only once #27 has actually done it**. Until then they remain `unsourced`, and the report must say so.
+- Our own conventions do not move. SNV keeps `ddof=1` and Savitzky–Golay keeps `mode="interp"`; both differences are recorded as divergences with reasons rather than resolved by matching.
+
+## Found while evaluating, and outside this decision
+
+`chemotools.outliers` provides `HotellingT2` and `QResiduals`, which report **confidence limits** — the quantities scikit-learn does not provide and on which feature `kernel-pca` (#11) has been `blocked` since it landed. Measured against our PCA on all three datasets:
+
+- **Our SPE limit and theirs are the same number**: Jackson–Mudholkar, agreeing to 2.3e-15 relative. Theirs also offers a chi-squared and a percentile variant, which is the divergence `pca.md` §13 already records.
+- **Our `T²` limits and theirs differ by a documented convention.** Theirs is `a(n−1)/(n−a)·F`; ours for a new sample is `a(n²−1)/(n(n−a))·F`, so the ratio is exactly `(n+1)/n` — 1.0125 on corn, 1.0167 on gasoline, 1.0042 on tecator. Our beta form for calibration samples has no counterpart there at all.
+
+That is a reference for the exact quantity #11 could not verify, and it does not need R. It is raised as [#28](https://github.com/millermuttu/Chemometrics-Workbench/issues/28) rather than folded in here, and it reduces #24 (R `mdatools`) from the only way to unblock #11 to a second, independent one.

--- a/feature_list.json
+++ b/feature_list.json
@@ -266,15 +266,15 @@
         "kernels-smoothing"
       ],
       "user_visible_behavior": "PROPOSAL.md and CLAUDE.md state adopted, partially adopted or rejected with a reason, and the provisional wording is gone.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "Open docs/decisions/ and confirm a dated decision record exists.",
         "Confirm it compares numerical agreement, edge handling, documented conventions, dtype and copy behaviour, maintenance activity and dependency weight.",
         "Confirm the decision is per transformer, not wholesale.",
         "Confirm PROPOSAL.md section 7 and CLAUDE.md no longer describe chemotools as provisional."
       ],
-      "evidence": "",
-      "notes": "Decide with evidence from the same fixtures used for our own kernels, not preference."
+      "evidence": "2026-08-22. `docs/decisions/0001-chemotools.md` records the decision, dated and numbered, against chemotools 0.4.3. Evidence gathered by running its transformers against the same 5 x 8 fixture blocks the #9 and #10 reference values were generated on, and the baselines against the first five full spectra. Numerical agreement, largest absolute difference relative to the largest reference value: SNV bit-identical at ddof=0 (1.3e-01 at our ddof=1 default, a convention); MSC 3.9e-12 corn, 7.1e-16 gasoline, 1.0e-10 tecator; AsLS 8.6e-10, 7.4e-11, 7.6e-10; rubberband bit-identical; polynomial 3.5e-15, 5.3e-16, 1.5e-14; normalise l1 and l2 bit-identical; Savitzky-Golay <=3.2e-15 at mode='interp'. Edge handling: their SavitzkyGolay defaults to mode='nearest' where ours fixes 'interp' - identical in the interior to 1e-16, up to 2.3e-02 apart within a half-window of each end, 30% of the largest value on gasoline's first derivative. Conventions: documented per class in numpydoc, but neither SNV's ddof nor the reason for the mode default is stated; both had to be measured. dtype and copy: equivalent to ours (float32 promoted, caller's array untouched, NaN and shape mismatch both raise) except that a constant spectrum returns NaN silently where ours raises. Maintenance: MIT, 0.4.3 released 2026-06-30, last push 2026-08-03, created 2023-01-26, 82 stars, 39 open issues, 8 contributors of whom one has 543 commits and the rest total 21 - effectively single-maintainer, with visible churn (FutureWarnings for three moved modules, three deprecated constructor arguments, two experimental modules). Dependency weight: requires scikit-learn>=1.6, which is dev-only here; installs 20 MB of which 17 MB is bundled example CSVs. Decision is per transform: reference-only for SNV, MSC and the three baselines; neither adopted nor referenced for Savitzky-Golay and normalisation, both redundant with SciPy and scikit-learn; rejected for the runtime throughout. PROPOSAL.md section 7 and the section 14 stack summary now say so, CLAUDE.md's toolchain section records it, and the provisional wording is gone: `grep -n chemotools PROPOSAL.md CLAUDE.md` shows no remaining 'pending' or 'subject to evaluation'. `uv run ruff check`, `ruff format --check`, `mypy`, `pytest` - all green, 408 passed.",
+      "notes": "Decided with evidence, not preference. Two things were found while evaluating and raised as issues rather than folded in: #27 wires chemotools into the dev group and sources the five unsourced entries, and #28 sources the T2 and SPE limits from chemotools.outliers - which reports the limits scikit-learn does not, agrees with our SPE limit to 2.3e-15, and is therefore a way to unblock #11 that does not need R. PROPOSAL.md section 7's claim that PCA and PLS come from scikit-learn was corrected in the same edit: it had been false since #11, and the section was already being rewritten. That was the standing question (b) from pull request #22."
     },
     {
       "id": "parity-report",
@@ -319,6 +319,47 @@
       ],
       "evidence": "",
       "notes": "Blocked on R not being installed on the development machine, which is an environment decision rather than a coding task: there is no sudo, but `conda install -c conda-forge r-base r-mdatools` installs both into the existing anaconda without root. The maintainer was asked during #11 and chose not to install it then. Raised out of #11, whose fourth verification step this is the only thing that unblocks. Note before recording any discrepancy as a defect: mdatools uses a chi-squared SPE limit in some configurations and Jackson-Mudholkar in others, and pca.md \u00a713 already lists that as a known divergence. Every matrix handed to mdatools must be pre-centred, as with scikit-learn, or R's own centring default applies twice."
+    },
+    {
+      "id": "reference-values-chemotools",
+      "priority": 27,
+      "area": "parity",
+      "title": "Source the SNV, MSC and baseline reference values from chemotools",
+      "issue": 27,
+      "depends_on": [
+        "chemotools-eval"
+      ],
+      "user_visible_behavior": "SNV, MSC and the three baseline methods are compared against an independent implementation rather than against their own defining identities alone.",
+      "status": "not_started",
+      "verification": [
+        "Regenerate the fixture and confirm the five entries per dataset are sourced.",
+        "Run the parity suite and confirm they are compared and passing.",
+        "Confirm parity-results.json still reports an empty not_compared list.",
+        "Confirm no tolerance already in TOLERANCES was loosened to make MSC pass."
+      ],
+      "evidence": "",
+      "notes": "Decided by docs/decisions/0001-chemotools.md. MSC agrees to 1e-10 relative, which is outside the preprocessing class's 1e-12 - it needs its own class with a reason or a recorded divergence, never a widened class."
+    },
+    {
+      "id": "reference-values-chemotools-limits",
+      "priority": 28,
+      "area": "parity",
+      "title": "Source the T-squared and SPE limits from chemotools, and unblock #11",
+      "issue": 28,
+      "depends_on": [
+        "chemotools-eval",
+        "kernel-pca"
+      ],
+      "user_visible_behavior": "The PCA confidence limits are compared against an independent implementation, and kernel-pca's fourth verification step can actually be run.",
+      "status": "not_started",
+      "verification": [
+        "Regenerate the fixture and confirm spe_limit and hotelling_t2_limit entries are sourced.",
+        "Run the parity suite and confirm the SPE limit is compared and passing.",
+        "Confirm the T-squared limit is recorded as a documented divergence with the formula difference stated, not as a failure.",
+        "Re-run kernel-pca's verification and move it to passing, or record what still blocks it."
+      ],
+      "evidence": "",
+      "notes": "Our SPE limit and chemotools' agree to 2.3e-15; the T-squared limits differ by exactly (n+1)/n because theirs is a(n-1)/(n-a)F and ours is a(n^2-1)/(n(n-a))F. Measured during #13 and recorded in docs/decisions/0001-chemotools.md."
     }
   ]
 }


### PR DESCRIPTION
`chemotools` 0.4.3 run against our preprocessing kernels on the **same fixture blocks the #9 and #10 reference values were generated on**. Decided per transform, recorded in [`docs/decisions/0001-chemotools.md`](docs/decisions/0001-chemotools.md), with the script that reproduces every number committed beside it.

## The decision

| Transform | Decision |
| --- | --- |
| SNV, MSC, AsLS, rubberband, polynomial baseline | **Reference only**, in the dev group |
| Savitzky–Golay, normalise `l1`/`l2` | **Neither** — redundant with SciPy and scikit-learn, which are already the references |
| Everything | **Not a runtime dependency** |

**Rejected for the runtime** because it requires scikit-learn — dev-only here by deliberate decision, since a kernel built on it cannot then be compared against it — and installs 20 MB of which 17 MB is example datasets the application would never read. It is also effectively a single-maintainer project (543 commits of 570), which §7 already treated as disqualifying for core numerics when it dropped `process-improve`.

**Adopted as a reference** because five of our transforms — SNV, MSC and all three baselines — have *no external reference at all* today and are checked only against their defining identities. Refusing an open, MIT, version-pinnable implementation that agrees with four of the five to between 0 and 1e-9 would leave those entries `unsourced` for no better reason than that the same package was wrong for a different job.

## Measured agreement

Largest absolute difference relative to the largest reference value; the harness's identical-within-float threshold is 32 ulp ≈ 7.1e-15.

| | corn | gasoline | tecator |
| --- | --- | --- | --- |
| SNV at `ddof=0` | 0.0 | 0.0 | 0.0 |
| MSC | 3.9e-12 | 7.1e-16 | 1.0e-10 |
| AsLS | 8.6e-10 | 7.4e-11 | 7.6e-10 |
| Rubberband | 0.0 | 0.0 | 0.0 |
| Polynomial | 3.5e-15 | 5.3e-16 | 1.5e-14 |
| Savitzky–Golay at `mode="interp"` | ≤6.8e-17 | ≤6.8e-17 | ≤3.2e-15 |

Two differences are conventions rather than defects, and both cut for our position: their SNV uses the population standard deviation where ours defaults to `ddof=1`, and their Savitzky–Golay defaults to `mode="nearest"` where ours fixes `"interp"` — identical in the interior to 1e-16, up to 30% of the largest value apart within a half-window of each end. A recipe recording "Savitzky–Golay, 11, 2, 1" is only reproducible if the mode belongs to the software rather than to a caller's default.

The one behavioural difference that matters for an application: a constant spectrum returns `NaN` silently there and raises here.

## The evidence is re-runnable

```bash
CHEMOMETRICS_DOWNLOAD_DATASETS=1 uv run --with chemotools==0.4.3 python \
    docs/decisions/0001-chemotools-evidence.py
```

`uv run --with` installs it into a throwaway environment, so re-deriving the numbers does not add `chemotools` to the project. A decision whose numbers cannot be re-derived is a preference with a table attached.

## Raised rather than folded in

- **#27** — wire `chemotools` into the dev group and source the five entries. MSC's 1e-10 agreement sits outside the `preprocessing` tolerance class; that class must not be widened to fit it.
- **#28** — `chemotools.outliers` reports the confidence limits scikit-learn does not. **Our SPE limit and theirs are the same number** (2.3e-15 relative), and the `T²` limits differ by exactly `(n+1)/n` because theirs is `a(n−1)/(n−a)·F` where our new-sample form is `a(n²−1)/(n(n−a))·F`. That is a reference for the exact quantity #11 is blocked on, and it does not need R — it reduces #24 from the only way to unblock #11 to a second, independent one.

## Also in this change

`PROPOSAL.md` §7 said `PLSRegression`, `PCA`, cross-validation and metrics come from scikit-learn. That has been false since #11, it is standing question (b) from #22, and the section was already being rewritten for this decision — so it now says what the repository does and why, with scikit-learn named as the dev-only reference it actually is.

Closes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3dSQrs9P2L9gbsrwhDd4W