### PR TITLE
Serve the contract fixtures from a stub server with real jobs

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -57,7 +57,7 @@
         "contract-fixtures"
       ],
       "user_visible_behavior": "A FastAPI application on 127.0.0.1 and an ephemeral port, token-authenticated, serving the generated fixtures at the endpoint paths Phase 1.2 will implement. A run started from the UI is a real job that advances, can be cancelled, and can be made to fail.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "The server binds 127.0.0.1 on an ephemeral port and refuses a request with no token or a wrong one.",
         "Every endpoint the frontend calls returns its fixture body unmodified.",
@@ -68,8 +68,8 @@
         "No database, no persistence and no executor - state is in memory only.",
         "Every handler names the Phase 1.2 issue that will replace it."
       ],
-      "evidence": null,
-      "notes": "This is what makes Phase 1.1 a walking skeleton rather than a horizontal layer, which is what PROPOSAL.md section 16 asked for. The frontend talks HTTP from its first commit and 1.2 replaces handlers behind unchanged URLs, so there is never a single integration moment. Static fixtures cannot exercise the three things most likely to be got wrong: a job that takes time, a request that fails, and a response with real bulk."
+      "evidence": "2026-08-24. On feature/53_stub-server. `uv run pytest` is 481 passed; tests/test_stub_server.py adds 15 covering every verification step. Live run: `STUB_TOKEN=live-token uv run python stub/server.py` printed `Launch URL: http://127.0.0.1:45117/?token=live-token`; `ss -ltnp` showed the socket bound to 127.0.0.1:45117 only and the host's LAN address refused the same request (curl exit 000). No token and a wrong token both returned 401 with an `{\"error\": {...}}` body. GET /api/spectra/source returned 53,469 bytes of fixture, byte-identical to spectra.json's `source` entry. A run polled once a second reported queued 0.0, running 0.15, 0.4, 0.65, 0.85 and succeeded 1.0 with the fixture's messages; cancelling at 2.5s returned cancelled at progress 0.4 and it stayed 0.4 four seconds later; `?fail=true` ended failed at 0.85 with the rank message. `X-Stub-Fail: 1` returned 422 carrying error.json unmodified. The bundle mount is exercised through STUB_BUNDLE against a temporary dist, and the CORS preflight from http://localhost:5173 is allowed. `uv run ruff check .`, `ruff format --check` and `uv run mypy` (strict, 27 files) are clean.",
+      "notes": "In-memory only: a job is its status sequence from jobs.json, the monotonic time it started and the step it was cancelled at, so the current step is elapsed/STEP_SECONDS with no background task, no lock and no executor. STUB_JOB_STEP_SECONDS (default 1.2) turns a six-step run down to milliseconds for the tests. Handlers carry `Phase 1.2:` markers naming the work that replaces them rather than issue numbers, because 1.2's issues are not cut yet - grep `Phase 1.2:` when they are, and put the numbers in."
     },
     {
       "id": "frontend-scaffold",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Open-source, local-first chemometrics workbench"
 requires-python = ">=3.12"
 license = "MIT"
 authors = [{ name = "Mallik" }]
-dependencies = ["pydantic>=2.9", "numpy>=2.0", "scipy>=1.14"]
+dependencies = ["pydantic>=2.9", "numpy>=2.0", "scipy>=1.14", "fastapi>=0.115", "uvicorn>=0.30"]
 
 [project.urls]
 Repository = "https://github.com/millermuttu/Chemometrics-Workbench"
@@ -31,6 +31,8 @@ dev = [
   "rdata>=0.11",
   "scikit-learn>=1.5",
   "chemotools>=0.4.3",
+  # httpx backs fastapi's TestClient; the application never calls out over HTTP.
+  "httpx>=0.27",
 ]
 
 [tool.ruff]

--- a/stub/server.py
+++ b/stub/server.py
@@ -1,0 +1,259 @@
+"""The Phase 1.1 stub server: real endpoints, generated fixtures, real jobs.
+
+Run it:
+
+    uv run python stub/server.py
+
+It prints the launch URL — `http://127.0.0.1:<port>/?token=<token>` — which is
+what the desktop shell will hand the frontend in Phase 1.2. The token is
+required on every `/api` request as `Authorization: Bearer <token>`.
+
+## What this module is, and what it is not
+
+It routes and it delays. It does not compute: every response body is a fixture
+from `stub/fixtures`, generated from the real kernels by
+`stub/generate_fixtures.py`, and returned unmodified. There is no database, no
+persistence and no executor — job state is a dict that dies with the process.
+Phase 1.2 replaces these handlers one at a time behind unchanged URLs; each
+one says below what replaces it.
+
+Phase 1.2's issues are not cut yet, so the handlers name the work rather than a
+number. When those issues exist, the marker to search for is `Phase 1.2:`.
+
+## Jobs advance because static fixtures cannot fail or take time
+
+`POST /api/experiments/{id}/run` starts an in-memory job that walks the status
+sequence in `jobs.json` against the wall clock: the current step is
+`elapsed / STEP_SECONDS`, so no background task, no lock and no executor is
+involved. `?fail=true` walks the failing sequence instead, which is how #49's
+failed state is reached without editing code. `X-Stub-Fail: 1` on any request
+returns the documented error body, which is how a failed *request* is reached.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Annotated, Any
+from uuid import uuid4
+
+import uvicorn
+from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+# Production mode serves the built frontend from here. STUB_BUNDLE overrides it,
+# which is how the mount is exercised before #42 has produced a bundle.
+_BUNDLE_DEFAULT = Path(__file__).resolve().parents[1] / "frontend" / "dist"
+BUNDLE = Path(os.environ.get("STUB_BUNDLE") or _BUNDLE_DEFAULT)
+
+# The token is a real check, not a placeholder: an unauthenticated localhost
+# server never gets authentication retrofitted (PROPOSAL.md section 4.3). Set
+# STUB_TOKEN to keep it stable across restarts while developing.
+TOKEN = os.environ.get("STUB_TOKEN") or secrets.token_urlsafe(32)
+
+# How long each job step lasts. Six steps at 1.2s is the "handful of seconds"
+# the UI needs to show progress moving; the tests turn it down to milliseconds.
+STEP_SECONDS = float(os.environ.get("STUB_JOB_STEP_SECONDS", "1.2"))
+
+# The Vite dev server, so the frontend can run on 5173 against this on its own
+# port. In production mode the bundle is served from here and no origin is.
+DEV_ORIGINS = ["http://localhost:5173", "http://127.0.0.1:5173"]
+
+
+def fixture(name: str) -> Any:
+    return json.loads((FIXTURES / f"{name}.json").read_text())
+
+
+def require_token(authorization: Annotated[str | None, Header()] = None) -> None:
+    if authorization != f"Bearer {TOKEN}":
+        raise HTTPException(status_code=401, detail="Invalid or missing bearer token")
+
+
+def maybe_fail(x_stub_fail: Annotated[str | None, Header()] = None) -> None:
+    """Make any request fail on demand, so the UI's failure state is reachable."""
+    if x_stub_fail:
+        raise HTTPException(status_code=422, detail=fixture("error")["error"])
+
+
+app = FastAPI(title="Chemometrics Workbench stub server")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=DEV_ORIGINS,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# One router rather than a mounted sub-application: a mount carries its own
+# exception middleware, and the error body below would then not apply to it.
+api = APIRouter(prefix="/api", dependencies=[Depends(require_token), Depends(maybe_fail)])
+
+
+@app.exception_handler(HTTPException)
+async def error_body(request: Request, exc: HTTPException) -> JSONResponse:
+    """Every failure has a body, not only a status code - the shape error.json documents."""
+    detail = exc.detail
+    if isinstance(detail, dict):
+        return JSONResponse(status_code=exc.status_code, content={"error": detail})
+    code = {401: "unauthorized", 404: "not_found"}.get(exc.status_code, "request_failed")
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": {"code": code, "message": str(detail), "detail": {}}},
+    )
+
+
+# --- Projects, datasets, import ------------------------------------------
+# Phase 1.2: the project directory reader and the file readers replace these.
+
+
+@api.get("/projects")
+def list_projects() -> Any:
+    return [fixture("project")]
+
+
+@api.get("/projects/{project_id}")
+def get_project(project_id: str) -> Any:
+    return fixture("project")
+
+
+@api.get("/projects/{project_id}/datasets")
+def list_datasets(project_id: str) -> Any:
+    return fixture("datasets")
+
+
+@api.post("/import/preview")
+def import_preview() -> Any:
+    return fixture("import_preview")
+
+
+@api.post("/import")
+def import_dataset() -> Any:
+    return fixture("datasets")[0]
+
+
+# --- Pipelines -----------------------------------------------------------
+# Phase 1.2: the pipeline store and the validator replace these.
+
+
+@api.get("/pipelines/{pipeline_id}")
+def get_pipeline(pipeline_id: str) -> Any:
+    return fixture("pipeline")
+
+
+@api.get("/pipelines/{pipeline_id}/state")
+def get_pipeline_state(pipeline_id: str) -> Any:
+    return fixture("pipeline_state")
+
+
+@api.post("/pipelines/{pipeline_id}/validate")
+def validate_pipeline(pipeline_id: str) -> Any:
+    # GUESS, like the envelope shapes in generate_fixtures.py: models.py does
+    # not cover a validation response, so 1.2 is free to change this.
+    return {"pipeline_id": fixture("pipeline")["pipeline_id"], "valid": True, "problems": []}
+
+
+# --- Results -------------------------------------------------------------
+# Phase 1.2: the executor's stored outputs replace these.
+
+
+@api.get("/experiments/{experiment_id}")
+def get_experiment(experiment_id: str) -> Any:
+    return fixture("experiment")
+
+
+@api.get("/spectra/{node_id}")
+def get_spectra(node_id: str) -> Any:
+    spectra = fixture("spectra")
+    if node_id not in spectra:
+        raise HTTPException(status_code=404, detail=f"No spectra for node {node_id!r}")
+    return spectra[node_id]
+
+
+@api.get("/results/{node_id}")
+def get_results(node_id: str) -> Any:
+    pca = fixture("pca")
+    if node_id not in pca:
+        raise HTTPException(status_code=404, detail=f"No results for node {node_id!r}")
+    return pca[node_id]
+
+
+# --- Jobs ----------------------------------------------------------------
+# Phase 1.2: the real executor and its job table replace these. In-memory only:
+# a job is its status sequence, when it started, and when it was cancelled.
+
+_jobs: dict[str, dict[str, Any]] = {}
+
+
+def _snapshot(job: dict[str, Any]) -> dict[str, Any]:
+    steps: list[dict[str, Any]] = job["steps"]
+    index = min(int((time.monotonic() - job["started"]) / STEP_SECONDS), len(steps) - 1)
+    if job["cancelled_at"] is not None:
+        index = min(index, job["cancelled_at"])
+        last = dict(steps[index])
+        last.update(status="cancelled", message="Cancelled")
+        return last | {"job_id": job["job_id"]}
+    return dict(steps[index]) | {"job_id": job["job_id"]}
+
+
+@api.post("/experiments/{experiment_id}/run")
+def run_experiment(experiment_id: str, fail: Annotated[bool, Query()] = False) -> Any:
+    job_id = str(uuid4())
+    _jobs[job_id] = {
+        "job_id": job_id,
+        "steps": fixture("jobs")["failed" if fail else "succeeded"],
+        "started": time.monotonic(),
+        "cancelled_at": None,
+    }
+    return _snapshot(_jobs[job_id])
+
+
+@api.get("/jobs/{job_id}")
+def get_job(job_id: str) -> Any:
+    if job_id not in _jobs:
+        raise HTTPException(status_code=404, detail=f"No job {job_id!r}")
+    return _snapshot(_jobs[job_id])
+
+
+@api.post("/jobs/{job_id}/cancel")
+def cancel_job(job_id: str) -> Any:
+    if job_id not in _jobs:
+        raise HTTPException(status_code=404, detail=f"No job {job_id!r}")
+    job = _jobs[job_id]
+    if job["cancelled_at"] is None:
+        elapsed = int((time.monotonic() - job["started"]) / STEP_SECONDS)
+        job["cancelled_at"] = min(elapsed, len(job["steps"]) - 1)
+    return _snapshot(job)
+
+
+# --- The bundle ----------------------------------------------------------
+# Production mode serves the built frontend; development mode leaves it to the
+# Vite dev server, which reaches the API across the CORS origins above.
+
+app.include_router(api)
+
+if BUNDLE.is_dir():
+    app.mount("/", StaticFiles(directory=BUNDLE, html=True), name="bundle")
+
+
+def main() -> None:
+    server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, log_level="info"))
+    # An ephemeral port is only knowable after the socket is bound, so the URL
+    # is printed from the socket rather than from the config.
+    original = server.startup
+
+    async def startup(sockets: Any = None) -> None:
+        await original(sockets=sockets)
+        port = server.servers[0].sockets[0].getsockname()[1]
+        print(f"\n  Launch URL: http://127.0.0.1:{port}/?token={TOKEN}\n", flush=True)
+
+    server.startup = startup  # type: ignore[method-assign]
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_stub_server.py
+++ b/tests/test_stub_server.py
@@ -1,0 +1,146 @@
+"""The stub server returns the fixtures unchanged, checks its token, and runs jobs.
+
+The point of these is the three things a static fixture cannot be: a request
+that is refused, a request that fails, and a job that takes time. The bodies
+themselves are checked for being the fixture *unmodified* - this module is
+allowed to route and to delay, and nothing else.
+
+`STUB_JOB_STEP_SECONDS` is set before the server is imported, so a job that
+takes seconds in the UI takes milliseconds here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ["STUB_JOB_STEP_SECONDS"] = "0.05"
+os.environ["STUB_TOKEN"] = "test-token"
+os.environ["STUB_BUNDLE"] = tempfile.mkdtemp()
+Path(os.environ["STUB_BUNDLE"], "index.html").write_text("<!doctype html><title>bundle</title>")
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "stub"))
+
+import server  # noqa: E402
+
+STEP = 0.05
+AUTH = {"Authorization": "Bearer test-token"}
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(server.app)
+
+
+def fixture(name: str) -> Any:
+    return json.loads((server.FIXTURES / f"{name}.json").read_text())
+
+
+def test_a_request_with_no_token_or_a_wrong_one_is_refused(client: TestClient) -> None:
+    assert client.get("/api/projects").status_code == 401
+    assert client.get("/api/projects", headers={"Authorization": "Bearer wrong"}).status_code == 401
+    body = client.get("/api/projects").json()
+    assert body["error"]["code"] == "unauthorized"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/api/projects/p", "project"),
+        ("/api/projects/p/datasets", "datasets"),
+        ("/api/pipelines/x", "pipeline"),
+        ("/api/pipelines/x/state", "pipeline_state"),
+        ("/api/experiments/e", "experiment"),
+    ],
+)
+def test_each_endpoint_returns_its_fixture_body_unmodified(
+    client: TestClient, path: str, expected: str
+) -> None:
+    assert client.get(path, headers=AUTH).json() == fixture(expected)
+
+
+def test_the_node_keyed_endpoints_serve_the_node_and_404_the_rest(client: TestClient) -> None:
+    assert client.get("/api/spectra/snv", headers=AUTH).json() == fixture("spectra")["snv"]
+    assert client.get("/api/results/pca_a", headers=AUTH).json() == fixture("pca")["pca_a"]
+    missing = client.get("/api/spectra/nope", headers=AUTH)
+    assert missing.status_code == 404
+    assert missing.json()["error"]["code"] == "not_found"
+
+
+def test_a_failure_can_be_provoked_without_editing_code(client: TestClient) -> None:
+    response = client.get("/api/projects", headers=AUTH | {"X-Stub-Fail": "1"})
+    assert response.status_code == 422
+    assert response.json() == fixture("error")
+
+
+def test_a_job_advances_over_time_rather_than_arriving_whole(client: TestClient) -> None:
+    job = client.post("/api/experiments/e/run", headers=AUTH).json()
+    assert (job["status"], job["progress"]) == ("queued", 0.0)
+
+    seen = [job["progress"]]
+    deadline = time.monotonic() + 10 * STEP + 2
+    while time.monotonic() < deadline:
+        time.sleep(STEP / 2)
+        now = client.get(f"/api/jobs/{job['job_id']}", headers=AUTH).json()
+        if now["progress"] != seen[-1]:
+            seen.append(now["progress"])
+        if now["status"] == "succeeded":
+            break
+    assert seen == sorted(seen), seen
+    assert len(seen) > 2, seen
+    assert now["status"] == "succeeded"
+    assert now["progress"] == 1.0
+
+
+def test_a_run_can_be_made_to_fail_and_the_failure_is_terminal(client: TestClient) -> None:
+    job = client.post("/api/experiments/e/run?fail=true", headers=AUTH).json()
+    time.sleep(7 * STEP)
+    final = client.get(f"/api/jobs/{job['job_id']}", headers=AUTH).json()
+    assert final["status"] == "failed"
+    assert final["message"] == fixture("jobs")["failed"][-1]["message"]
+
+
+def test_cancelling_a_running_job_stops_it(client: TestClient) -> None:
+    job = client.post("/api/experiments/e/run", headers=AUTH).json()
+    time.sleep(2 * STEP)
+    cancelled = client.post(f"/api/jobs/{job['job_id']}/cancel", headers=AUTH).json()
+    assert cancelled["status"] == "cancelled"
+
+    frozen = cancelled["progress"]
+    time.sleep(6 * STEP)
+    later = client.get(f"/api/jobs/{job['job_id']}", headers=AUTH).json()
+    assert later["status"] == "cancelled"
+    assert later["progress"] == frozen
+
+
+def test_an_unknown_job_is_a_404_with_a_body(client: TestClient) -> None:
+    response = client.get("/api/jobs/nope", headers=AUTH)
+    assert response.status_code == 404
+    assert response.json()["error"]["message"]
+
+
+def test_production_mode_serves_the_built_bundle(client: TestClient) -> None:
+    """The mount, not StaticFiles - that the bundle is reachable without a token."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "bundle" in response.text
+
+
+def test_development_mode_lets_the_vite_dev_server_call_the_api(client: TestClient) -> None:
+    response = client.options(
+        "/api/projects",
+        headers={
+            "Origin": "http://localhost:5173",
+            "Access-Control-Request-Method": "GET",
+            "Access-Control-Request-Headers": "authorization",
+        },
+    )
+    assert response.headers["access-control-allow-origin"] == "http://localhost:5173"

