### PR TITLE
Build the import flow, the empty project and the dataset view

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -131,7 +131,7 @@
         "app-shell"
       ],
       "user_visible_behavior": "A new project states its next action plainly. Choosing a file shows what the reader detected - wavelength range, sample count, delimiter, decimal separator, orientation, metadata columns - and nothing is committed until that is confirmed.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "The empty state names the next action without a tour or a modal.",
         "The preview shows all six detected properties before any commit.",
@@ -142,8 +142,8 @@
         "The failure state names the offending file or setting and shows no stack trace.",
         "The screen uses only components the artboards already establish - table rules, .kv rows, .pill, .btn, sidebar section headers - and any new one was raised rather than introduced in passing."
       ],
-      "evidence": null,
-      "notes": "No artboard exists for this screen. DESIGN_BRIEF.md section 6 asked for the first four screens fully and the rest as needed; screens 6 and 7 and the importing state were never drawn. Default taken: build from the component vocabulary the artboards establish. If it should be drawn first, that is one more artboard and this feature waits."
+      "evidence": "2026-08-24. On feature/44_import-flow. `pnpm e2e` is 10 passed, 4 of them this feature: the empty project offers one action and opens the import tab; the preview shows tecator.txt with delimiter=whitespace and decimal=point, states the reconstructed axis and the 22 discarded principal components, and correcting the orientation to samples_in_columns flips the confirm button from `Import 240 x 100` to `Import 100 x 240` before anything is committed; confirming opens the dataset tab, closes the import tab and shows the sample table with the target columns; the broken file returns READER_FAILED with the row-87 message and no traceback, and Try again returns to the picker. `pnpm test` 17 passed, typecheck, lint and build clean, Python 484 passed (1 new: the empty-project knob). Screenshots taken of the empty state, the corrected preview and the imported dataset in the dark palette.",
+      "notes": "No artboard exists for these screens - DESIGN_BRIEF.md section 6 drew the first four and this was among the rest - so they are built from the established vocabulary: the table rules, the .kv rows, .pill and .btn. Nothing new was invented visually. `?empty` in the application's URL asks the stub server for a project with no datasets, which is how the empty state is reachable from a fixture that always has one; `Import a broken file` sends X-Stub-Fail. Both are 1.1 affordances that vanish in 1.2, where a new project is simply empty and a truncated file fails on its own. The dataset view shows the first 60 of 240 samples and says so; virtualisation belongs to #45, where the payload is large enough to need it."
     },
     {
       "id": "spectra-view",

--- a/frontend/e2e/import.spec.ts
+++ b/frontend/e2e/import.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** From an empty project to a loaded dataset, with one detection corrected
+ * and the failure state reached - all against the stub server's fixtures. */
+
+async function ready(page: Page, query = "") {
+  await page.goto(`/?token=e2e-token${query}`);
+  await expect(page.getByText("Tecator meat study")).toBeVisible();
+}
+
+test("an empty project offers the one action that matters", async ({ page }) => {
+  await ready(page, "&empty");
+  await expect(page.getByRole("heading", { name: "This project is empty" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Import data" }).click();
+  await expect(page.getByRole("heading", { name: "Import data" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: /Import/ })).toBeVisible();
+});
+
+test("the preview shows what was detected, and a correction changes what would be read", async ({
+  page,
+}) => {
+  await ready(page);
+  await page.getByRole("button", { name: "Import…" }).click();
+  await page.getByRole("button", { name: "Use the example file" }).click();
+
+  await expect(page.getByText("tecator.txt")).toBeVisible();
+  await expect(page.getByLabel("Delimiter")).toHaveValue("whitespace");
+  await expect(page.getByLabel("Decimal")).toHaveValue(".");
+  await expect(page.getByRole("button", { name: "Import 240 × 100" })).toBeVisible();
+
+  // The reconstructed axis and the discarded columns are stated, not hidden.
+  await expect(page.getByText(/reconstructed as 100 evenly spaced points/)).toBeVisible();
+  await expect(page.getByText(/22 principal components/)).toBeVisible();
+
+  // Correcting the orientation swaps what the counts mean, before anything is
+  // committed - a transposed file is the common wrong guess.
+  await page.getByLabel("Orientation").selectOption("samples_in_columns");
+  await expect(page.getByText("corrected")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Import 100 × 240" })).toBeVisible();
+});
+
+test("confirming the preview opens the dataset, and nothing is committed before that", async ({
+  page,
+}) => {
+  await ready(page);
+  await page.getByRole("button", { name: "Import…" }).click();
+  await page.getByRole("button", { name: "Use the example file" }).click();
+  await expect(page.getByRole("tab", { name: /tecator_raw/ })).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Import 240 × 100" }).click();
+  await expect(page.getByRole("tab", { name: /tecator_raw/ })).toBeVisible();
+  await expect(page.getByRole("tab", { name: /Import/ })).toHaveCount(0);
+
+  // The dataset itself: the artboard's table, the targets as columns.
+  await expect(page.getByRole("columnheader", { name: "moisture" })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "C001" })).toBeVisible();
+  await expect(page.getByText("Showing 60 of 240 samples.")).toBeVisible();
+});
+
+test("a failed import names the file and the setting, not a stack trace", async ({ page }) => {
+  await ready(page);
+  await page.getByRole("button", { name: "Import…" }).click();
+  await page.getByRole("button", { name: "Import a broken file" }).click();
+
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText("READER_FAILED");
+  await expect(alert).toContainText("expected a multiple of 125 values per row");
+  await expect(alert).toContainText("row: 87");
+  await expect(alert).not.toContainText("Traceback");
+
+  await alert.getByRole("button", { name: "Try again" }).click();
+  await expect(page.getByRole("button", { name: "Use the example file" })).toBeVisible();
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -20,9 +20,56 @@ export interface DatasetVersion {
   n_samples: number;
   n_variables: number;
   axis: { kind: string; unit: string | null; values?: number[] };
-  source: { filename: string; reader: string; reader_version: string; file_hash: string } | null;
+  sample_ids: string[];
+  targets: Record<string, number[]>;
+  metadata_columns: Record<string, (string | number)[]>;
+  excluded_samples: number[];
+  excluded_variables: number[];
+  source: {
+    filename: string;
+    reader: string;
+    reader_version: string;
+    file_hash: string;
+    imported_at?: string;
+  } | null;
   derived_from: string | null;
   created_at: string;
+}
+
+/** What a reader says it found, before anything is committed. Every value the
+ * user can correct arrives with the alternatives the reader considered. */
+export interface Detected<T> {
+  value: T;
+  alternatives: T[];
+}
+
+export interface ImportPreview {
+  source: {
+    filename: string;
+    file_hash: string;
+    reader: string;
+    reader_version: string;
+    size_bytes: number;
+  };
+  detected: {
+    delimiter: Detected<string>;
+    decimal: Detected<string>;
+    orientation: Detected<string>;
+    n_samples: number;
+    n_variables: number;
+    axis: {
+      kind: string;
+      unit: string | null;
+      start: number;
+      end: number;
+      reconstructed: boolean;
+      note?: string;
+    };
+    metadata_columns: string[];
+    targets: string[];
+    discarded: { what: string; why: string }[];
+  };
+  head: { sample_ids: string[]; rows: number[][] };
 }
 
 export interface DatasetEntry {
@@ -71,11 +118,41 @@ export function useProjects() {
   return useQuery({ queryKey: ["projects"], queryFn: () => api<Project[]>("/projects") });
 }
 
+/** `?empty` in the application's own URL asks the stub server for a project
+ * with no datasets, which is how the empty-project state (#44) is reached
+ * without editing code. In 1.2 a new project is simply empty. */
 export function useDatasets(projectId: string | undefined) {
+  const empty = new URLSearchParams(window.location.search).has("empty");
   return useQuery({
-    queryKey: ["datasets", projectId],
-    queryFn: () => api<DatasetEntry[]>(`/projects/${projectId}/datasets`),
+    queryKey: ["datasets", projectId, empty],
+    queryFn: () => api<DatasetEntry[]>(`/projects/${projectId}/datasets${empty ? "?empty=true" : ""}`),
     enabled: Boolean(projectId),
+  });
+}
+
+/** Nothing is committed by a preview: it reports what the reader found and
+ * the user confirms or corrects it. The corrections ride along on the import
+ * so 1.2's reader has them; the stub server ignores them. */
+export function useImportPreview() {
+  return useMutation({
+    mutationFn: (options: { fail?: boolean } = {}) =>
+      api<ImportPreview>("/import/preview", {
+        method: "POST",
+        headers: options.fail ? { "X-Stub-Fail": "1" } : {},
+      }),
+  });
+}
+
+export function useImportDataset() {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (corrections: Record<string, string>) =>
+      api<DatasetEntry>("/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ corrections }),
+      }),
+    onSuccess: () => client.invalidateQueries({ queryKey: ["datasets"] }),
   });
 }
 

--- a/frontend/src/screens/DatasetView.tsx
+++ b/frontend/src/screens/DatasetView.tsx
@@ -1,0 +1,117 @@
+import type { DatasetEntry, DatasetVersion } from "@/api/queries";
+
+/** The dataset a user has just imported: what came in, what is excluded, and
+ * where it came from. Built from the artboard's table rules - mono uppercase
+ * headers, tabular numbers right-aligned, excluded rows dimmed and labelled. */
+
+const ROWS = 60;
+
+function summary(version: DatasetVersion) {
+  const axis = version.axis.values;
+  const range = axis?.length
+    ? `${axis[0].toFixed(0)}–${axis.at(-1)!.toFixed(0)} ${version.axis.unit ?? ""}`
+    : version.axis.kind;
+  return [
+    `${version.n_samples} × ${version.n_variables}`,
+    range,
+    `${Object.keys(version.targets).length} targets`,
+  ];
+}
+
+export function DatasetView({ entry, version }: { entry: DatasetEntry; version: DatasetVersion }) {
+  const targets = Object.keys(version.targets);
+  const metadata = Object.keys(version.metadata_columns);
+  const excluded = new Set(version.excluded_samples);
+
+  return (
+    <div className="pane">
+      <div
+        style={{
+          height: 40,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0 14px",
+          borderBottom: "1px solid var(--rule2)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+          <span style={{ fontWeight: 600, fontSize: 13.5 }}>{entry.dataset.name}</span>
+          <span className="pill mono">v{version.version}</span>
+          <span className="mono" style={{ fontSize: 10.5, color: "var(--ink3)" }}>
+            {version.content_hash.slice(0, 18)}…
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+          {summary(version).map((item) => (
+            <span key={item} className="pill mono">
+              {item}
+            </span>
+          ))}
+          {excluded.size > 0 ? (
+            <span className="pill mono" style={{ color: "var(--stale)", borderColor: "var(--stale)" }}>
+              {excluded.size} excluded
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        <table>
+          <thead>
+            <tr>
+              <th className="n" style={{ width: 38 }}>
+                #
+              </th>
+              <th style={{ width: 90 }}>Sample</th>
+              {metadata.map((column) => (
+                <th key={column}>{column}</th>
+              ))}
+              {targets.map((target) => (
+                <th key={target} className="n">
+                  {target}
+                </th>
+              ))}
+              <th style={{ textAlign: "right" }}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {version.sample_ids.slice(0, ROWS).map((id, index) => (
+              <tr key={id} style={excluded.has(index) ? { opacity: 0.45 } : undefined}>
+                <td className="n" style={{ color: "var(--ink3)" }}>
+                  {index + 1}
+                </td>
+                <td className="mono" style={{ color: "var(--ink)" }}>
+                  {id}
+                </td>
+                {metadata.map((column) => (
+                  <td key={column}>{String(version.metadata_columns[column][index])}</td>
+                ))}
+                {targets.map((target) => (
+                  <td key={target} className="n">
+                    {version.targets[target][index]?.toFixed(2)}
+                  </td>
+                ))}
+                <td style={{ textAlign: "right" }}>
+                  {excluded.has(index) ? (
+                    <span className="mono" style={{ color: "var(--stale)", fontSize: 10 }}>
+                      excluded
+                    </span>
+                  ) : null}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {version.sample_ids.length > ROWS ? (
+          <div className="empty">
+            {/* Virtualised scrolling is #45's problem, where the payload is
+                large enough to need it. */}
+            Showing {ROWS} of {version.sample_ids.length} samples.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/EmptyProject.tsx
+++ b/frontend/src/screens/EmptyProject.tsx
@@ -1,0 +1,17 @@
+/** First run: a project with nothing in it, and one obvious next action. */
+export function EmptyProject({ onImport }: { onImport: () => void }) {
+  return (
+    <div className="pane">
+      <div style={{ padding: 40, maxWidth: 520, margin: "0 auto", textAlign: "center" }}>
+        <h2 style={{ margin: "0 0 6px", fontSize: 14, fontWeight: 600 }}>This project is empty</h2>
+        <p style={{ margin: "0 0 16px", color: "var(--ink3)", lineHeight: 1.5 }}>
+          Import spectra to begin. CSV, TXT, XLSX and JCAMP-DX are read here; the file stays on this
+          machine and nothing is committed until you have seen what the reader found.
+        </p>
+        <button className="btn btn-p" style={{ margin: "0 auto" }} onClick={onImport}>
+          Import data
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/Import.tsx
+++ b/frontend/src/screens/Import.tsx
@@ -1,0 +1,333 @@
+import { useState } from "react";
+
+import { ApiError } from "@/api/client";
+import { useImportDataset, useImportPreview, type ImportPreview } from "@/api/queries";
+
+/** The screen that decides whether a file becomes a dataset.
+ *
+ * No artboard was drawn for it - DESIGN_BRIEF.md section 6 asked for the first
+ * four screens and this was among "the rest". It is built from the vocabulary
+ * the artboards do establish: the table rules, the .kv rows, .pill and .btn. A
+ * preview is a table plus a form, and nothing here is a new visual idea.
+ *
+ * Nothing is committed until the user confirms. The detection comes from the
+ * server, never from a guess made here: the real readers land in 1.2 and have
+ * to return this shape.
+ */
+
+interface Props {
+  onImported: (versionId: string, name: string) => void;
+  onCancel: () => void;
+}
+
+const LABELS: Record<string, string> = {
+  whitespace: "whitespace",
+  ",": "comma ,",
+  ";": "semicolon ;",
+  "\t": "tab",
+  "|": "pipe |",
+  ".": "point .",
+  samples_in_rows: "samples in rows",
+  samples_in_columns: "samples in columns",
+};
+
+const label = (value: string) => LABELS[value] ?? value;
+
+function Choice({
+  name,
+  detected,
+  value,
+  onChange,
+}: {
+  name: string;
+  detected: { value: string; alternatives: string[] };
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const corrected = value !== detected.value;
+  return (
+    <div className="kv" style={{ alignItems: "center", padding: "5px 12px" }}>
+      <b>{name}</b>
+      <span style={{ display: "flex", alignItems: "center", gap: 6 }}>
+        <select
+          className="mono"
+          aria-label={name}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          style={{
+            height: 22,
+            padding: "0 6px",
+            borderRadius: 3,
+            border: `1px solid ${corrected ? "var(--accent)" : "var(--rule)"}`,
+            background: "var(--surface)",
+            color: "var(--ink)",
+            font: "inherit",
+            fontSize: 11.5,
+          }}
+        >
+          {[detected.value, ...detected.alternatives].map((option) => (
+            <option key={option} value={option}>
+              {label(option)}
+            </option>
+          ))}
+        </select>
+        {corrected ? (
+          <span className="mono" style={{ fontSize: 10, color: "var(--accent)" }}>
+            corrected
+          </span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+/** A failure names the file and the setting. It is never a stack trace, and
+ * the body it reads is the one the server documents. */
+export function Failure({ error, onRetry }: { error: ApiError; onRetry?: () => void }) {
+  const detail = error.detail as Record<string, unknown> | undefined;
+  return (
+    <div
+      role="alert"
+      style={{
+        margin: 12,
+        padding: "10px 12px",
+        borderRadius: 3,
+        border: "1px solid var(--fail)",
+        background: "var(--failSoft)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+        <span className="mono" style={{ fontSize: 10, color: "var(--fail)" }}>
+          {error.code.toUpperCase()}
+        </span>
+        {onRetry ? (
+          <button className="btn" style={{ marginLeft: "auto", height: 22 }} onClick={onRetry}>
+            Try again
+          </button>
+        ) : null}
+      </div>
+      <p style={{ margin: "4px 0 0", color: "var(--ink)" }}>{error.message}</p>
+      {detail ? (
+        <p className="mono" style={{ margin: "4px 0 0", fontSize: 10.5, color: "var(--ink3)" }}>
+          {Object.entries(detail)
+            .map(([key, item]) => `${key}: ${String(item)}`)
+            .join(" · ")}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function Preview({ preview, onImported, onCancel }: Props & { preview: ImportPreview }) {
+  const { source, detected, head } = preview;
+  const [corrections, setCorrections] = useState<Record<string, string>>({});
+  const commit = useImportDataset();
+
+  const value = (key: "delimiter" | "decimal" | "orientation") =>
+    corrections[key] ?? detected[key].value;
+
+  // Reading a file the other way round is the common wrong guess, and it
+  // swaps what the counts mean. Say so before the import, not after.
+  const flipped = value("orientation") !== detected.orientation.value;
+  const samples = flipped ? detected.n_variables : detected.n_samples;
+  const variables = flipped ? detected.n_samples : detected.n_variables;
+  const error = commit.error instanceof ApiError ? commit.error : null;
+
+  return (
+    <div className="pane" style={{ overflowY: "auto" }}>
+      <div
+        style={{
+          height: 40,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0 14px",
+          borderBottom: "1px solid var(--rule2)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+          <span style={{ fontWeight: 600, fontSize: 13.5 }}>{source.filename}</span>
+          <span className="pill mono">{source.reader}</span>
+          <span className="mono" style={{ fontSize: 10.5, color: "var(--ink3)" }}>
+            {Math.round(source.size_bytes / 1024)} kB
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+          <button className="btn" onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            className="btn btn-p"
+            disabled={commit.isPending}
+            onClick={async () => {
+              const entry = await commit.mutateAsync(corrections);
+              const version = entry.versions.at(-1)!;
+              onImported(version.version_id, entry.dataset.name);
+            }}
+          >
+            Import {samples} × {variables}
+          </button>
+        </div>
+      </div>
+
+      {error ? <Failure error={error} /> : null}
+
+      <div style={{ display: "flex", minHeight: 0, flex: 1 }}>
+        <section style={{ width: 360, flex: "none", borderRight: "1px solid var(--rule)" }}>
+          <div className="ilabel" style={{ padding: "10px 12px 4px" }}>
+            Detected
+          </div>
+          <Choice
+            name="Delimiter"
+            detected={detected.delimiter}
+            value={value("delimiter")}
+            onChange={(next) => setCorrections({ ...corrections, delimiter: next })}
+          />
+          <Choice
+            name="Decimal"
+            detected={detected.decimal}
+            value={value("decimal")}
+            onChange={(next) => setCorrections({ ...corrections, decimal: next })}
+          />
+          <Choice
+            name="Orientation"
+            detected={detected.orientation}
+            value={value("orientation")}
+            onChange={(next) => setCorrections({ ...corrections, orientation: next })}
+          />
+          <div className="kv">
+            <b>Samples</b>
+            <span>{samples}</span>
+          </div>
+          <div className="kv">
+            <b>Variables</b>
+            <span>{variables}</span>
+          </div>
+
+          <div className="ilabel" style={{ padding: "12px 12px 4px" }}>
+            Variable axis
+          </div>
+          <div className="kv">
+            <b>Kind</b>
+            <span>{detected.axis.kind}</span>
+          </div>
+          <div className="kv">
+            <b>Range</b>
+            <span>
+              {detected.axis.start}–{detected.axis.end} {detected.axis.unit}
+            </span>
+          </div>
+          {detected.axis.reconstructed ? (
+            <p style={{ margin: "4px 12px 0", fontSize: 11, color: "var(--stale)", lineHeight: 1.35 }}>
+              {detected.axis.note}
+            </p>
+          ) : null}
+
+          <div className="ilabel" style={{ padding: "12px 12px 4px" }}>
+            Targets
+          </div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 5, padding: "0 12px" }}>
+            {detected.targets.map((target) => (
+              <span key={target} className="pill mono">
+                {target}
+              </span>
+            ))}
+            {detected.metadata_columns.map((column) => (
+              <span key={column} className="pill mono">
+                {column}
+              </span>
+            ))}
+          </div>
+
+          {detected.discarded.length > 0 ? (
+            <>
+              <div className="ilabel" style={{ padding: "12px 12px 4px" }}>
+                Not imported
+              </div>
+              {detected.discarded.map((item) => (
+                <p key={item.what} style={{ margin: "0 12px 6px", fontSize: 11, color: "var(--ink3)" }}>
+                  <span style={{ color: "var(--ink2)" }}>{item.what}</span> — {item.why}
+                </p>
+              ))}
+            </>
+          ) : null}
+        </section>
+
+        <section style={{ flex: 1, minWidth: 0, overflow: "auto" }}>
+          <div className="ilabel" style={{ padding: "10px 12px 6px" }}>
+            First rows, as they would be read
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: 74 }}>Sample</th>
+                {head.rows[0]?.map((_, index) => (
+                  <th key={index} className="n">
+                    v{index + 1}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {head.sample_ids.map((id, row) => (
+                <tr key={id}>
+                  <td className="mono" style={{ color: "var(--ink)" }}>
+                    {id}
+                  </td>
+                  {head.rows[row]?.map((cell, column) => (
+                    <td key={column} className="n">
+                      {cell.toFixed(4)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+export function Import({ onImported, onCancel }: Props) {
+  const preview = useImportPreview();
+  const error = preview.error instanceof ApiError ? preview.error : null;
+
+  if (preview.data) {
+    return <Preview preview={preview.data} onImported={onImported} onCancel={onCancel} />;
+  }
+
+  return (
+    <div className="pane">
+      <div style={{ padding: 16, maxWidth: 620 }}>
+        <h2 style={{ margin: "0 0 4px", fontSize: 13.5, fontWeight: 600 }}>Import data</h2>
+        <p style={{ margin: "0 0 12px", color: "var(--ink3)" }}>
+          Choose a file. Nothing is imported until you have seen what the reader found and said so.
+        </p>
+
+        {error ? <Failure error={error} onRetry={() => preview.reset()} /> : null}
+
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <label className="btn" style={{ position: "relative", overflow: "hidden" }}>
+            Choose file…
+            <input
+              type="file"
+              aria-label="Choose file"
+              style={{ position: "absolute", inset: 0, opacity: 0, cursor: "pointer" }}
+              onChange={() => preview.mutate({})}
+            />
+          </label>
+          <button className="btn" onClick={() => preview.mutate({})} disabled={preview.isPending}>
+            {preview.isPending ? "Reading…" : "Use the example file"}
+          </button>
+          {/* The failed import state (#49) has to be reachable without editing
+              code; in 1.2 a truncated file reaches it on its own. */}
+          <button className="btn" onClick={() => preview.mutate({ fail: true })}>
+            Import a broken file
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useReducer, useRef, useState } from "react";
 
+import type { DatasetEntry } from "@/api/queries";
 import {
   useCancelJob,
   useDatasets,
@@ -10,6 +11,9 @@ import {
   useProjects,
   useRunExperiment,
 } from "@/api/queries";
+import { DatasetView } from "@/screens/DatasetView";
+import { EmptyProject } from "@/screens/EmptyProject";
+import { Import } from "@/screens/Import";
 import { Inspector } from "@/shell/Inspector";
 import { Sidebar } from "@/shell/Sidebar";
 import { StatusBar } from "@/shell/StatusBar";
@@ -53,7 +57,26 @@ function useResizable(initial: number, min: number, max: number, side: "left" | 
   return { width, onPointerDown };
 }
 
-function Pane({ tab }: { tab: Tab | undefined }) {
+function Pane({
+  tab,
+  datasets,
+  onImported,
+  onCloseImport,
+}: {
+  tab: Tab | undefined;
+  datasets: DatasetEntry[] | undefined;
+  onImported: (versionId: string, name: string) => void;
+  onCloseImport: () => void;
+}) {
+  if (tab?.kind === "import") {
+    return <Import onImported={onImported} onCancel={onCloseImport} />;
+  }
+
+  const found = datasets
+    ?.flatMap((entry) => entry.versions.map((version) => ({ entry, version })))
+    .find((pair) => pair.version.version_id === tab?.id);
+  if (found) return <DatasetView entry={found.entry} version={found.version} />;
+
   if (!tab) {
     return (
       <div className="pane">
@@ -117,9 +140,22 @@ export function Shell() {
     [],
   );
 
+  const openImport = useCallback(
+    () => open({ id: "import", kind: "import", title: "Import" }, false),
+    [open],
+  );
+  const imported = useCallback(
+    (versionId: string, name: string) => {
+      dispatch({ type: "close", id: "import" });
+      dispatch({ type: "open", tab: { id: versionId, kind: "dataset", title: name }, transient: false });
+    },
+    [],
+  );
+
   const activeTab = state.tabs.find((tab) => tab.id === state.activeId);
   const splitTab = state.tabs.find((tab) => tab.id === state.splitId);
   const samples = datasets.data?.[0]?.versions.at(-1);
+  const noDatasets = datasets.isSuccess && datasets.data.length === 0;
 
   return (
     <div className={`app ${theme}`}>
@@ -135,6 +171,9 @@ export function Shell() {
               {samples.n_samples} × {samples.n_variables}
             </span>
           ) : null}
+          <button className="btn" onClick={openImport}>
+            Import…
+          </button>
           <button className="btn" onClick={() => setTheme(theme === "t-light" ? "t-dark" : "t-light")}>
             {theme === "t-light" ? "Dark" : "Light"}
           </button>
@@ -183,13 +222,15 @@ export function Shell() {
             onMove={(from, to) => dispatch({ type: "move", from, to })}
             onSplit={(id) => dispatch({ type: "split", id })}
           />
-          {state.splitId ? (
+          {noDatasets && !activeTab ? (
+            <EmptyProject onImport={openImport} />
+          ) : state.splitId ? (
             <div className="split">
-              <Pane tab={activeTab} />
-              <Pane tab={splitTab} />
+              <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} />
+              <Pane tab={splitTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} />
             </div>
           ) : (
-            <Pane tab={activeTab} />
+            <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} />
           )}
         </main>
 

--- a/frontend/src/shell/icons.tsx
+++ b/frontend/src/shell/icons.tsx
@@ -81,8 +81,17 @@ export const SplitIcon = () => (
   </Icon>
 );
 
+export const ImportIcon = () => (
+  <Icon>
+    <path d="M12 3v12" />
+    <path d="M7 10l5 5 5-5" />
+    <path d="M4 20h16" />
+  </Icon>
+);
+
 export const KIND_ICONS = {
   dataset: DatasetIcon,
+  import: ImportIcon,
   pipeline: NodeIcon,
   spectra: PlotIcon,
   results: PlotIcon,

--- a/frontend/src/shell/tabs.ts
+++ b/frontend/src/shell/tabs.ts
@@ -6,7 +6,14 @@
  * through fifteen preprocessing variants from leaving fifteen tabs behind.
  */
 
-export type TabKind = "dataset" | "pipeline" | "spectra" | "results" | "experiment" | "model";
+export type TabKind =
+  | "dataset"
+  | "import"
+  | "pipeline"
+  | "spectra"
+  | "results"
+  | "experiment"
+  | "model";
 
 export interface Tab {
   /** Stable across opens: the node, dataset or experiment id it shows. */

--- a/stub/server.py
+++ b/stub/server.py
@@ -126,8 +126,12 @@ def get_project(project_id: str) -> Any:
 
 
 @api.get("/projects/{project_id}/datasets")
-def list_datasets(project_id: str) -> Any:
-    return fixture("datasets")
+def list_datasets(project_id: str, empty: Annotated[bool, Query()] = False) -> Any:
+    # `?empty=true` is the same kind of affordance as `?fail=true` on a run:
+    # the empty-project state (#44) has to be reachable without editing code,
+    # and a project with no datasets is otherwise unreachable from a fixture
+    # that always has one.
+    return [] if empty else fixture("datasets")
 
 
 @api.post("/import/preview")

--- a/tests/test_stub_server.py
+++ b/tests/test_stub_server.py
@@ -157,3 +157,9 @@ def test_a_path_from_the_client_cannot_escape_the_bundle(client: TestClient) -> 
     response = client.get("/../../etc/passwd")
     assert response.status_code == 200
     assert "root:" not in response.text
+
+
+def test_a_project_can_be_asked_to_look_empty(client: TestClient) -> None:
+    """The empty-project state is unreachable from a fixture that has a dataset."""
+    assert client.get("/api/projects/p/datasets?empty=true", headers=AUTH).json() == []
+    assert client.get("/api/projects/p/datasets", headers=AUTH).json() == fixture("datasets")


### PR DESCRIPTION
The first-run moment and the screen that decides whether a file becomes a dataset.

No artboard was drawn for either — `DESIGN_BRIEF.md` §6 drew the first four screens and these were among "the rest". As the issue's default said, they are built from the vocabulary the artboards do establish: the table rules, the `.kv` inspector rows, `.pill`, `.btn`. Nothing here invents a visual idea; if you would rather see them drawn, that is one artboard and this can be reworked against it.

## What it does

- **Nothing is committed until the user confirms.** The preview states what the reader found — delimiter, decimal, orientation, counts, targets — plus the two things worth surfacing about this file: the axis is *reconstructed* (it carries none), and 22 principal components are discarded because they are preprocessing the file supplied, not raw data.
- **A wrong detection is correctable**, and correcting it changes what the confirm button says it will do: `Import 240 × 100` becomes `Import 100 × 240` when the orientation flips. A transposed layout is the common wrong guess, and before the import is the moment to catch it.
- **A failure names the file, the row and the reader** — never a stack trace.
- **The dataset view** is the artboard's table: mono uppercase headers, right-aligned tabular numbers, targets as columns, excluded rows dimmed and labelled.

## Evidence

`pnpm e2e` 10 passed, 4 of them new and covering exactly the "done when": empty project → import → see the detection → correct one → read the resulting table, plus the failure state and its retry. `pnpm test` 17, typecheck / lint / build clean, `uv run pytest` 484 (1 new).

## Two affordances that exist only in 1.1

`?empty` in the application's URL asks the stub server for a project with no datasets — the empty state is otherwise unreachable from a fixture that always has one. "Import a broken file" sends `X-Stub-Fail`. Both go in 1.2, where a new project is simply empty and a truncated file fails on its own.

The dataset view shows the first 60 of 240 samples and says so; virtualisation belongs to #45, where the payload is large enough to need it.

Closes #44