### PR TITLE
Stop tracking the TypeScript build info files

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,7 @@ node_modules/
 dist/
 test-results/
 playwright-report/
+# tsc -b writes these on every incremental build, and vite caches resolved
+# dependencies in .vite/. Both change constantly and belong to nobody's diff.
+*.tsbuildinfo
+.vite/

--- a/frontend/tsconfig.app.tsbuildinfo
+++ b/frontend/tsconfig.app.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./src/App.tsx","./src/main.tsx","./src/__tests__/client.test.ts","./src/__tests__/tokens.test.ts","./src/api/client.ts","./src/api/queries.ts","./src/lib/utils.ts","./src/pages/Tokens.tsx","./src/styles/tokens.ts"],"version":"5.9.3"}

--- a/frontend/tsconfig.node.tsbuildinfo
+++ b/frontend/tsconfig.node.tsbuildinfo
@@ -1,1 +1,0 @@
-{"root":["./vite.config.ts","./vitest.config.ts","./playwright.config.ts"],"version":"5.9.3"}


### PR DESCRIPTION
`tsc -b` rewrites `frontend/tsconfig.*.tsbuildinfo` on every incremental build, and #42 committed both. They would have shown up as noise in every diff from here on. `.vite/`, the dev server's dependency cache, has the same problem and was untracked only by luck.

Both are now ignored and the two tracked copies are removed from the index.

**Evidence:** `pnpm build` followed by `git status --short` prints nothing.

Closes #58