--- a/uv.lock
+++ b/uv.lock
@@ -14,12 +14,34 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -87,18 +109,30 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "chemometrics-workbench"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "numpy" },
     { name = "pydantic" },
     { name = "scipy" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "chemotools" },
+    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "rdata" },
@@ -108,14 +142,17 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "scipy", specifier = ">=1.14" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "chemotools", specifier = ">=0.4.3" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "rdata", specifier = ">=0.11" },
@@ -138,12 +175,86 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -770,6 +881,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -806,6 +930,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
FastAPI on `127.0.0.1` and an ephemeral port, bearer-token authenticated, serving the #41 fixtures unmodified at the endpoint paths Phase 1.2 will implement. This is what makes Phase 1.1 a walking skeleton rather than a horizontal layer: the frontend speaks HTTP from its first commit, and 1.2 replaces handlers behind unchanged URLs.

## What is here

- **Jobs advance against the clock.** `POST /api/experiments/{id}/run` starts an in-memory job that walks the status sequence in `jobs.json`; the current step is `elapsed / STEP_SECONDS`, so there is no background task, no lock and no executor. `cancel` freezes progress where it stood. `STUB_JOB_STEP_SECONDS` (default 1.2s) turns a six-step run down to milliseconds for the tests.
- **Failure is reachable without editing code.** `?fail=true` on a run walks the failing sequence; `X-Stub-Fail: 1` on any request returns the documented error body with a 422.
- **One router, not a mounted sub-application.** A mount carries its own exception middleware, and the `{"error": {...}}` body would not have applied to it.
- **Production and development modes.** The built bundle is served when it exists; the Vite dev server is allowed by CORS otherwise. `STUB_BUNDLE` overrides the bundle path, which is how the mount is exercised before #42 has produced one.

`fastapi` and `uvicorn` become runtime dependencies — they are the recorded stack for Phase 1.2, not something this module drags in. `httpx` is dev-only, for the test client.

## Evidence

`uv run pytest` is 481 passed; `tests/test_stub_server.py` adds 15 covering every verification step. Live run of `stub/server.py`:

- `ss -ltnp` shows the socket bound to `127.0.0.1` only; the same request to the host's LAN address is refused (curl exit 000).
- No token and a wrong token both return 401 with an error body.
- `GET /api/spectra/source` returns 53,469 bytes, byte-identical to the fixture's `source` entry.
- A run polled once a second: queued 0.0 → running 0.15, 0.4, 0.65, 0.85 → succeeded 1.0, with the fixture's messages. Cancelling at 2.5s returned cancelled at 0.4, still 0.4 four seconds later. `?fail=true` ended failed at 0.85 with the rank message.
- `ruff check`, `ruff format --check` and `mypy` (strict, 27 files) are clean.

## One thing deliberately not done

The handlers carry `Phase 1.2:` markers naming the work that replaces them rather than issue numbers, because 1.2's issues are not written yet. Grep `Phase 1.2:` when they are and put the numbers in.

Closes #53