### PR TITLE
Build the application shell to the artboard's measurements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,5 +122,18 @@ jobs:
       - name: Install Playwright chromium
         run: pnpm exec playwright install --with-deps chromium
 
+      # The end-to-end tests run against the stub server serving the built
+      # bundle - the same origin and the same token the packaged application
+      # uses - so this job needs the Python environment too.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Sync the stub server's environment
+        working-directory: .
+        run: uv sync --locked
+
       - name: End-to-end
         run: pnpm e2e

--- a/feature_list.json
+++ b/feature_list.json
@@ -107,7 +107,7 @@
         "frontend-scaffold"
       ],
       "user_visible_behavior": "A single window with a resizable project tree, a tabbed document area and a collapsible inspector, over a status bar carrying job name, progress, elapsed time and cancel.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "Tabs open, close, reorder and split side by side.",
         "A single click previews into the transient tab and replaces it; a double click or an edit pins it.",
@@ -118,8 +118,8 @@
         "The shell matches design/canvas/Main.dc.html at 1440x900 in both themes: 40px top bar, 248px sidebar, 34px tab strip, 292px inspector, 28px status bar.",
         "A transient tab renders italic in --ink3, as the artboard draws it."
       ],
-      "evidence": null,
-      "notes": null
+      "evidence": "2026-08-24. On feature/43_app-shell. `pnpm test` is 17 passed (10 new, the tab rules); `pnpm e2e` is 6 passed, of which 5 are the shell; `pnpm typecheck`, `pnpm lint` and `pnpm build` are clean; the Python side is 483 passed (2 new: the deep link and the traversal guard). The measurements are asserted in the browser against the artboard, not eyeballed: top bar 40, sidebar 248, tab strip 34, inspector 292, status bar 28. Tab rules exercised end to end - a single click previews into one italic transient tab and a second preview replaces it; a double click pins; opening 16 outline rows overflows the strip and the +N menu finds pca_d by id; the split shows two panes; closing removes the tab. A run started from the top bar reports Queued then Preprocessing: SNV then advances, and Cancel stops it at the step it had reached - the progress width is unchanged 1.2s later. Both palettes checked through --accent: #0B6B62 light, #54BFAB dark. Screenshots of both themes were taken against the stub server at 127.0.0.1:8765.",
+      "notes": "The overflow measurement had a real bug the e2e caught: rendering only the tabs that fit means an unrendered tab has no width, so the measurement can only ever confirm what it already shows and the strip stuck at one tab. Every tab now stays in the DOM and the strip clips them; the +N button floats over the clipped ones. The stub server gained a catch-all that serves index.html so /tokens arrives as the application rather than a 404, with a traversal guard, and the e2e suite now runs against the stub server serving the built bundle rather than a Vite preview - the same origin and token the packaged application uses, so CI's frontend job needs uv. Models has an empty state: no fixture describes a model and they are Phase 2 (#51). Pane contents are placeholders naming the issue that fills them (#44-#48)."
     },
     {
       "id": "import-flow",

--- a/frontend/e2e/shell.spec.ts
+++ b/frontend/e2e/shell.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** The shell against the stub server: the artboard's measurements, the tab
+ * rules, and a run that really advances and can really be cancelled. */
+
+async function open(page: Page) {
+  await page.goto("/?token=e2e-token");
+  await expect(page.getByText("Tecator meat study")).toBeVisible();
+}
+
+/** The numbers in design/canvas/Main.dc.html. They are the design of record,
+ * so a shell that drifts from them is wrong even if it looks fine. */
+test("the regions carry the artboard's measurements", async ({ page }) => {
+  await open(page);
+  const height = (locator: string) => page.locator(locator).first().boundingBox();
+
+  expect((await height(".tbar"))?.height).toBe(40);
+  expect((await height(".side"))?.width).toBe(248);
+  expect((await height(".tabs"))?.height).toBe(34);
+  expect((await height(".insp"))?.width).toBe(292);
+  expect((await height(".status"))?.height).toBe(28);
+});
+
+test("the outline previews into one transient tab and pins on a double click", async ({ page }) => {
+  await open(page);
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+
+  await outline.getByRole("button", { name: /^SNV/ }).first().click();
+  const tabs = page.getByRole("tab");
+  await expect(tabs).toHaveCount(1);
+  await expect(tabs.first()).toHaveClass(/tr/);
+
+  // A second preview replaces the first rather than adding to it.
+  await outline.getByRole("button", { name: /MSC/ }).first().click();
+  await expect(tabs).toHaveCount(1);
+
+  await outline.getByRole("button", { name: /MSC/ }).first().dblclick();
+  await expect(tabs.first()).not.toHaveClass(/tr/);
+  await outline.getByRole("button", { name: /^SNV/ }).first().click();
+  await expect(tabs).toHaveCount(2);
+});
+
+test("tabs close, split and overflow into a searchable menu", async ({ page }) => {
+  await open(page);
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  const rows = outline.getByRole("button");
+  const count = await rows.count();
+
+  // Fifteen preprocessing variants is the normal case; open enough to overflow.
+  for (let index = 0; index < count; index += 1) {
+    await rows.nth(index).dblclick();
+  }
+  const overflow = page.getByRole("button", { name: /more tabs/ });
+  await expect(overflow).toBeVisible();
+
+  await overflow.click();
+  await page.getByRole("textbox", { name: "Search tabs" }).fill("pca_d");
+  const match = page.locator(".omenu button");
+  await expect(match).toHaveCount(1);
+  await match.click();
+
+  await page.getByRole("button", { name: "Split view" }).click();
+  await expect(page.locator(".split .pane")).toHaveCount(2);
+
+  const before = await page.getByRole("tab").count();
+  await page.getByRole("tab").first().getByRole("button").click();
+  await expect(page.getByRole("tab")).toHaveCount(before - 1);
+});
+
+test("a run advances, then cancels where it stood", async ({ page }) => {
+  await open(page);
+  await page.getByRole("button", { name: "Run pipeline" }).click();
+
+  const status = page.getByRole("status");
+  await expect(status).toContainText("Queued");
+  await expect(status).toContainText("Preprocessing: SNV", { timeout: 5000 });
+
+  await status.getByRole("button", { name: "Cancel" }).click();
+  await expect(status).toContainText("Cancelled");
+
+  // Cancelled means stopped: the message does not move on afterwards.
+  const width = await page.locator(".prog i").getAttribute("style");
+  await page.waitForTimeout(1200);
+  await expect(status).toContainText("Cancelled");
+  expect(await page.locator(".prog i").getAttribute("style")).toBe(width);
+});
+
+test("both themes are the artboard's palettes", async ({ page }) => {
+  await open(page);
+  const accent = () =>
+    page.evaluate(() => getComputedStyle(document.querySelector(".app")!).getPropertyValue("--accent").trim());
+
+  expect((await accent()).toUpperCase()).toBe("#0B6B62");
+  await page.getByRole("button", { name: "Dark", exact: true }).click();
+  expect((await accent()).toUpperCase()).toBe("#54BFAB");
+});

--- a/frontend/e2e/tokens.spec.ts
+++ b/frontend/e2e/tokens.spec.ts
@@ -12,7 +12,7 @@ test("the built bundle renders both palettes in IBM Plex", async ({ page }) => {
     if (!request.url().startsWith("http://127.0.0.1")) external.push(request.url());
   });
 
-  await page.goto("/");
+  await page.goto("/tokens?token=e2e-token");
   await expect(page.getByRole("heading", { name: "Design tokens" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Light" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Dark" })).toBeVisible();

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,23 +1,28 @@
 import { defineConfig } from "@playwright/test";
 
-// The walkthrough that is Phase 1.1's exit criterion (#50) lives here. For now
-// it is one smoke test, running against the production build rather than the
-// dev server, so what is tested is what would ship.
+/** The walkthrough that is Phase 1.1's exit criterion (#50) grows out of these.
+ *
+ * They run against the stub server serving the built bundle - the same origin,
+ * the same handlers and the same token the packaged application will use. A
+ * Vite preview server would test a page that talks to nothing.
+ */
 export default defineConfig({
   testDir: "./e2e",
   use: {
-    baseURL: "http://127.0.0.1:4173",
+    baseURL: "http://127.0.0.1:8765",
     viewport: { width: 1440, height: 900 },
     // No GPU: the container this runs in has no usable one, and chromium takes
     // the whole browser down rather than falling back on its own.
     launchOptions: { args: ["--disable-gpu"] },
   },
   webServer: {
-    // --host 127.0.0.1 is not decoration: without it vite preview binds
-    // whatever localhost resolves to, which on a CI runner is ::1, and the
-    // wait below polls 127.0.0.1 until it times out.
-    command: "pnpm preview --host 127.0.0.1 --port 4173 --strictPort",
-    url: "http://127.0.0.1:4173",
-    reuseExistingServer: !process.env.CI,
+    // From the repository root, because that is where uv's environment is.
+    command: "uv run python stub/server.py",
+    cwd: "..",
+    url: "http://127.0.0.1:8765/",
+    env: { STUB_PORT: "8765", STUB_TOKEN: "e2e-token", STUB_JOB_STEP_SECONDS: "1" },
+    // Never reuse: a server left running from a development session holds a
+    // different token, and the failure would look like a broken application.
+    reuseExistingServer: false,
   },
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,13 @@
 import { Tokens } from "./pages/Tokens";
+import { Shell } from "./shell/Shell";
 
-/** The screens are #43 onward. Until the shell exists, the token page is the
- * application - it is what proves the palettes, the type and the HTTP seam. */
+/** The screens are #44 onward; the shell is what they open inside.
+ *
+ * The token page that stood here through #42 moves to /tokens and stays
+ * reachable: it is what proves the palettes and the bundled type, and the
+ * end-to-end test still checks it. One comparison is cheaper than a router,
+ * and a router arrives when a screen needs a URL of its own.
+ */
 export function App() {
-  return <Tokens />;
+  return window.location.pathname === "/tokens" ? <Tokens /> : <Shell />;
 }

--- a/frontend/src/__tests__/tabs.test.ts
+++ b/frontend/src/__tests__/tabs.test.ts
@@ -1,0 +1,80 @@
+/** The tab rules. The point of the transient tab is that clicking through
+ * fifteen preprocessing variants leaves one tab behind, not fifteen. */
+import { describe, expect, it } from "vitest";
+
+import { emptyTabs, tabsReducer, type TabState } from "@/shell/tabs";
+
+const preview = (id: string): Parameters<typeof tabsReducer>[1] => ({
+  type: "open",
+  tab: { id, kind: "spectra", title: id.toUpperCase() },
+  transient: true,
+});
+
+const pinned = (id: string): Parameters<typeof tabsReducer>[1] => ({
+  type: "open",
+  tab: { id, kind: "spectra", title: id.toUpperCase() },
+  transient: false,
+});
+
+function run(actions: Parameters<typeof tabsReducer>[1][], from: TabState = emptyTabs): TabState {
+  return actions.reduce(tabsReducer, from);
+}
+
+describe("previewing", () => {
+  it("replaces the transient tab instead of adding one", () => {
+    const state = run([preview("snv"), preview("msc"), preview("savgol")]);
+    expect(state.tabs.map((tab) => tab.id)).toEqual(["savgol"]);
+    expect(state.activeId).toBe("savgol");
+  });
+
+  it("keeps pinned tabs and previews beside them, in place", () => {
+    const state = run([pinned("snv"), preview("msc"), preview("savgol")]);
+    expect(state.tabs.map((tab) => tab.id)).toEqual(["snv", "savgol"]);
+  });
+
+  it("pins on a double click, and the next preview no longer replaces it", () => {
+    const state = run([preview("snv"), { type: "pin", id: "snv" }, preview("msc")]);
+    expect(state.tabs.map((tab) => tab.id)).toEqual(["snv", "msc"]);
+    expect(state.tabs[0].transient).toBe(false);
+  });
+
+  it("opening an open tab focuses it rather than duplicating it", () => {
+    const state = run([pinned("snv"), pinned("msc"), preview("snv")]);
+    expect(state.tabs.map((tab) => tab.id)).toEqual(["snv", "msc"]);
+    expect(state.activeId).toBe("snv");
+  });
+
+  it("opening a preview deliberately a second time makes it permanent", () => {
+    const state = run([preview("snv"), pinned("snv"), preview("msc")]);
+    expect(state.tabs.map((tab) => tab.id)).toEqual(["snv", "msc"]);
+  });
+});
+
+describe("closing", () => {
+  it("falls to the neighbour on the right, then the left", () => {
+    const three = run([pinned("a"), pinned("b"), pinned("c")]);
+    expect(tabsReducer(three, { type: "close", id: "c" }).activeId).toBe("b");
+    const middle = tabsReducer({ ...three, activeId: "b" }, { type: "close", id: "b" });
+    expect(middle.activeId).toBe("c");
+  });
+
+  it("leaves nothing active when the last tab closes", () => {
+    const state = run([pinned("a"), { type: "close", id: "a" }]);
+    expect(state).toEqual({ tabs: [], activeId: null, splitId: null });
+  });
+
+  it("closes the split when the tab it showed goes", () => {
+    const state = run([pinned("a"), pinned("b"), { type: "split", id: "a" }, { type: "close", id: "a" }]);
+    expect(state.splitId).toBeNull();
+  });
+
+  it("does not disturb the active tab when another closes", () => {
+    const state = run([pinned("a"), pinned("b"), { type: "activate", id: "a" }, { type: "close", id: "b" }]);
+    expect(state.activeId).toBe("a");
+  });
+});
+
+it("reorders by moving one tab to another index", () => {
+  const state = run([pinned("a"), pinned("b"), pinned("c"), { type: "move", from: 2, to: 0 }]);
+  expect(state.tabs.map((tab) => tab.id)).toEqual(["c", "a", "b"]);
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,9 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "./client";
 
-/** The payload shapes are the stub server's, which are generated from the
- * kernels - see stub/generate_fixtures.py. Only the fields used are typed. */
+/** The payload shapes are the stub server's, generated from the kernels by
+ * stub/generate_fixtures.py. Only the fields the shell reads are typed. */
+
 export interface Project {
   project_id: string;
   name: string;
@@ -12,6 +13,117 @@ export interface Project {
   created_at: string;
 }
 
+export interface DatasetVersion {
+  version_id: string;
+  version: number;
+  content_hash: string;
+  n_samples: number;
+  n_variables: number;
+  axis: { kind: string; unit: string | null; values?: number[] };
+  source: { filename: string; reader: string; reader_version: string; file_hash: string } | null;
+  derived_from: string | null;
+  created_at: string;
+}
+
+export interface DatasetEntry {
+  dataset: { dataset_id: string; name: string; description: string };
+  versions: DatasetVersion[];
+}
+
+export interface PipelineNode {
+  id: string;
+  type: string;
+  inputs: string[];
+  /** Preprocessing nodes carry `step`; estimators and splits carry `spec`. */
+  step?: { kind: string; [key: string]: unknown };
+  spec?: { kind: string; [key: string]: unknown };
+  version_id?: string;
+}
+
+export interface Pipeline {
+  pipeline_id: string;
+  name: string;
+  nodes: PipelineNode[];
+}
+
+export interface PipelineState {
+  pipeline_id: string;
+  nodes: Record<string, { state: string; message?: string }>;
+}
+
+export interface Experiment {
+  experiment_id: string;
+  status: string;
+  started_at: string;
+  finished_at: string | null;
+  metrics: { explained_variance: number[] | null };
+}
+
+export interface Job {
+  job_id: string;
+  experiment_id: string;
+  status: "queued" | "running" | "succeeded" | "failed" | "cancelled";
+  progress: number;
+  message: string;
+}
+
 export function useProjects() {
   return useQuery({ queryKey: ["projects"], queryFn: () => api<Project[]>("/projects") });
+}
+
+export function useDatasets(projectId: string | undefined) {
+  return useQuery({
+    queryKey: ["datasets", projectId],
+    queryFn: () => api<DatasetEntry[]>(`/projects/${projectId}/datasets`),
+    enabled: Boolean(projectId),
+  });
+}
+
+/** Phase 1.1 has one pipeline and one experiment, and the stub server returns
+ * them whatever id it is given. 1.2 keeps the URLs and stops ignoring the id. */
+export function usePipeline() {
+  return useQuery({ queryKey: ["pipeline"], queryFn: () => api<Pipeline>("/pipelines/current") });
+}
+
+export function usePipelineState() {
+  return useQuery({
+    queryKey: ["pipeline-state"],
+    queryFn: () => api<PipelineState>("/pipelines/current/state"),
+  });
+}
+
+export function useExperiment() {
+  return useQuery({
+    queryKey: ["experiment"],
+    queryFn: () => api<Experiment>("/experiments/current"),
+  });
+}
+
+/** A run is a real job: it advances, it can be cancelled and it can fail. The
+ * poll stops when the job reaches a terminal status. */
+export function useJob(jobId: string | null) {
+  return useQuery({
+    queryKey: ["job", jobId],
+    queryFn: () => api<Job>(`/jobs/${jobId}`),
+    enabled: Boolean(jobId),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === "queued" || status === "running" ? 400 : false;
+    },
+  });
+}
+
+export function useRunExperiment() {
+  return useMutation({
+    mutationFn: (options: { fail?: boolean } = {}) =>
+      api<Job>(`/experiments/current/run${options.fail ? "?fail=true" : ""}`, { method: "POST" }),
+  });
+}
+
+export function useCancelJob() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (jobId: string) => api<Job>(`/jobs/${jobId}/cancel`, { method: "POST" }),
+    onSuccess: (job) => client.setQueryData(["job", job.job_id], job),
+  });
 }

--- a/frontend/src/shell/Inspector.tsx
+++ b/frontend/src/shell/Inspector.tsx
@@ -1,0 +1,105 @@
+import type { DatasetEntry, PipelineNode, PipelineState } from "@/api/queries";
+import type { Tab } from "@/shell/tabs";
+
+/** The inspector's frame. What fills it per selection is #47; what it must do
+ * here is be context-sensitive - a different heading and a different set of
+ * facts depending on what the active tab shows - and collapse. */
+
+interface Props {
+  tab: Tab | undefined;
+  datasets: DatasetEntry[] | undefined;
+  nodes: PipelineNode[] | undefined;
+  state: PipelineState | undefined;
+  collapsed: boolean;
+}
+
+function Kv({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="kv">
+      <b>{label}</b>
+      <span>{value}</span>
+    </div>
+  );
+}
+
+function short(hash: string): string {
+  return hash.length > 20 ? `${hash.slice(0, 11)}…${hash.slice(-4)}` : hash;
+}
+
+export function Inspector({ tab, datasets, nodes, state, collapsed }: Props) {
+  if (collapsed) return <aside className="insp rail" aria-label="Inspector" />;
+
+  if (!tab) {
+    return (
+      <aside className="insp" aria-label="Inspector">
+        <div className="ihead">
+          <span className="ilabel">Nothing selected</span>
+        </div>
+        <div className="empty">Select a dataset or a node in the outline.</div>
+      </aside>
+    );
+  }
+
+  const version = datasets
+    ?.flatMap((entry) => entry.versions.map((v) => ({ entry, v })))
+    .find((pair) => pair.v.version_id === tab.id);
+  const node = nodes?.find((candidate) => candidate.id === tab.id);
+
+  return (
+    <aside className="insp" aria-label="Inspector">
+      <div className="ihead">
+        <span className="ilabel">
+          {version ? "Dataset version" : node ? "Node" : tab.kind === "experiment" ? "Experiment" : "Selection"}
+        </span>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>
+          {version ? `${version.entry.dataset.name} · v${version.v.version}` : tab.title}
+        </span>
+      </div>
+
+      {version ? (
+        <>
+          <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
+            <Kv label="Samples" value={version.v.n_samples} />
+            <Kv label="Variables" value={version.v.n_variables} />
+            <Kv label="Content hash" value={short(version.v.content_hash)} />
+            <Kv label="Derived from" value={version.v.derived_from ? "v1" : "—"} />
+            <Kv label="Created" value={version.v.created_at.slice(0, 10)} />
+          </div>
+          <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
+            <div className="ilabel" style={{ padding: "2px 12px 4px" }}>
+              Variable axis
+            </div>
+            <Kv label="Kind" value={version.v.axis.kind} />
+            <Kv label="Unit" value={version.v.axis.unit ?? "—"} />
+          </div>
+          {version.v.source ? (
+            <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
+              <div className="ilabel" style={{ padding: "2px 12px 4px" }}>
+                Source
+              </div>
+              <Kv label="File" value={version.v.source.filename} />
+              <Kv
+                label="Reader"
+                value={`${version.v.source.reader} ${version.v.source.reader_version}`}
+              />
+              <Kv label="File hash" value={short(version.v.source.file_hash)} />
+            </div>
+          ) : null}
+        </>
+      ) : null}
+
+      {node ? (
+        <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
+          <Kv label="Type" value={node.type} />
+          {node.step?.kind ? <Kv label="Step" value={String(node.step.kind)} /> : null}
+          <Kv label="Inputs" value={node.inputs.join(", ") || "—"} />
+          <Kv label="Run state" value={state?.nodes[node.id]?.state ?? "unknown"} />
+        </div>
+      ) : null}
+
+      {/* The parameter editors, the metrics table and the provenance record
+          are #47. This frame is what they mount into. */}
+      <div style={{ padding: "9px 12px", color: "var(--ink2)" }}>Provenance record</div>
+    </aside>
+  );
+}

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useReducer, useRef, useState } from "react";
+
+import {
+  useCancelJob,
+  useDatasets,
+  useExperiment,
+  useJob,
+  usePipeline,
+  usePipelineState,
+  useProjects,
+  useRunExperiment,
+} from "@/api/queries";
+import { Inspector } from "@/shell/Inspector";
+import { Sidebar } from "@/shell/Sidebar";
+import { StatusBar } from "@/shell/StatusBar";
+import { TabStrip } from "@/shell/TabStrip";
+import { FlaskIcon, KIND_ICONS } from "@/shell/icons";
+import { emptyTabs, tabsReducer, type Tab } from "@/shell/tabs";
+
+/** The frame every screen opens inside. The measurements are the artboard's -
+ * see src/styles/shell.css, which is ported from design/canvas/_base.css. */
+
+type Theme = "t-light" | "t-dark";
+
+/** A region the user can drag wider or collapse. The handle straddles the rule
+ * so the pointer target is bigger than the line it moves. */
+function useResizable(initial: number, min: number, max: number, side: "left" | "right") {
+  const [width, setWidth] = useState(initial);
+  const dragging = useRef(false);
+
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent) => {
+      dragging.current = true;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      const startX = event.clientX;
+      const startWidth = width;
+      const move = (moveEvent: PointerEvent) => {
+        if (!dragging.current) return;
+        const delta = side === "left" ? moveEvent.clientX - startX : startX - moveEvent.clientX;
+        setWidth(Math.min(max, Math.max(min, startWidth + delta)));
+      };
+      const up = () => {
+        dragging.current = false;
+        window.removeEventListener("pointermove", move);
+        window.removeEventListener("pointerup", up);
+      };
+      window.addEventListener("pointermove", move);
+      window.addEventListener("pointerup", up);
+    },
+    [width, min, max, side],
+  );
+
+  return { width, onPointerDown };
+}
+
+function Pane({ tab }: { tab: Tab | undefined }) {
+  if (!tab) {
+    return (
+      <div className="pane">
+        <div className="empty" style={{ padding: 16 }}>
+          Nothing open. Select something in the outline.
+        </div>
+      </div>
+    );
+  }
+  const KindIcon = KIND_ICONS[tab.kind];
+  return (
+    <div className="pane">
+      <div
+        style={{
+          height: 40,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          gap: 9,
+          padding: "0 14px",
+          borderBottom: "1px solid var(--rule2)",
+        }}
+      >
+        <KindIcon />
+        <span style={{ fontWeight: 600, fontSize: 13.5 }}>{tab.title}</span>
+        <span className="pill mono">{tab.kind}</span>
+      </div>
+      {/* The documents themselves are #44 to #48. The shell's job is to open,
+          close, reorder, split and focus them. */}
+      <div className="empty" style={{ padding: 16 }}>
+        {tab.kind} view — built in a later issue.
+      </div>
+    </div>
+  );
+}
+
+export function Shell() {
+  const [theme, setTheme] = useState<Theme>("t-light");
+  const [state, dispatch] = useReducer(tabsReducer, emptyTabs);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
+  const sidebar = useResizable(248, 180, 420, "left");
+  const inspector = useResizable(292, 220, 460, "right");
+
+  const projects = useProjects();
+  const project = projects.data?.[0];
+  const datasets = useDatasets(project?.project_id);
+  const pipeline = usePipeline();
+  const pipelineState = usePipelineState();
+  const experiment = useExperiment();
+
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const job = useJob(jobId);
+  const run = useRunExperiment();
+  const cancel = useCancelJob();
+
+  const open = useCallback(
+    (tab: Omit<Tab, "transient">, transient: boolean) =>
+      dispatch({ type: "open", tab, transient }),
+    [],
+  );
+
+  const activeTab = state.tabs.find((tab) => tab.id === state.activeId);
+  const splitTab = state.tabs.find((tab) => tab.id === state.splitId);
+  const samples = datasets.data?.[0]?.versions.at(-1);
+
+  return (
+    <div className={`app ${theme}`}>
+      <div className="tbar">
+        <div className="tb-l">
+          <FlaskIcon />
+          <span className="proj">{project?.name ?? "Loading…"}</span>
+          <span className="crumb mono">{project?.directory ?? ""}</span>
+        </div>
+        <div className="tb-r">
+          {samples ? (
+            <span className="pill mono">
+              {samples.n_samples} × {samples.n_variables}
+            </span>
+          ) : null}
+          <button className="btn" onClick={() => setTheme(theme === "t-light" ? "t-dark" : "t-light")}>
+            {theme === "t-light" ? "Dark" : "Light"}
+          </button>
+          <button className="btn" onClick={() => setSidebarCollapsed(!sidebarCollapsed)}>
+            Outline
+          </button>
+          <button className="btn" onClick={() => setInspectorCollapsed(!inspectorCollapsed)}>
+            Inspector
+          </button>
+          <button
+            className="btn btn-p"
+            onClick={async () => {
+              const started = await run.mutateAsync({});
+              setJobId(started.job_id);
+              setStartedAt(Date.now());
+            }}
+          >
+            Run pipeline
+          </button>
+        </div>
+      </div>
+
+      <div className="body">
+        <div style={{ display: "flex", width: sidebarCollapsed ? undefined : sidebar.width }}>
+          <div style={{ flex: 1, display: "flex", minWidth: 0 }}>
+            <Sidebar
+              projectId={project?.project_id}
+              activeId={state.activeId}
+              collapsed={sidebarCollapsed}
+              onOpen={open}
+            />
+          </div>
+        </div>
+        {sidebarCollapsed ? null : (
+          <div className="grip" onPointerDown={sidebar.onPointerDown} role="separator" aria-label="Resize outline" />
+        )}
+
+        <main className="doc">
+          <TabStrip
+            tabs={state.tabs}
+            activeId={state.activeId}
+            splitId={state.splitId}
+            onActivate={(id) => dispatch({ type: "activate", id })}
+            onPin={(id) => dispatch({ type: "pin", id })}
+            onClose={(id) => dispatch({ type: "close", id })}
+            onMove={(from, to) => dispatch({ type: "move", from, to })}
+            onSplit={(id) => dispatch({ type: "split", id })}
+          />
+          {state.splitId ? (
+            <div className="split">
+              <Pane tab={activeTab} />
+              <Pane tab={splitTab} />
+            </div>
+          ) : (
+            <Pane tab={activeTab} />
+          )}
+        </main>
+
+        {inspectorCollapsed ? null : (
+          <div className="grip" onPointerDown={inspector.onPointerDown} role="separator" aria-label="Resize inspector" />
+        )}
+        <div style={{ display: "flex", width: inspectorCollapsed ? undefined : inspector.width }}>
+          <div style={{ flex: 1, display: "flex", minWidth: 0 }}>
+            <Inspector
+              tab={activeTab}
+              datasets={datasets.data}
+              nodes={pipeline.data?.nodes}
+              state={pipelineState.data}
+              collapsed={inspectorCollapsed}
+            />
+          </div>
+        </div>
+      </div>
+
+      <StatusBar
+        job={job.data}
+        startedAt={startedAt}
+        onCancel={() => {
+          if (jobId) cancel.mutate(jobId);
+        }}
+      />
+      {/* experiment is read for the outline's Experiments section; keeping the
+          query here means one fetch shared by both regions. */}
+      <span hidden>{experiment.data?.status}</span>
+    </div>
+  );
+}

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -1,0 +1,176 @@
+import {
+  useDatasets,
+  useExperiment,
+  usePipeline,
+  usePipelineState,
+  type PipelineNode,
+} from "@/api/queries";
+import { DatasetIcon, FlaskIcon, ModelIcon, NodeIcon } from "@/shell/icons";
+import type { Tab } from "@/shell/tabs";
+
+/** The left outline: datasets, the pipeline as a node list, experiments and
+ * models. Selecting a row opens it as a preview; a double click pins it. That
+ * is the mechanism tying the outline to the pages, so it lives here and the
+ * shell owns nothing but the handler. */
+
+interface Props {
+  projectId: string | undefined;
+  activeId: string | null;
+  collapsed: boolean;
+  onOpen: (tab: Omit<Tab, "transient">, transient: boolean) => void;
+}
+
+function Row({
+  icon,
+  label,
+  dim,
+  depth,
+  selected,
+  onOpen,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  dim?: string;
+  depth: number;
+  selected: boolean;
+  onOpen: (transient: boolean) => void;
+}) {
+  return (
+    <button
+      className={`srow${selected ? " sel" : ""}`}
+      style={{ paddingLeft: depth }}
+      onClick={() => onOpen(true)}
+      onDoubleClick={() => onOpen(false)}
+      title={label}
+    >
+      {icon}
+      <span>{label}</span>
+      {dim ? <span className="sdim mono">{dim}</span> : null}
+    </button>
+  );
+}
+
+function Head({ label, note }: { label: string; note?: string }) {
+  return (
+    <div className="shead">
+      <span>{label}</span>
+      {note ? (
+        <span className="mono" style={{ fontSize: 10 }}>
+          {note}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/** "SNV", "SG d1 w11", "K-fold 10 · seed 42" - what the artboard's outline
+ * shows. A node reads as what it does, not as its id or its node type. */
+export function nodeLabel(node: PipelineNode): string {
+  const step = node.step as Record<string, number | string> | undefined;
+  const spec = node.spec as Record<string, number | string> | undefined;
+  switch (step?.kind ?? spec?.kind ?? node.type) {
+    case "snv":
+      return "SNV";
+    case "msc":
+      return `MSC · ${step?.reference}`;
+    case "mean_centre":
+      return "Mean centre";
+    case "autoscale":
+      return "Autoscale";
+    case "savgol":
+      return `SG d${step?.deriv} w${step?.window_length}`;
+    case "kfold":
+      return `K-fold ${spec?.n_splits} · seed ${spec?.seed}`;
+    case "pca":
+      return `PCA ${spec?.n_components} PC`;
+    case "source":
+      return "Source";
+    default:
+      return node.id;
+  }
+}
+
+export function Sidebar({ projectId, activeId, collapsed, onOpen }: Props) {
+  const datasets = useDatasets(projectId);
+  const pipeline = usePipeline();
+  const pipelineState = usePipelineState();
+  const experiment = useExperiment();
+
+  return (
+    <aside className={`side${collapsed ? " rail" : ""}`} aria-label="Project outline">
+      <div style={{ overflowY: "auto" }}>
+        <Head label="Datasets" note={datasets.data ? String(datasets.data.length) : undefined} />
+        {datasets.data?.map((entry) =>
+          entry.versions.map((version) => (
+            <Row
+              key={version.version_id}
+              icon={<DatasetIcon />}
+              label={entry.dataset.name}
+              dim={`v${version.version} · ${version.n_samples}×${version.n_variables}`}
+              depth={16}
+              selected={activeId === version.version_id}
+              onOpen={(transient) =>
+                onOpen(
+                  { id: version.version_id, kind: "dataset", title: entry.dataset.name },
+                  transient,
+                )
+              }
+            />
+          )),
+        )}
+
+        <Head
+          label="Pipeline"
+          note={pipeline.data ? `${pipeline.data.nodes.length} nodes` : undefined}
+        />
+        {pipeline.data?.nodes.map((node) => {
+          const state = pipelineState.data?.nodes[node.id]?.state;
+          return (
+            <Row
+              key={node.id}
+              icon={<NodeIcon />}
+              label={nodeLabel(node)}
+              dim={state && state !== "complete" ? state : node.id}
+              depth={node.type === "source" ? 26 : 34}
+              selected={activeId === node.id}
+              onOpen={(transient) =>
+                onOpen(
+                  {
+                    id: node.id,
+                    kind: node.type === "estimator" ? "results" : "spectra",
+                    title: nodeLabel(node),
+                  },
+                  transient,
+                )
+              }
+            />
+          );
+        })}
+
+        <Head label="Experiments" note={experiment.data ? "1" : undefined} />
+        {experiment.data ? (
+          <Row
+            icon={<FlaskIcon />}
+            label="Runs"
+            dim={experiment.data.status}
+            depth={26}
+            selected={activeId === experiment.data.experiment_id}
+            onOpen={(transient) =>
+              onOpen(
+                { id: experiment.data.experiment_id, kind: "experiment", title: "Runs" },
+                transient,
+              )
+            }
+          />
+        ) : null}
+
+        <Head label="Models" note="0" />
+        {/* Models are Phase 2 (#51) and no fixture describes one, so the
+            section is here with its empty state rather than invented. */}
+        <div className="empty">
+          {collapsed ? <ModelIcon /> : "No models yet — a run produces the first."}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/shell/StatusBar.tsx
+++ b/frontend/src/shell/StatusBar.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+
+import type { Job } from "@/api/queries";
+import { LockIcon, StopIcon } from "@/shell/icons";
+
+/** The status bar. A run is a real job, so this shows real progress and can
+ * really cancel it - and it is never a blocking modal. */
+
+interface Props {
+  job: Job | undefined;
+  startedAt: number | null;
+  onCancel: () => void;
+}
+
+function elapsed(since: number): string {
+  const seconds = Math.floor((Date.now() - since) / 1000);
+  return `${Math.floor(seconds / 60)}:${String(seconds % 60).padStart(2, "0")}`;
+}
+
+export function StatusBar({ job, startedAt, onCancel }: Props) {
+  const running = job?.status === "queued" || job?.status === "running";
+  const [, tick] = useState(0);
+
+  // The clock is the only thing here that changes without the server saying so.
+  useEffect(() => {
+    if (!running) return;
+    const timer = setInterval(() => tick((n) => n + 1), 1000);
+    return () => clearInterval(timer);
+  }, [running]);
+
+  const colour =
+    job?.status === "failed"
+      ? "var(--fail)"
+      : job?.status === "cancelled"
+        ? "var(--stale)"
+        : "var(--accent)";
+
+  return (
+    <div className="status" role="status">
+      <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+        {job ? (
+          <>
+            <span style={{ color: colour, fontWeight: 500 }}>{job.message}</span>
+            <div className="prog">
+              <i style={{ width: `${Math.round(job.progress * 100)}%`, background: colour }} />
+            </div>
+            {startedAt ? <span className="mono">{elapsed(startedAt)}</span> : null}
+            {running ? (
+              <button
+                className="srow"
+                style={{ width: "auto", height: 20, padding: 0, gap: 4, color: "var(--ink3)" }}
+                onClick={onCancel}
+              >
+                <StopIcon />
+                Cancel
+              </button>
+            ) : null}
+          </>
+        ) : (
+          <span style={{ color: "var(--ink3)" }}>Idle</span>
+        )}
+      </div>
+      <div style={{ display: "flex", alignItems: "center", gap: 6, color: "var(--ink3)" }}>
+        <LockIcon />
+        <span>Local · nothing leaves this machine</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shell/TabStrip.tsx
+++ b/frontend/src/shell/TabStrip.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { KIND_ICONS, SplitIcon } from "@/shell/icons";
+import type { Tab } from "@/shell/tabs";
+
+/** The tab strip: reorderable, closable, with the overflow the artboard draws
+ * as a mono "+3" at the end. Fifteen preprocessing variants is the normal
+ * case, so the overflow is searchable rather than a plain list.
+ *
+ * Every tab stays in the DOM and the strip clips them. The first version
+ * rendered only the tabs that fit, which cannot work: a tab that is not
+ * rendered has no width, so the measurement that decides what fits could only
+ * ever confirm what it already showed, and the strip stuck at one tab.
+ *
+ * Reordering is the platform's own drag and drop. A drag library would be
+ * three dependencies for what four handlers do.
+ */
+
+interface Props {
+  tabs: Tab[];
+  activeId: string | null;
+  splitId: string | null;
+  onActivate: (id: string) => void;
+  onPin: (id: string) => void;
+  onClose: (id: string) => void;
+  onMove: (from: number, to: number) => void;
+  onSplit: (id: string | null) => void;
+}
+
+export function TabStrip({
+  tabs,
+  activeId,
+  splitId,
+  onActivate,
+  onPin,
+  onClose,
+  onMove,
+  onSplit,
+}: Props) {
+  const stripRef = useRef<HTMLDivElement>(null);
+  const [clipped, setClipped] = useState<string[]>([]);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const dragFrom = useRef<number | null>(null);
+
+  // Which tabs the strip has run out of room for is a measurement, not a
+  // guess. Reserve room for the "+N" and the split control at the right end.
+  useLayoutEffect(() => {
+    const strip = stripRef.current;
+    if (!strip) return;
+    const measure = () => {
+      const available = strip.clientWidth - 96;
+      const out: string[] = [];
+      for (const child of Array.from(strip.querySelectorAll<HTMLElement>("[data-tab]"))) {
+        if (child.offsetLeft + child.offsetWidth > available) out.push(child.dataset.tab!);
+      }
+      setClipped(out);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(strip);
+    return () => observer.disconnect();
+  }, [tabs]);
+
+  useEffect(() => {
+    if (!menuOpen) setSearch("");
+  }, [menuOpen]);
+
+  const hidden = tabs.filter((tab) => clipped.includes(tab.id));
+  // Searching matches the id as well as the title: a pipeline with four PCA
+  // branches gives four tabs reading "PCA 5 PC", and the id is what tells
+  // them apart.
+  const matches = hidden.filter((tab) =>
+    `${tab.title} ${tab.id}`.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <div className="tabs" ref={stripRef} style={{ position: "relative" }} role="tablist">
+      {tabs.map((tab, index) => {
+        const KindIcon = KIND_ICONS[tab.kind];
+        return (
+          <div
+            key={tab.id}
+            data-tab={tab.id}
+            draggable
+            onDragStart={() => (dragFrom.current = index)}
+            onDragOver={(event) => event.preventDefault()}
+            onDrop={() => {
+              if (dragFrom.current !== null) onMove(dragFrom.current, index);
+              dragFrom.current = null;
+            }}
+            className={`tab${tab.id === activeId ? " act" : ""}${tab.transient ? " tr" : ""}`}
+            role="tab"
+            aria-selected={tab.id === activeId}
+            onClick={() => onActivate(tab.id)}
+            onDoubleClick={() => onPin(tab.id)}
+          >
+            <KindIcon />
+            <span>{tab.title}</span>
+            <button
+              className="tabx"
+              aria-label={`Close ${tab.title}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                onClose(tab.id);
+              }}
+            >
+              ×
+            </button>
+          </div>
+        );
+      })}
+
+      {hidden.length > 0 ? (
+        <button
+          className="tab mono"
+          style={{
+            color: "var(--ink3)",
+            borderRight: "none",
+            position: "absolute",
+            right: 38,
+            top: 0,
+            bottom: 0,
+            background: "var(--panel)",
+          }}
+          aria-label={`${hidden.length} more tabs`}
+          onClick={() => setMenuOpen(!menuOpen)}
+        >
+          +{hidden.length}
+        </button>
+      ) : null}
+
+      <div
+        style={{
+          position: "absolute",
+          right: 0,
+          top: 0,
+          bottom: 0,
+          display: "flex",
+          alignItems: "center",
+          padding: "0 8px",
+          background: "var(--panel)",
+        }}
+      >
+        <button
+          className="iconbtn"
+          aria-label={splitId ? "Close split" : "Split view"}
+          aria-pressed={Boolean(splitId)}
+          onClick={() => {
+            const other = tabs.find((tab) => tab.id !== activeId);
+            onSplit(splitId ? null : (other?.id ?? null));
+          }}
+        >
+          <SplitIcon />
+        </button>
+      </div>
+
+      {menuOpen ? (
+        <div className="omenu">
+          <input
+            autoFocus
+            placeholder="Search tabs…"
+            value={search}
+            aria-label="Search tabs"
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          {matches.map((tab) => {
+            const KindIcon = KIND_ICONS[tab.kind];
+            return (
+              <button
+                key={tab.id}
+                onClick={() => {
+                  onActivate(tab.id);
+                  setMenuOpen(false);
+                }}
+              >
+                <KindIcon />
+                {tab.title}
+              </button>
+            );
+          })}
+          {matches.length === 0 ? <div className="empty">Nothing matches.</div> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/shell/icons.tsx
+++ b/frontend/src/shell/icons.tsx
@@ -1,0 +1,91 @@
+/** The artboard's icon set, at the artboard's 13px and 1.8 stroke.
+ *
+ * Traced from design/canvas/Main.dc.html rather than pulled from a library:
+ * six paths weigh less than a dependency, and these are the exact shapes the
+ * design uses.
+ */
+import type { ReactNode } from "react";
+
+function Icon({ children, size = 13 }: { children: ReactNode; size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.8}
+      aria-hidden="true"
+      style={{ flex: "none" }}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export const FlaskIcon = () => (
+  <Icon>
+    <path d="M9 3v6L4 19a1.6 1.6 0 0 0 1.4 2h13.2A1.6 1.6 0 0 0 20 19l-5-10V3" />
+    <path d="M8 3h8" />
+    <path d="M7 14h10" />
+  </Icon>
+);
+
+export const DatasetIcon = () => (
+  <Icon>
+    <ellipse cx="12" cy="6" rx="8" ry="3" />
+    <path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6" />
+    <path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3" />
+  </Icon>
+);
+
+export const NodeIcon = () => (
+  <Icon>
+    <rect x="3" y="9" width="7" height="6" rx="1" />
+    <rect x="14" y="9" width="7" height="6" rx="1" />
+    <path d="M10 12h4" />
+  </Icon>
+);
+
+export const PlotIcon = () => (
+  <Icon>
+    <path d="M3 20h18" />
+    <path d="M4 16l5-6 4 3 6-8" />
+  </Icon>
+);
+
+export const ModelIcon = () => (
+  <Icon>
+    <path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z" />
+    <path d="M12 12l8-4.5M12 12v9M12 12L4 7.5" />
+  </Icon>
+);
+
+export const LockIcon = () => (
+  <Icon size={12}>
+    <rect x="4" y="10" width="16" height="10" rx="2" />
+    <path d="M8 10V7a4 4 0 0 1 8 0v3" />
+  </Icon>
+);
+
+export const StopIcon = () => (
+  <Icon size={11}>
+    <rect x="6" y="6" width="12" height="12" rx="1.5" />
+  </Icon>
+);
+
+export const SplitIcon = () => (
+  <Icon size={12}>
+    <rect x="3" y="5" width="18" height="14" rx="1.5" />
+    <path d="M12 5v14" />
+  </Icon>
+);
+
+export const KIND_ICONS = {
+  dataset: DatasetIcon,
+  pipeline: NodeIcon,
+  spectra: PlotIcon,
+  results: PlotIcon,
+  experiment: FlaskIcon,
+  model: ModelIcon,
+} as const;

--- a/frontend/src/shell/tabs.ts
+++ b/frontend/src/shell/tabs.ts
@@ -1,0 +1,87 @@
+/** The tab model. Pure, so the rules can be tested without a browser.
+ *
+ * The one rule worth stating: a single click previews into *the* transient
+ * tab - there is only ever one, and opening another preview replaces it. A
+ * double click, or an edit, pins it. This is what stops a session of clicking
+ * through fifteen preprocessing variants from leaving fifteen tabs behind.
+ */
+
+export type TabKind = "dataset" | "pipeline" | "spectra" | "results" | "experiment" | "model";
+
+export interface Tab {
+  /** Stable across opens: the node, dataset or experiment id it shows. */
+  id: string;
+  kind: TabKind;
+  title: string;
+  transient: boolean;
+}
+
+export interface TabState {
+  tabs: Tab[];
+  activeId: string | null;
+  /** The document shown beside the active one, or null when not split. */
+  splitId: string | null;
+}
+
+export const emptyTabs: TabState = { tabs: [], activeId: null, splitId: null };
+
+export type TabAction =
+  | { type: "open"; tab: Omit<Tab, "transient">; transient: boolean }
+  | { type: "pin"; id: string }
+  | { type: "close"; id: string }
+  | { type: "activate"; id: string }
+  | { type: "move"; from: number; to: number }
+  | { type: "split"; id: string | null };
+
+export function tabsReducer(state: TabState, action: TabAction): TabState {
+  switch (action.type) {
+    case "open": {
+      const existing = state.tabs.find((tab) => tab.id === action.tab.id);
+      if (existing) {
+        // Opening what is already open focuses it. A pinned tab stays pinned;
+        // a preview opened again deliberately becomes permanent.
+        const tabs = action.transient
+          ? state.tabs
+          : state.tabs.map((tab) =>
+              tab.id === action.tab.id ? { ...tab, transient: false } : tab,
+            );
+        return { ...state, tabs, activeId: action.tab.id };
+      }
+      const opened: Tab = { ...action.tab, transient: action.transient };
+      const transientIndex = state.tabs.findIndex((tab) => tab.transient);
+      const tabs = [...state.tabs];
+      if (action.transient && transientIndex >= 0) tabs.splice(transientIndex, 1, opened);
+      else tabs.push(opened);
+      return { ...state, tabs, activeId: opened.id };
+    }
+    case "pin":
+      return {
+        ...state,
+        tabs: state.tabs.map((tab) => (tab.id === action.id ? { ...tab, transient: false } : tab)),
+        activeId: action.id,
+      };
+    case "close": {
+      const index = state.tabs.findIndex((tab) => tab.id === action.id);
+      if (index < 0) return state;
+      const tabs = state.tabs.filter((tab) => tab.id !== action.id);
+      // Closing the active tab falls to its neighbour, the way an editor does.
+      const activeId =
+        state.activeId === action.id
+          ? (tabs[index]?.id ?? tabs[index - 1]?.id ?? null)
+          : state.activeId;
+      const splitId = state.splitId === action.id ? null : state.splitId;
+      return { tabs, activeId, splitId };
+    }
+    case "activate":
+      return { ...state, activeId: action.id };
+    case "move": {
+      const tabs = [...state.tabs];
+      const [moved] = tabs.splice(action.from, 1);
+      if (!moved) return state;
+      tabs.splice(action.to, 0, moved);
+      return { ...state, tabs };
+    }
+    case "split":
+      return { ...state, splitId: action.id };
+  }
+}

--- a/frontend/src/styles/app.css
+++ b/frontend/src/styles/app.css
@@ -11,6 +11,7 @@
 @import "@fontsource/ibm-plex-mono/600.css";
 
 @import "./tokens.css";
+@import "./shell.css";
 
 @theme {
   --font-sans: "IBM Plex Sans", system-ui, sans-serif;

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -1,0 +1,95 @@
+/* The shell's measurements, ported from design/canvas/_base.css.
+ *
+ * Every number here - the 40px top bar, the 248px sidebar, the 34px tab strip,
+ * the 292px inspector, the 28px status bar, the 118 x 4 progress bar - comes
+ * from the artboards, which are the design of record. They are not choices
+ * made in this file. The palette and the type live in tokens.css and app.css;
+ * this is geometry only.
+ *
+ * Rules that only the React shell needs (resize handles, the collapsed rail,
+ * the overflow menu, the split) are added at the end and marked.
+ */
+
+.app{width:1440px;height:900px;display:flex;flex-direction:column;background:var(--ground);color:var(--ink);font-size:12.5px;line-height:1.45}
+.mono{font-family:'IBM Plex Mono',ui-monospace,monospace;font-variant-numeric:tabular-nums}
+.tbar{height:40px;flex:none;display:flex;align-items:center;justify-content:space-between;padding:0 12px;gap:12px;background:var(--panel);border-bottom:1px solid var(--rule)}
+.tb-l,.tb-r{display:flex;align-items:center;gap:10px}
+.proj{font-weight:600;font-size:13px;letter-spacing:-.01em}
+.crumb{font-size:11px;color:var(--ink3)}
+.pill{display:flex;align-items:center;gap:6px;height:22px;padding:0 8px;border:1px solid var(--rule);border-radius:3px;font-size:11px;color:var(--ink2);background:var(--surface)}
+.btn{display:flex;align-items:center;gap:6px;height:26px;padding:0 10px;border:1px solid var(--rule);border-radius:3px;background:var(--surface);color:var(--ink);font-size:12px;font-weight:500}
+.btn-p{background:var(--accent);border-color:var(--accent);color:#fff}
+.body{flex:1;display:flex;min-height:0}
+.side{width:248px;flex:none;background:var(--panel);border-right:1px solid var(--rule);display:flex;flex-direction:column;overflow:hidden}
+.doc{flex:1;display:flex;flex-direction:column;min-width:0;background:var(--surface)}
+.insp{width:292px;flex:none;background:var(--panel);border-left:1px solid var(--rule);display:flex;flex-direction:column;overflow:hidden}
+.shead{display:flex;align-items:center;justify-content:space-between;height:26px;padding:0 10px;font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.11em;text-transform:uppercase;color:var(--ink3);margin-top:6px}
+.srow{display:flex;align-items:center;gap:7px;height:24px;padding:0 10px 0 16px;font-size:12px;color:var(--ink2)}
+.srow.sel{background:var(--accentSoft);color:var(--accentInk);font-weight:500}
+.sdim{color:var(--ink3);font-size:11px;margin-left:auto}
+.tabs{height:34px;flex:none;display:flex;align-items:stretch;background:var(--panel);border-bottom:1px solid var(--rule)}
+.tab{display:flex;align-items:center;gap:7px;padding:0 11px;border-right:1px solid var(--rule);font-size:12px;color:var(--ink2);white-space:nowrap}
+.tab.act{background:var(--surface);color:var(--ink);font-weight:500}
+.tab.tr{font-style:italic;color:var(--ink3)}
+.tabx{color:var(--ink3);font-size:14px;line-height:1}
+.pane{flex:1;min-height:0;overflow:hidden;display:flex;flex-direction:column}
+.status{height:28px;flex:none;display:flex;align-items:center;justify-content:space-between;padding:0 12px;gap:12px;background:var(--panel);border-top:1px solid var(--rule);font-size:11px;color:var(--ink2)}
+.prog{width:118px;height:4px;border-radius:2px;background:var(--sunken);overflow:hidden}
+.prog i{display:block;height:100%;background:var(--accent)}
+.ihead{padding:9px 12px;border-bottom:1px solid var(--rule);display:flex;flex-direction:column;gap:2px}
+.ilabel{font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.11em;text-transform:uppercase;color:var(--ink3)}
+.kv{display:flex;justify-content:space-between;gap:10px;padding:3px 12px;font-size:11.5px}
+.kv b{font-weight:400;color:var(--ink3)}
+.kv span{color:var(--ink);font-family:'IBM Plex Mono',monospace;font-variant-numeric:tabular-nums}
+table{border-collapse:collapse;width:100%;font-size:12px}
+th{background:var(--panel);text-align:left;font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.09em;text-transform:uppercase;color:var(--ink3);font-weight:500;padding:7px 10px;border-bottom:1px solid var(--rule)}
+td{padding:5px 10px;border-bottom:1px solid var(--rule2);color:var(--ink2)}
+td.n,th.n{font-family:'IBM Plex Mono',monospace;font-variant-numeric:tabular-nums;text-align:right}
+td.n{color:var(--ink)}
+
+/* --- Added here: what a static artboard has no need of ------------------- */
+
+/* The drag handle straddles the rule rather than sitting beside it, so the
+ * pointer target is 7px wide while the rule stays 1px. */
+.grip{width:7px;flex:none;margin:0 -3px;cursor:col-resize;position:relative;z-index:1}
+.grip:hover{background:var(--accentSoft)}
+
+/* Collapsed, a sidebar keeps only its icons. 44px is the row height plus the
+ * padding the artboard's rows carry. */
+.side.rail,.insp.rail{width:44px}
+.side.rail .srow{padding-left:0;justify-content:center}
+.side.rail .srow span,.side.rail .shead span{display:none}
+
+.tabs{overflow:hidden}
+.tab{background:none;border-top:none;border-bottom:none;border-left:none;cursor:pointer;font-family:inherit}
+.tab.act{font-weight:500}
+.tabx{background:none;border:none;cursor:pointer;padding:0 0 0 2px;font-family:inherit}
+
+/* The overflow menu the "+3" opens. Fifteen preprocessing variants is the
+ * normal case, so it is searchable rather than a plain list. */
+.omenu{position:absolute;top:34px;right:0;width:260px;max-height:320px;overflow:auto;background:var(--surface);border:1px solid var(--rule);border-radius:3px;z-index:5;box-shadow:0 6px 20px rgba(0,0,0,.12)}
+.omenu input{width:100%;height:28px;padding:0 9px;border:none;border-bottom:1px solid var(--rule);background:var(--surface);color:var(--ink);font:inherit;font-size:12px;outline:none}
+.omenu button{display:flex;align-items:center;gap:7px;width:100%;height:26px;padding:0 9px;border:none;background:none;color:var(--ink2);font:inherit;font-size:12px;text-align:left;cursor:pointer}
+.omenu button:hover{background:var(--accentSoft);color:var(--accentInk)}
+
+/* Side by side, for comparing two documents. The rule between them is the
+ * same one that separates every other region. */
+.split{display:flex;flex:1;min-height:0}
+.split>.pane+.pane{border-left:1px solid var(--rule)}
+
+.iconbtn{display:flex;align-items:center;justify-content:center;height:22px;width:22px;border:1px solid var(--rule);border-radius:3px;background:var(--surface);color:var(--ink2);cursor:pointer}
+.btn{cursor:pointer;font-family:inherit}
+.srow{width:100%;border:none;background:none;font-family:inherit;text-align:left;cursor:pointer}
+.srow:hover{background:var(--rule2)}
+.srow.sel:hover{background:var(--accentSoft)}
+.empty{padding:6px 16px;font-size:11px;color:var(--ink3)}
+
+/* The artboard is a fixed 1440 x 900 frame because it is a picture. The
+ * application fills its window and refuses to reflow below the design width -
+ * PROPOSAL.md and the brief both put the floor at 1440. */
+.app{width:100%;height:100%;min-width:1440px}
+
+/* A long node label truncates rather than wrapping: the row is 24px and the
+ * artboard's rows are one line each. */
+.srow span:not(.sdim){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.sdim{flex:none;padding-left:6px}

--- a/stub/server.py
+++ b/stub/server.py
@@ -43,8 +43,7 @@ from uuid import uuid4
 import uvicorn
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse, JSONResponse
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 # Production mode serves the built frontend from here. STUB_BUNDLE overrides it,
@@ -242,7 +241,23 @@ def cancel_job(job_id: str) -> Any:
 app.include_router(api)
 
 if BUNDLE.is_dir():
-    app.mount("/", StaticFiles(directory=BUNDLE, html=True), name="bundle")
+
+    @app.get("/{path:path}")
+    def bundle(path: str) -> FileResponse:
+        """Serve the built file, or index.html so a deep link reaches the app.
+
+        The frontend routes on the path itself (#42), so /tokens has to arrive
+        as the application rather than as a 404. Anything under /api never
+        reaches here - those routes are registered above this one.
+        """
+        candidate = (BUNDLE / path).resolve()
+        # A path from the client never escapes the bundle: PROPOSAL.md section
+        # 4.3 confines filesystem access, and ../ in a URL is the cheapest way
+        # to test whether anyone meant it.
+        inside = candidate.is_relative_to(BUNDLE.resolve())
+        if path and inside and candidate.is_file():
+            return FileResponse(candidate)
+        return FileResponse(BUNDLE / "index.html")
 
 
 def main() -> None:

--- a/tests/test_stub_server.py
+++ b/tests/test_stub_server.py
@@ -144,3 +144,16 @@ def test_development_mode_lets_the_vite_dev_server_call_the_api(client: TestClie
         },
     )
     assert response.headers["access-control-allow-origin"] == "http://localhost:5173"
+
+
+def test_a_deep_link_arrives_as_the_application_not_a_404(client: TestClient) -> None:
+    """The frontend routes on the path, so /tokens must be served the bundle."""
+    response = client.get("/tokens")
+    assert response.status_code == 200
+    assert "bundle" in response.text
+
+
+def test_a_path_from_the_client_cannot_escape_the_bundle(client: TestClient) -> None:
+    response = client.get("/../../etc/passwd")
+    assert response.status_code == 200
+    assert "root:" not in response.text


### PR DESCRIPTION
The frame every screen opens inside. `src/styles/shell.css` is ported from `design/canvas/_base.css`, so the geometry is the artboard's — and `e2e/shell.spec.ts` asserts it in a real browser rather than trusting the port: top bar 40, sidebar 248, tab strip 34, inspector 292, status bar 28.

## What it does

- **The outline drives the tabs.** A single click previews into *the* transient tab (italic, `--ink3`), a second preview replaces it, a double click pins it. That rule is why clicking through fifteen preprocessing variants leaves one tab behind rather than fifteen. It is a pure reducer with ten tests.
- **Tabs** reorder by the platform's own drag and drop, close, split side by side, and overflow into a searchable menu. Search matches ids as well as titles: four PCA branches all read `PCA 5 PC`, and the id is what tells them apart.
- **Sidebar and inspector** drag to resize and collapse to a rail.
- **The status bar shows a real job** — it advances, reports what the server says, and Cancel stops it where it stood. Never a modal.

## The bug the end-to-end test caught

The first overflow implementation rendered only the tabs that fit. That cannot work: an unrendered tab has no width, so the measurement deciding what fits can only ever confirm what it already shows — the strip stuck at one tab and every later tab silently vanished into "+N". Every tab now stays in the DOM, the strip clips them, and the "+N" floats over the clipped ones.

## Also here

The stub server gains a catch-all serving `index.html`, so `/tokens` arrives as the application rather than a 404, with a guard that a client path cannot escape the bundle (`PROPOSAL.md` §4.3). The e2e suite now runs against the stub server serving the built bundle — the same origin and token the packaged application uses, rather than a Vite preview talking to nothing — so CI's frontend job installs uv too.

## Evidence

- `pnpm test` 17 passed (10 new), `pnpm e2e` 6 passed (5 new), `pnpm typecheck` / `lint` / `build` clean, `uv run pytest` 483 passed (2 new: the deep link, the traversal guard).
- A run reports `Queued` → `Preprocessing: SNV` → advances; Cancel freezes it and the progress width is unchanged 1.2s later.
- `--accent` resolves to `#0B6B62` light and `#54BFAB` dark, in the browser.

## Deliberately not here

Models has an empty state — no fixture describes a model and they are Phase 2 (#51). Pane contents are placeholders naming the issue that fills them (#44–#48).

Closes #43