### PR TITLE
Draw the spectra view over a density band

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -155,7 +155,7 @@
         "app-shell"
       ],
       "user_visible_behavior": "Raw and processed spectra overlaid on a labelled wavelength axis, with large sets shown as a shaded density envelope and selected spectra drawn over it at full resolution.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "The largest fixture dataset renders as a density band rather than one trace per spectrum.",
         "A selected spectrum draws at full resolution on top of the band.",
@@ -167,8 +167,8 @@
         "The screen matches design/canvas/SpectraView.dc.html in both themes.",
         "Plotly's fonts and palette are driven from the design tokens, not from its defaults."
       ],
-      "evidence": null,
-      "notes": "Decimation is consumed here, not computed. Phase 1.2 computes it server-side per PROPOSAL.md section 13."
+      "evidence": "2026-08-24. On feature/45_spectra-view. `pnpm e2e` is 16 passed, 6 of them this feature; `pnpm test` is 24 passed (7 new, the trace rules); typecheck, lint and build clean; Python unchanged at 484. Asserted in the browser: the header reads `240 spectra \u00b7 0 highlighted \u00b7 100 variables` with pills `60 of 240 drawn` and `no x decimation`, and the note `shaded band = full set (240)`; the axes read `wavelength_nm (nm)` and `Absorbance`; highlighting a sample puts one trace at opacity 1 with more than 50 others below it and names it under the plot; the envelope's fillcolor equals the `--band` token read off the running application; the paper background follows the theme, rgb(255,255,255) light and rgb(12,20,19) dark. Every drawn trace is `scattergl` on the Okabe-Ito series, never the accent - checked in the unit tests against the committed fixture. Screenshots taken in both themes, with the hover readout naming sample E1005 at 967.2 nm.",
+      "notes": "Plotly is the gl2d dist bundle called directly - react-plotly.js would be a wrapper dependency for two function calls, and it lags React. The bundle ships no types, so src/plot/plotly.d.ts declares only `react` and `purge`. Every colour and font comes from the CSS variables read off the DOM, so a theme switch repaints the plot; a plot that ignored the theme is how this screen would drift from the artboards. Decimation is consumed, never computed: 240 spectra arrive as 60 traces plus a 5/50/95 band, and Tecator's 100 variables mean the x-axis decimation path is populated but not exercised - the screen says `no x decimation` rather than pretending otherwise. Clicking a trace selects it (plotly_click, bound once the plot exists); a `Highlight sample` list does the same thing deterministically, because sixty overlapping lines are a small target."
     },
     {
       "id": "pipeline-canvas",

--- a/frontend/e2e/spectra.spec.ts
+++ b/frontend/e2e/spectra.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** The spectra view against the stub server: WebGL traces over a density
+ * band, the counts the artboard shows, and a plot that follows the theme. */
+
+async function openSpectra(page: Page, node = /^SNV/) {
+  await page.goto("/?token=e2e-token");
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  await outline.getByRole("button", { name: node }).first().dblclick();
+  await expect(page.getByTestId("spectra-plot")).toBeVisible();
+  await expect(page.locator(".gl-container canvas").first()).toBeVisible();
+}
+
+test("240 spectra arrive as a band plus the drawn subset, and the counts say so", async ({
+  page,
+}) => {
+  await openSpectra(page);
+  await expect(page.getByText("240 spectra · 0 highlighted · 100 variables")).toBeVisible();
+  await expect(page.getByText("60 of 240 drawn")).toBeVisible();
+  await expect(page.getByText("shaded band = full set (240)")).toBeVisible();
+
+  // Tecator is 100 variables wide, so nothing is dropped along the x axis -
+  // the screen says which of the two decimations is in play.
+  await expect(page.getByText("no x decimation")).toBeVisible();
+});
+
+test("highlighting a sample draws it over the band and names it", async ({ page }) => {
+  await openSpectra(page);
+  await page.getByLabel("Highlight sample").selectOption({ index: 3 });
+
+  await expect(page.getByText("240 spectra · 1 highlighted · 100 variables")).toBeVisible();
+  const named = page.locator("text=Highlighted:");
+  await expect(named).toBeVisible();
+
+  // The selected sample is drawn at full strength; the others stay faint.
+  const opacities = await page.evaluate(() => {
+    const plot = document.querySelector("[data-testid=spectra-plot]") as HTMLElement & {
+      data?: { opacity?: number; customdata?: number }[];
+    };
+    return (plot.data ?? []).filter((trace) => typeof trace.customdata === "number").map((t) => t.opacity);
+  });
+  expect(opacities).toContain(1);
+  expect(opacities.filter((value) => value !== 1).length).toBeGreaterThan(50);
+
+  await page.getByRole("button", { name: "Clear highlight" }).click();
+  await expect(page.getByText("240 spectra · 0 highlighted · 100 variables")).toBeVisible();
+});
+
+test("the band is the token's envelope over the whole set", async ({ page }) => {
+  await openSpectra(page);
+  const band = await page.evaluate(() => {
+    const plot = document.querySelector("[data-testid=spectra-plot]") as HTMLElement & {
+      data?: { fill?: string; fillcolor?: string }[];
+    };
+    const filled = (plot.data ?? []).find((trace) => trace.fill === "tonexty");
+    const token = getComputedStyle(document.querySelector(".app")!)
+      .getPropertyValue("--band")
+      .trim();
+    return { fillcolor: filled?.fillcolor, token };
+  });
+  expect(band.fillcolor).toBe(band.token);
+});
+
+test("the axes carry their real units", async ({ page }) => {
+  await openSpectra(page);
+  const plot = page.getByTestId("spectra-plot");
+  await expect(plot).toContainText("wavelength_nm (nm)");
+  await expect(plot).toContainText("Absorbance");
+});
+
+test("the layers switch, and a source node has only raw", async ({ page }) => {
+  await openSpectra(page);
+  const group = page.getByRole("group", { name: "Layers" });
+  await expect(group.getByRole("button", { name: "Both" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+  await group.getByRole("button", { name: "Processed" }).click();
+  await expect(group.getByRole("button", { name: "Processed" })).toHaveAttribute(
+    "aria-pressed",
+    "true",
+  );
+
+  await openSpectra(page, /^Source/);
+  await expect(page.getByRole("group", { name: "Layers" }).getByRole("button", { name: "Processed" })).toBeDisabled();
+});
+
+test("the plot is drawn from the tokens, in whichever theme is applied", async ({ page }) => {
+  await openSpectra(page);
+  // Plotly paints the paper on the first main-svg. Reading it back is the
+  // only honest check that the plot took the token rather than its default
+  // white, which would look right in the light theme and wrong in the dark.
+  const paper = () =>
+    page.evaluate(
+      () => (document.querySelector(".main-svg") as SVGElement | null)?.style.background ?? "",
+    );
+
+  expect(await paper()).toContain("rgb(255, 255, 255)");
+  await page.getByRole("button", { name: "Dark", exact: true }).click();
+  await expect
+    .poll(async () => await paper())
+    .toContain("rgb(12, 20, 19)");
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@fontsource/ibm-plex-sans": "^5.1.0",
     "@tanstack/react-query": "^5.59.0",
     "clsx": "^2.1.1",
+    "plotly.js-gl2d-dist-min": "^3.7.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^2.5.0"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      plotly.js-gl2d-dist-min:
+        specifier: ^3.7.0
+        version: 3.7.0
       react:
         specifier: ^19.0.0
         version: 19.2.8
@@ -1413,6 +1416,9 @@ packages:
     resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
     engines: {node: '>=20'}
     hasBin: true
+
+  plotly.js-gl2d-dist-min@3.7.0:
+    resolution: {integrity: sha512-3vR+89HBYkuLNIx/DmIQbIG6JW+4Ok6MMuWVNYO4OsghZR2n0fB+XL241buc0YsvNWKtLV1YtRrPUiZmOdvBsw==}
 
   postcss@8.5.26:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
@@ -2824,6 +2830,8 @@ snapshots:
       playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  plotly.js-gl2d-dist-min@3.7.0: {}
 
   postcss@8.5.26:
     dependencies:

--- a/frontend/src/__tests__/traces.test.ts
+++ b/frontend/src/__tests__/traces.test.ts
@@ -1,0 +1,88 @@
+/** What gets drawn as a band and what gets drawn as a line.
+ *
+ * This is the substance of the spectra view: 240 spectra become 60 traces
+ * plus an envelope, and a selected sample is drawn over the top at full
+ * strength. None of it needs a browser to check.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { SpectraPayload } from "@/api/queries";
+import { bandTraces, spectraTraces } from "@/plot/traces";
+import type { PlotTheme } from "@/plot/theme";
+
+const FIXTURES = path.resolve(import.meta.dirname, "../../../stub/fixtures");
+const spectra = JSON.parse(
+  readFileSync(path.join(FIXTURES, "spectra.json"), "utf8"),
+) as Record<string, SpectraPayload>;
+
+const theme: PlotTheme = {
+  ink: "#0F1A18",
+  ink3: "#6E7D79",
+  surface: "#FFFFFF",
+  grid: "#EDF1F0",
+  band: "#CBD7D4",
+  series: ["#0072B2", "#E69F00", "#009E73", "#CC79A7", "#56B4E9", "#D55E00"],
+  font: "sans",
+  mono: "mono",
+};
+
+const source = spectra.source;
+
+describe("the density band", () => {
+  it("is the token's colour, not a grey chosen here", () => {
+    for (const trace of bandTraces(source, theme)) {
+      const line = trace.line as { color: string };
+      expect([line.color, trace.fillcolor].filter(Boolean)).toContain(theme.band);
+    }
+  });
+
+  it("fills between the bounds and marks the median", () => {
+    const [lower, upper, median] = bandTraces(source, theme);
+    expect(lower.y).toEqual(source.band.y_lower);
+    expect(upper.fill).toBe("tonexty");
+    expect(upper.y).toEqual(source.band.y_upper);
+    expect(median.y).toEqual(source.band.y_median);
+  });
+
+  it("carries the whole set, not the drawn subset", () => {
+    expect(source.band.n_spectra).toBe(source.n_spectra);
+    expect(source.traces.length).toBeLessThan(source.n_spectra);
+  });
+});
+
+describe("the drawn spectra", () => {
+  it("are WebGL traces on the Okabe-Ito palette, never the accent", () => {
+    for (const trace of spectraTraces(source, theme, { selected: [] })) {
+      expect(trace.type).toBe("scattergl");
+      expect(theme.series).toContain((trace.line as { color: string }).color);
+    }
+  });
+
+  it("draws a selected sample at full strength over the rest", () => {
+    const chosen = source.traces[3].index;
+    const traces = spectraTraces(source, theme, { selected: [chosen] });
+    const selected = traces.find((trace) => trace.customdata === chosen)!;
+    const other = traces.find((trace) => trace.customdata !== chosen)!;
+    expect(selected.opacity).toBe(1);
+    expect(Number(other.opacity)).toBeLessThan(1);
+    expect((selected.line as { width: number }).width).toBeGreaterThan(
+      (other.line as { width: number }).width,
+    );
+  });
+
+  it("names the sample on hover, because identifying an outlier is the workflow", () => {
+    const [first] = spectraTraces(source, theme, { selected: [] });
+    expect(first.name).toBe(source.traces[0].sample_id);
+    expect(String(first.hovertemplate)).toContain(source.traces[0].sample_id);
+  });
+
+  it("keeps every processed node's payload the same shape", () => {
+    for (const [node, payload] of Object.entries(spectra)) {
+      expect(payload.axis.values.length, node).toBe(payload.decimation.variables_kept);
+      expect(payload.traces.length, node).toBe(payload.decimation.traces_drawn);
+    }
+  });
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -106,6 +106,26 @@ export interface Experiment {
   metrics: { explained_variance: number[] | null };
 }
 
+/** What the spectra endpoint returns for one node. Decimation is consumed,
+ * never computed here: the fixture carries the decimated and band forms and
+ * 1.2 computes them server-side, where PROPOSAL.md section 13 puts them. */
+export interface SpectraPayload {
+  node_id: string;
+  label: string;
+  axis: { kind: string; unit: string | null; values: number[] };
+  ordinate: { label: string };
+  n_spectra: number;
+  decimation: {
+    variables_total: number;
+    variables_kept: number;
+    traces_total: number;
+    traces_drawn: number;
+    banded: boolean;
+  };
+  traces: { index: number; sample_id: string; y: number[] }[];
+  band: { n_spectra: number; y_lower: number[]; y_median: number[]; y_upper: number[] };
+}
+
 export interface Job {
   job_id: string;
   experiment_id: string;
@@ -178,6 +198,17 @@ export function useExperiment() {
 
 /** A run is a real job: it advances, it can be cancelled and it can fail. The
  * poll stops when the job reaches a terminal status. */
+export function useSpectra(nodeId: string | undefined) {
+  return useQuery({
+    queryKey: ["spectra", nodeId],
+    queryFn: () => api<SpectraPayload>(`/spectra/${nodeId}`),
+    enabled: Boolean(nodeId),
+    // The decimated payload is the largest thing crossing the wire; holding it
+    // means switching between two nodes does not refetch either.
+    staleTime: Infinity,
+  });
+}
+
 export function useJob(jobId: string | null) {
   return useQuery({
     queryKey: ["job", jobId],

--- a/frontend/src/plot/plotly.d.ts
+++ b/frontend/src/plot/plotly.d.ts
@@ -1,0 +1,17 @@
+/** The gl2d bundle ships no types. Only what this project calls is declared:
+ * a fuller @types/plotly.js would pull in the whole API surface for two
+ * functions, and would then describe a bundle that is not the one loaded. */
+declare module "plotly.js-gl2d-dist-min" {
+  export interface PlotData {
+    [key: string]: unknown;
+  }
+  export function react(
+    root: HTMLElement,
+    data: PlotData[],
+    layout: Record<string, unknown>,
+    config?: Record<string, unknown>,
+  ): Promise<void>;
+  export function purge(root: HTMLElement): void;
+  const Plotly: { react: typeof react; purge: typeof purge };
+  export default Plotly;
+}

--- a/frontend/src/plot/theme.ts
+++ b/frontend/src/plot/theme.ts
@@ -1,0 +1,68 @@
+/** Plotly draws from the design tokens, not from its own defaults.
+ *
+ * A plot that ignores the theme is the most likely way this screen drifts from
+ * the artboards, so every colour and every font below is read out of the CSS
+ * variables that `_base.css` defines - including `--band`, which exists in
+ * both palettes precisely because the density envelope is a designed element.
+ */
+
+export interface PlotTheme {
+  ink: string;
+  ink3: string;
+  surface: string;
+  grid: string;
+  band: string;
+  series: string[];
+  font: string;
+  mono: string;
+}
+
+export function readTheme(element: HTMLElement): PlotTheme {
+  const style = getComputedStyle(element);
+  const token = (name: string) => style.getPropertyValue(`--${name}`).trim();
+  return {
+    ink: token("ink"),
+    ink3: token("ink3"),
+    surface: token("surface"),
+    grid: token("grid"),
+    band: token("band"),
+    series: ["d1", "d2", "d3", "d4", "d5", "d6"].map(token),
+    font: "'IBM Plex Sans', system-ui, sans-serif",
+    mono: "'IBM Plex Mono', ui-monospace, monospace",
+  };
+}
+
+export function axisLayout(theme: PlotTheme, title: string) {
+  return {
+    title: { text: title, font: { size: 10.5, color: theme.ink3, family: theme.mono } },
+    color: theme.ink3,
+    gridcolor: theme.grid,
+    zeroline: false,
+    linecolor: theme.grid,
+    tickfont: { size: 10, color: theme.ink3, family: theme.mono },
+    automargin: true,
+  };
+}
+
+export function baseLayout(theme: PlotTheme) {
+  return {
+    paper_bgcolor: theme.surface,
+    plot_bgcolor: theme.surface,
+    font: { family: theme.font, size: 11, color: theme.ink },
+    margin: { l: 52, r: 14, t: 6, b: 40 },
+    showlegend: false,
+    hoverlabel: {
+      bgcolor: theme.surface,
+      bordercolor: theme.grid,
+      font: { family: theme.mono, size: 11, color: theme.ink },
+    },
+    dragmode: "zoom",
+  };
+}
+
+export const PLOT_CONFIG = {
+  displayModeBar: false,
+  responsive: true,
+  // Nothing here reaches the network, and a plot is no exception.
+  showTips: false,
+};

--- a/frontend/src/plot/traces.ts
+++ b/frontend/src/plot/traces.ts
@@ -1,0 +1,90 @@
+import type { SpectraPayload } from "@/api/queries";
+
+import type { PlotTheme } from "./theme";
+
+/** Turning a spectra payload into Plotly traces. Pure, and tested: the rules
+ * about what is drawn as a band and what is drawn at full resolution are the
+ * substance of this screen, and they should not need a browser to check. */
+
+export interface TraceOptions {
+  /** Sample indices the user has selected. Drawn over the band, in series colour. */
+  selected: number[];
+  /** Dims a comparison layer so the primary one reads first. */
+  faded?: boolean;
+}
+
+/** The envelope is two traces: the lower bound, then the upper bound filling
+ * down to it. `--band` is the token for exactly this. */
+export function bandTraces(
+  payload: SpectraPayload,
+  theme: PlotTheme,
+  options: { faded?: boolean } = {},
+) {
+  const x = payload.axis.values;
+  const opacity = options.faded ? 0.35 : 1;
+  return [
+    {
+      type: "scattergl",
+      mode: "lines",
+      x,
+      y: payload.band.y_lower,
+      line: { width: 0, color: theme.band },
+      hoverinfo: "skip",
+      showlegend: false,
+      opacity,
+    },
+    {
+      type: "scattergl",
+      mode: "lines",
+      x,
+      y: payload.band.y_upper,
+      fill: "tonexty",
+      fillcolor: theme.band,
+      line: { width: 0, color: theme.band },
+      hoverinfo: "skip",
+      showlegend: false,
+      opacity,
+    },
+    {
+      type: "scattergl",
+      mode: "lines",
+      x,
+      y: payload.band.y_median,
+      line: { width: 1.2, color: theme.band, dash: "dot" },
+      name: "median",
+      hovertemplate: "median<br>%{x:.1f} · %{y:.4f}<extra></extra>",
+      opacity,
+    },
+  ];
+}
+
+/** The drawn traces. Selected samples are full-strength in the series palette
+ * and named on hover - clicking an outlier to find out which sample it is is
+ * the workflow this screen exists for. */
+export function spectraTraces(
+  payload: SpectraPayload,
+  theme: PlotTheme,
+  { selected, faded }: TraceOptions,
+) {
+  const x = payload.axis.values;
+  const chosen = new Set(selected);
+  return payload.traces.map((trace, position) => {
+    const isSelected = chosen.has(trace.index);
+    return {
+      type: "scattergl",
+      mode: "lines",
+      x,
+      y: trace.y,
+      name: trace.sample_id,
+      customdata: trace.index,
+      line: {
+        width: isSelected ? 1.6 : 0.7,
+        color: isSelected
+          ? theme.series[position % theme.series.length]
+          : theme.series[position % theme.series.length],
+      },
+      opacity: isSelected ? 1 : faded ? 0.12 : 0.22,
+      hovertemplate: `${trace.sample_id}<br>%{x:.1f} · %{y:.4f}<extra></extra>`,
+    };
+  });
+}

--- a/frontend/src/screens/SpectraView.tsx
+++ b/frontend/src/screens/SpectraView.tsx
@@ -1,0 +1,263 @@
+import Plotly from "plotly.js-gl2d-dist-min";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { useSpectra, type SpectraPayload } from "@/api/queries";
+import { PLOT_CONFIG, axisLayout, baseLayout, readTheme } from "@/plot/theme";
+import { bandTraces, spectraTraces } from "@/plot/traces";
+
+/** The most-looked-at screen in the product.
+ *
+ * The performance envelope is the design constraint here, not a later
+ * optimisation: 240 spectra arrive as 60 drawn traces plus a 5/50/95 density
+ * band, and PROPOSAL.md section 13 is why. Decimation is consumed - the
+ * fixture carries both forms and 1.2 computes them server-side.
+ */
+
+type Layer = "raw" | "processed" | "both";
+
+interface PlotlyDiv extends HTMLElement {
+  on?: (event: string, handler: (data: { points: { customdata?: number }[] }) => void) => void;
+  removeAllListeners?: (event: string) => void;
+}
+
+function Plot({
+  payloads,
+  selected,
+  onPick,
+}: {
+  payloads: { payload: SpectraPayload; faded: boolean }[];
+  selected: number[];
+  onPick: (index: number) => void;
+}) {
+  const host = useRef<HTMLDivElement>(null);
+  // The handler is read through a ref so it can be attached once, when the
+  // plot first exists, rather than re-attached on every render.
+  const pick = useRef(onPick);
+  pick.current = onPick;
+
+  // The theme is read out of the DOM rather than passed in, so the plot picks
+  // up the palette that is actually applied - including a theme switch.
+  useLayoutEffect(() => {
+    const element = host.current;
+    if (!element || payloads.length === 0) return;
+    const theme = readTheme(element);
+    const primary = payloads[0].payload;
+
+    const data = payloads.flatMap(({ payload, faded }) => [
+      ...(payload.decimation.banded ? bandTraces(payload, theme, { faded }) : []),
+      ...spectraTraces(payload, theme, { selected, faded }),
+    ]);
+
+    void Plotly.react(
+      element,
+      data,
+      {
+        ...baseLayout(theme),
+        xaxis: axisLayout(theme, `${primary.axis.kind} (${primary.axis.unit ?? ""})`),
+        yaxis: axisLayout(theme, primary.ordinate.label),
+      },
+      PLOT_CONFIG,
+    ).then(() => {
+      // Plotly attaches `on` to the div while it draws, so the listener can
+      // only go on once that has happened - and only once.
+      const node = element as PlotlyDiv;
+      if (node.dataset.clickBound) return;
+      node.dataset.clickBound = "yes";
+      node.on?.("plotly_click", (event) => {
+        const index = event.points[0]?.customdata;
+        if (typeof index === "number") pick.current(index);
+      });
+    });
+  }, [payloads, selected]);
+
+  useEffect(() => {
+    const element = host.current;
+    return () => {
+      if (element) Plotly.purge(element);
+    };
+  }, []);
+
+  return <div ref={host} data-testid="spectra-plot" style={{ flex: 1, minHeight: 0 }} />;
+}
+
+function Segmented({
+  layer,
+  onChange,
+  disabled,
+}: {
+  layer: Layer;
+  onChange: (layer: Layer) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Layers"
+      style={{
+        display: "flex",
+        border: "1px solid var(--rule)",
+        borderRadius: 3,
+        overflow: "hidden",
+        background: "var(--sunken)",
+      }}
+    >
+      {(["raw", "processed", "both"] as const).map((option) => {
+        const active = option === layer;
+        return (
+          <button
+            key={option}
+            disabled={disabled && option !== "raw"}
+            aria-pressed={active}
+            onClick={() => onChange(option)}
+            style={{
+              padding: "0 10px",
+              height: 24,
+              border: "none",
+              font: "inherit",
+              fontSize: 11.5,
+              cursor: "pointer",
+              background: active ? "var(--surface)" : "transparent",
+              color: active ? "var(--ink)" : "var(--ink3)",
+              fontWeight: active ? 600 : 400,
+            }}
+          >
+            {option[0].toUpperCase() + option.slice(1)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function SpectraView({ nodeId, title }: { nodeId: string; title: string }) {
+  const [layer, setLayer] = useState<Layer>("both");
+  const [selected, setSelected] = useState<number[]>([]);
+
+  const processed = useSpectra(nodeId);
+  const raw = useSpectra("source");
+  const isSource = nodeId === "source";
+
+  const pick = (index: number) =>
+    setSelected((current) =>
+      current.includes(index) ? current.filter((item) => item !== index) : [...current, index],
+    );
+
+  if (!processed.data || !raw.data) {
+    return (
+      <div className="pane">
+        <div className="empty" style={{ padding: 16 }}>
+          Loading spectra…
+        </div>
+      </div>
+    );
+  }
+
+  const primary = isSource ? raw.data : processed.data;
+  const payloads =
+    isSource || layer === "raw"
+      ? [{ payload: raw.data, faded: false }]
+      : layer === "processed"
+        ? [{ payload: processed.data, faded: false }]
+        : [
+            { payload: raw.data, faded: true },
+            { payload: processed.data, faded: false },
+          ];
+
+  const { decimation } = primary;
+
+  return (
+    <div className="pane">
+      <div
+        style={{
+          height: 42,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: "0 14px",
+          borderBottom: "1px solid var(--rule2)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <Segmented layer={isSource ? "raw" : layer} onChange={setLayer} disabled={isSource} />
+          <span className="mono" style={{ fontSize: 11, color: "var(--ink3)" }}>
+            {primary.n_spectra} spectra · {selected.length} highlighted ·{" "}
+            {decimation.variables_total} variables
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 7 }}>
+          <span className="pill mono">
+            {decimation.traces_drawn} of {decimation.traces_total} drawn
+          </span>
+          <span className="pill mono">
+            {decimation.variables_kept === decimation.variables_total
+              ? "no x decimation"
+              : `decimated to ${decimation.variables_kept} px`}
+          </span>
+          {/* Clicking a trace is the workflow this screen exists for, but
+              sixty overlapping lines are a small target - so the drawn samples
+              are also a list. */}
+          <select
+            className="mono"
+            aria-label="Highlight sample"
+            value=""
+            onChange={(event) => pick(Number(event.target.value))}
+            style={{
+              height: 22,
+              padding: "0 6px",
+              borderRadius: 3,
+              border: "1px solid var(--rule)",
+              background: "var(--surface)",
+              color: "var(--ink2)",
+              font: "inherit",
+              fontSize: 11,
+            }}
+          >
+            <option value="">Highlight sample…</option>
+            {primary.traces.map((trace) => (
+              <option key={trace.index} value={trace.index}>
+                {trace.sample_id}
+              </option>
+            ))}
+          </select>
+          {selected.length > 0 ? (
+            <button className="btn" style={{ height: 22 }} onClick={() => setSelected([])}>
+              Clear highlight
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          padding: "8px 14px 10px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 6,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "baseline", justifyContent: "space-between" }}>
+          <span style={{ fontSize: 11.5, fontWeight: 600 }}>{title}</span>
+          <span className="mono" style={{ fontSize: 10.5, color: "var(--ink3)" }}>
+            shaded band = full set ({primary.band.n_spectra}) · lines drawn at full resolution
+          </span>
+        </div>
+        <Plot payloads={payloads} selected={selected} onPick={pick} />
+        {selected.length > 0 ? (
+          <div className="mono" style={{ fontSize: 10.5, color: "var(--ink3)" }}>
+            Highlighted:{" "}
+            {selected
+              .map(
+                (index) =>
+                  primary.traces.find((trace) => trace.index === index)?.sample_id ?? `#${index}`,
+              )
+              .join(" · ")}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -14,6 +14,7 @@ import {
 import { DatasetView } from "@/screens/DatasetView";
 import { EmptyProject } from "@/screens/EmptyProject";
 import { Import } from "@/screens/Import";
+import { SpectraView } from "@/screens/SpectraView";
 import { Inspector } from "@/shell/Inspector";
 import { Sidebar } from "@/shell/Sidebar";
 import { StatusBar } from "@/shell/StatusBar";
@@ -71,6 +72,8 @@ function Pane({
   if (tab?.kind === "import") {
     return <Import onImported={onImported} onCancel={onCloseImport} />;
   }
+
+  if (tab?.kind === "spectra") return <SpectraView nodeId={tab.id} title={tab.title} />;
 
   const found = datasets
     ?.flatMap((entry) => entry.versions.map((version) => ({ entry, version })))


### PR DESCRIPTION
The most-looked-at screen in the product, and the one where the performance envelope is the design constraint rather than a later optimisation.

240 spectra arrive as **60 drawn traces plus a 5/50/95 envelope**, and the screen says so: `60 of 240 drawn`, `shaded band = full set (240)`, `240 spectra · N highlighted · 100 variables`.

## What it does

- **Decimation is consumed, never computed.** The fixture carries both forms; 1.2 computes them server-side where `PROPOSAL.md` §13 puts them. Tecator is 100 variables wide, so the x-axis path is populated but not exercised — the header reads `no x decimation` rather than implying one.
- **`--band` is the envelope's colour**, because that is what the token exists for. An end-to-end test reads the fill back off the running plot and compares it against the CSS variable, so a grey picked at build time fails the build.
- **The plot follows the theme.** Every colour and font is read out of the CSS variables at draw time; switching to dark repaints it (`rgb(255,255,255)` → `rgb(12,20,19)`, asserted). Keeping Plotly's defaults is the most likely way this screen would drift from the artboards.
- **Raw and processed overlay**, comparison layer faded. Selecting a sample draws it at full strength over the band and names it; hovering names it too — clicking an outlier to find out which sample it is, is the workflow this screen exists for.

## Dependency note

Plotly is `plotly.js-gl2d-dist-min`, called directly. `react-plotly.js` would be a wrapper dependency for two function calls and it lags React. The bundle ships no types, so `src/plot/plotly.d.ts` declares only `react` and `purge` — a full `@types/plotly.js` would describe an API surface this bundle does not have.

## Evidence

`pnpm e2e` 16 passed (6 new), `pnpm test` 24 passed (7 new — the band and trace rules, checked against the committed fixture without a browser), typecheck / lint / build clean, `uv run pytest` 484.

Every drawn trace is `scattergl` on the Okabe-Ito series, never the accent — so a failing node can never be read as a red spectrum.

Also: clicking a trace selects it, and a `Highlight sample` list does the same deterministically, because sixty overlapping lines are a small target.

Closes #45