### PR TITLE
Bump the version to 0.1.0 for the Phase 0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chemometrics-workbench"
-version = "0.0.0"
+version = "0.1.0"
 description = "Open-source, local-first chemometrics workbench"
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/chemometrics_workbench/__init__.py
+++ b/src/chemometrics_workbench/__init__.py
@@ -1,3 +1,3 @@
 """Open-source, local-first chemometrics workbench."""
 
-__version__ = "0.0.0"
+__version__ = "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "chemometrics-workbench"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy" },


### PR DESCRIPTION
The tag and the built wheel should tell the same story. `main` has Phase 0 merged (#34) and is about to be tagged `v0.1.0`, so `pyproject.toml` and `__init__.py` move from `0.0.0` to match, and `uv.lock` follows.

`0.1.0` rather than `1.0.0` on purpose: there is no user interface, the application does not run, and what is being released is the numerical foundation plus the parity report that vouches for it.

Three lines. `ruff`, `mypy` and the full suite (432 tests) are green.

Closes #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3dSQrs9P2L9gbsrwhDd4W