### PR TITLE
Render the pipeline as a graph with all five node states

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -180,7 +180,7 @@
         "app-shell"
       ],
       "user_visible_behavior": "The pipeline renders as a pan and zoom node graph with every node type and run state legible at a glance. Steps are added through a list rather than by dragging.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "The fixture's four-branch pipeline renders with its branches distinct.",
         "All six node states are visible simultaneously in the fixture and are distinguishable in greyscale as well as in colour.",
@@ -193,8 +193,8 @@
         "Stale renders as a dashed --stale border over a 135 degree --staleSoft hatch at 0.72 opacity with an 'edited - downstream stale' footer, as drawn.",
         "Edges are 1.4px --rule at rest, 1.8px --accent on the active path, dashed 4 3 in --stale where stale, over a 22px --grid dot ground."
       ],
-      "evidence": null,
-      "notes": "Direct canvas editing is deliberately deferred to #51 in Phase 2, where branch comparison first needs it."
+      "evidence": "2026-08-24. On feature/46_pipeline-canvas. `pnpm e2e` is 20 passed, 4 of them this feature; `pnpm test` is 33 passed (9 new, the node and edge encodings); typecheck, lint and build clean; Python 484 passed. Asserted in the browser: the fixture's branching pipeline renders as 14 nodes and 13 edges with their parameter lines (`window 11 \u00b7 poly 2 \u00b7 deriv 1`, `10 folds \u00b7 shuffle \u00b7 seed 42`); all five states are on screen at once and separable by form, not only colour - stale is dashed over a repeating-linear-gradient hatch, not_run is dashed, failed carries a 3px left stripe, complete is solid, and the running node shows its progress bar; the stale node says `edited - downstream stale` and the failed one names the rank-4 matrix. Clicking a node opens its tab. Adding SNV, SG d1 w11 and PCA through the step list adds three nodes to the canvas, Validate reports `valid \u00b7 3 steps`, and removing a step removes its node. Screenshots taken in both themes.",
+      "notes": "React Flow (@xyflow/react) as the issue asks, with a custom node type rather than its default: the artboard fixes 132x70, a 17px mono header, the parameter line and the footer. Edges take --accent at 1.8px into a running or queued node, dashed 4 3 in --stale wherever either end is stale, and --rule at 1.4px at rest; animation rides only on the accent path and is off entirely under prefers-reduced-motion. Layout coordinates come from pipeline_state.json, outside Pipeline.content_hash(), and a test asserts the pipeline itself carries no layout - moving a node must not change the science. The fixture generator gained the fifth state: pca_d now fails with the same rank-4 message jobs.json's failing run ends on, because the node that failed and the run that failed are one event seen twice. Only pipeline_state.json changed. The canvas is read-only: dragging nodes into place is #51."
     },
     {
       "id": "inspector",

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** The pipeline canvas against the stub server: the branching graph, the five
+ * states side by side, and a pipeline assembled through the step list. */
+
+async function openCanvas(page: Page) {
+  await page.goto("/?token=e2e-token");
+  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
+  await expect(page.getByTestId("pipeline-canvas")).toBeVisible();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible();
+}
+
+test("the branching pipeline renders with every node the fixture describes", async ({ page }) => {
+  await openCanvas(page);
+  await expect(page.locator(".react-flow__node")).toHaveCount(14);
+  await expect(page.locator(".react-flow__edge")).toHaveCount(13);
+
+  // The node bodies carry their parameters, which is what makes the graph
+  // readable without opening anything.
+  await expect(page.getByText("window 11 · poly 2 · deriv 1").first()).toBeVisible();
+  await expect(page.getByText("10 folds · shuffle · seed 42")).toBeVisible();
+});
+
+test("all five states are on screen at once and distinguishable by form", async ({ page }) => {
+  await openCanvas(page);
+  for (const state of ["complete", "running", "stale", "failed", "not_run"]) {
+    await expect(page.getByTestId(`node-${state}`).first()).toBeVisible();
+  }
+
+  // Form, not only colour: dashed for stale and not-run, a left stripe for
+  // failed, an accent border and progress for running.
+  const border = (state: string) =>
+    page
+      .getByTestId(`node-${state}`)
+      .first()
+      .evaluate((element) => {
+        const style = getComputedStyle(element);
+        return {
+          style: style.borderTopStyle,
+          left: style.borderLeftWidth,
+          background: style.backgroundImage,
+        };
+      });
+
+  expect((await border("stale")).style).toBe("dashed");
+  expect((await border("stale")).background).toContain("repeating-linear-gradient");
+  expect((await border("not_run")).style).toBe("dashed");
+  expect((await border("failed")).left).toBe("3px");
+  expect((await border("complete")).style).toBe("solid");
+
+  // The stale node says why, and the failed one says what went wrong.
+  await expect(page.getByText("edited - downstream stale")).toBeVisible();
+  await expect(page.getByText(/matrix of rank 4/)).toBeVisible();
+  await expect(page.getByTestId("node-running").locator(".prog i")).toBeVisible();
+});
+
+test("selecting a node focuses its tab", async ({ page }) => {
+  await openCanvas(page);
+  await page.locator(".react-flow__node").filter({ hasText: "SNV" }).first().click();
+  await expect(page.getByRole("tab", { name: /SNV/ })).toBeVisible();
+});
+
+test("a linear SNV to Savitzky-Golay to PCA pipeline is assembled through the step list", async ({
+  page,
+}) => {
+  await openCanvas(page);
+  const before = await page.locator(".react-flow__node").count();
+
+  for (const step of ["SNV", "SG d1 w11", "PCA"]) {
+    await page.getByLabel("Step").selectOption(step);
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+  }
+  await expect(page.locator(".react-flow__node")).toHaveCount(before + 3);
+
+  await page.getByRole("button", { name: "Validate" }).click();
+  await expect(page.getByText("valid · 3 steps")).toBeVisible();
+
+  await page.getByRole("button", { name: "Remove PCA" }).click();
+  await expect(page.locator(".react-flow__node")).toHaveCount(before + 2);
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@fontsource/ibm-plex-mono": "^5.1.0",
     "@fontsource/ibm-plex-sans": "^5.1.0",
     "@tanstack/react-query": "^5.59.0",
+    "@xyflow/react": "^12.11.3",
     "clsx": "^2.1.1",
     "plotly.js-gl2d-dist-min": "^3.7.0",
     "react": "^19.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.102.0(react@19.2.8)
+      '@xyflow/react':
+        specifier: ^12.11.3
+        version: 12.11.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -808,6 +811,24 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -919,6 +940,22 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@xyflow/react@12.11.3':
+    resolution: {integrity: sha512-G3jogHz2GWUtIOkhavUGno2YzY9u6fILIJBttfsBendb0/HWB90JG+sOTAvlIMEwyvq9zgy9V9ZQSwyQjR5QzQ==}
+    peerDependencies:
+      '@types/react': '>=17'
+      '@types/react-dom': '>=17'
+      react: '>=17'
+      react-dom: '>=17'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@xyflow/system@0.0.80':
+    resolution: {integrity: sha512-ywc3ZqG91brzWrH1WlwMdIX4goOfrpBy6AbLdVSaof/Xx9l138ijIKRExM6EkMro2F+OImGmSiA/WKcXvKVcfA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -990,6 +1027,9 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1013,6 +1053,44 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1561,6 +1639,11 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1682,6 +1765,21 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
 snapshots:
 
@@ -2209,6 +2307,27 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.8
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2368,6 +2487,31 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@xyflow/react@12.11.3(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@xyflow/system': 0.0.80
+      classcat: 5.0.5
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      zustand: 4.5.7(@types/react@19.2.18)(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+    transitivePeerDependencies:
+      - immer
+
+  '@xyflow/system@0.0.80':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
       acorn: 8.18.0
@@ -2433,6 +2577,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  classcat@5.0.5: {}
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -2452,6 +2598,42 @@ snapshots:
       which: 2.0.2
 
   csstype@3.2.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   debug@4.4.3(supports-color@7.2.0):
     dependencies:
@@ -2966,6 +3148,10 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
   vite-node@2.1.9(@types/node@26.2.0)(lightningcss@1.32.0)(supports-color@7.2.0):
     dependencies:
       cac: 6.7.14
@@ -3057,3 +3243,10 @@ snapshots:
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@4.5.7(@types/react@19.2.18)(react@19.2.8):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react: 19.2.8

--- a/frontend/src/__tests__/graph.test.ts
+++ b/frontend/src/__tests__/graph.test.ts
@@ -1,0 +1,97 @@
+/** The canvas's encodings: what each node says, and what each edge means.
+ *
+ * These are the artboard's rules, checked against the committed fixture. The
+ * screen is the signature one and its states carry meaning - a stale result
+ * must stay visible rather than vanish - so the rules are tested here rather
+ * than only looked at.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { Pipeline, PipelineState } from "@/api/queries";
+import { draftGraph, nodeStateOf, parameterLine, toEdges, toNodes } from "@/canvas/graph";
+
+const FIXTURES = path.resolve(import.meta.dirname, "../../../stub/fixtures");
+const read = <T,>(name: string) =>
+  JSON.parse(readFileSync(path.join(FIXTURES, `${name}.json`), "utf8")) as T;
+
+const pipeline = read<Pipeline>("pipeline");
+const state = read<PipelineState>("pipeline_state");
+const colours = { rule: "#D2DAD8", accent: "#0B6B62", stale: "#9A6206" };
+
+it("carries all five states at once, which is what the artboard shows", () => {
+  const states = new Set(Object.values(state.nodes).map((node) => node.state));
+  for (const required of ["complete", "running", "stale", "failed", "not_run"]) {
+    expect(states, required).toContain(required);
+  }
+});
+
+describe("nodes", () => {
+  it("read as what they do, with their parameters underneath", () => {
+    const savgol = pipeline.nodes.find((node) => node.id === "savgol")!;
+    expect(parameterLine(savgol)).toBe("window 11 · poly 2 · deriv 1");
+    const split = pipeline.nodes.find((node) => node.id === "split_d")!;
+    expect(parameterLine(split)).toBe("10 folds · shuffle · seed 42");
+  });
+
+  it("carry why they are stale and what failed, because that is the useful part", () => {
+    expect(nodeStateOf("savgol", state).footer).toBe("edited - downstream stale");
+    expect(nodeStateOf("pca_d", state).footer).toContain("rank 4");
+  });
+
+  it("take their position from the layout the server sends, not from the recipe", () => {
+    const nodes = toNodes(pipeline, state, (node) => node.id);
+    for (const node of nodes) {
+      expect(node.position).toEqual(state.layout[node.id]);
+    }
+    // The layout is not part of what the pipeline hashes: moving a node must
+    // not change the science (design/data-model.md).
+    expect(Object.keys(pipeline)).not.toContain("layout");
+  });
+});
+
+describe("edges", () => {
+  const edges = toEdges(pipeline, state, colours, true);
+  const edge = (id: string) => edges.find((candidate) => candidate.id === id)!;
+
+  it("run accent and animated into a node a run is working on", () => {
+    expect(edge("source->msc").style.stroke).toBe(colours.accent);
+    expect(edge("source->msc").style.strokeWidth).toBe(1.8);
+    expect(edge("source->msc").animated).toBe(true);
+    expect(edge("centre_b->pca_b").style.stroke).toBe(colours.accent);
+  });
+
+  it("run dashed stale wherever either end is stale", () => {
+    expect(edge("source->savgol").style).toMatchObject({
+      stroke: colours.stale,
+      strokeDasharray: "4 3",
+    });
+    expect(edge("savgol->autoscale_c").style.stroke).toBe(colours.stale);
+  });
+
+  it("run rule-coloured and still at rest", () => {
+    expect(edge("snv->centre_a").style).toEqual({ stroke: colours.rule, strokeWidth: 1.4 });
+    expect(edge("snv->centre_a").animated).toBe(false);
+  });
+
+  it("never animate when motion is not wanted", () => {
+    expect(toEdges(pipeline, state, colours, false).every((item) => !item.animated)).toBe(true);
+  });
+});
+
+it("lays a drafted pipeline out as a chain below the committed one", () => {
+  const { nodes, edges } = draftGraph(
+    [
+      { kind: "SNV", type: "preprocess", parameters: "" },
+      { kind: "SG d1 w11", type: "preprocess", parameters: "" },
+      { kind: "PCA", type: "estimator", parameters: "5 components" },
+    ],
+    { x: 40, y: 500 },
+  );
+  expect(nodes.map((node) => node.data.label)).toEqual(["SNV", "SG d1 w11", "PCA"]);
+  expect(nodes.every((node) => node.data.state === "not_run")).toBe(true);
+  expect(nodes.map((node) => node.position.x)).toEqual([40, 210, 380]);
+  expect(edges).toHaveLength(2);
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -95,7 +95,10 @@ export interface Pipeline {
 
 export interface PipelineState {
   pipeline_id: string;
-  nodes: Record<string, { state: string; message?: string }>;
+  nodes: Record<string, { state: string; progress?: number; reason?: string; message?: string }>;
+  /** Presentation only, and deliberately outside Pipeline.content_hash():
+   * moving a node must not change the science (design/data-model.md). */
+  layout: Record<string, { x: number; y: number }>;
 }
 
 export interface Experiment {

--- a/frontend/src/canvas/NodeCard.tsx
+++ b/frontend/src/canvas/NodeCard.tsx
@@ -1,0 +1,118 @@
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+
+import type { NodeData } from "@/canvas/graph";
+
+/** The artboard's node, at the artboard's measurements.
+ *
+ * 132 x 70, or 74 where a footer carries a content hash. Header 17px on
+ * --sunken in mono 9px uppercase; body a 12px label over its parameters in
+ * mono 9.5px; footer above a --rule2 rule.
+ *
+ * The five states are encoded in form as well as colour, which is what makes
+ * them survive greyscale and colour blindness: complete is solid, running
+ * takes an accent border and shows progress inside the node, stale is a
+ * dashed border over a 135 degree hatch, failed carries a left stripe, and
+ * not-yet-run is a dashed outline.
+ */
+
+const HEADER = 17;
+
+function frame(state: NodeData["state"]): React.CSSProperties {
+  switch (state) {
+    case "running":
+      return { border: "1px solid var(--accent)", background: "var(--surface)" };
+    case "stale":
+      return {
+        border: "1px dashed var(--stale)",
+        background:
+          "repeating-linear-gradient(135deg,var(--surface),var(--surface) 5px,var(--staleSoft) 5px,var(--staleSoft) 10px)",
+        opacity: 0.72,
+      };
+    case "failed":
+      return {
+        border: "1px solid var(--rule)",
+        borderLeft: "3px solid var(--fail)",
+        background: "var(--surface)",
+      };
+    case "not_run":
+    case "queued":
+      return { border: "1px dashed var(--rule)", background: "var(--surface)" };
+    default:
+      return { border: "1px solid var(--rule)", background: "var(--surface)" };
+  }
+}
+
+export function NodeCard({ data, selected }: NodeProps) {
+  const node = data as NodeData;
+  const stale = node.state === "stale";
+  const failed = node.state === "failed";
+
+  return (
+    <div
+      data-state={node.state}
+      data-testid={`node-${node.state}`}
+      style={{
+        width: 132,
+        minHeight: 70,
+        borderRadius: 4,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+        boxShadow: selected ? "0 0 0 2px var(--accentSoft)" : undefined,
+        ...frame(node.state),
+      }}
+    >
+      <Handle type="target" position={Position.Left} style={{ opacity: 0 }} />
+      <div
+        className="mono"
+        style={{
+          height: HEADER,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          padding: "0 8px",
+          background: stale ? "var(--staleSoft)" : "var(--sunken)",
+          fontSize: 9,
+          letterSpacing: ".1em",
+          textTransform: "uppercase",
+          color: stale ? "var(--stale)" : "var(--ink3)",
+        }}
+      >
+        {node.type}
+      </div>
+
+      <div style={{ flex: 1, padding: "5px 8px 0", minHeight: 0 }}>
+        <div style={{ fontSize: 12, fontWeight: 500, color: "var(--ink)", lineHeight: 1.25 }}>
+          {node.label}
+        </div>
+        <div className="mono" style={{ fontSize: 9.5, color: "var(--ink3)", marginTop: 2 }}>
+          {node.parameters}
+        </div>
+        {node.state === "running" && typeof node.progress === "number" ? (
+          <div className="prog" style={{ width: "100%", marginTop: 6 }}>
+            <i style={{ width: `${Math.round(node.progress * 100)}%` }} />
+          </div>
+        ) : null}
+      </div>
+
+      {node.footer ? (
+        <div
+          className="mono"
+          style={{
+            padding: "4px 8px 6px",
+            fontSize: 10,
+            borderTop: "1px solid var(--rule2)",
+            color: stale ? "var(--stale)" : failed ? "var(--fail)" : "var(--ink2)",
+            // A failure names what went wrong; the node is 132px wide and the
+            // message is a sentence, so it wraps rather than being truncated
+            // into something unreadable.
+            lineHeight: 1.3,
+          }}
+        >
+          {node.footer}
+        </div>
+      ) : null}
+      <Handle type="source" position={Position.Right} style={{ opacity: 0 }} />
+    </div>
+  );
+}

--- a/frontend/src/canvas/PipelineCanvas.tsx
+++ b/frontend/src/canvas/PipelineCanvas.tsx
@@ -1,0 +1,91 @@
+import { Background, BackgroundVariant, ReactFlow, type Node } from "@xyflow/react";
+import { useMemo, useState } from "react";
+
+import { api } from "@/api/client";
+import { usePipeline, usePipelineState } from "@/api/queries";
+import { NodeCard } from "@/canvas/NodeCard";
+import { StepList } from "@/canvas/StepList";
+import { draftGraph, toEdges, toNodes, type DraftStep } from "@/canvas/graph";
+import { nodeLabel } from "@/shell/Sidebar";
+
+import "@xyflow/react/dist/style.css";
+
+/** The signature screen: the pipeline as a graph.
+ *
+ * Read-only in 1.1 - it renders and it selects, and the pipeline is built
+ * through the step list beside it. Dragging nodes around is #51.
+ */
+
+const NODE_TYPES = { workbench: NodeCard };
+
+/** Motion is an accent on a running path, never decoration, and never at all
+ * for someone who asked the system not to move things. */
+function usesMotion(): boolean {
+  return !window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}
+
+export function PipelineCanvas({ onOpenNode }: { onOpenNode: (id: string, label: string) => void }) {
+  const pipeline = usePipeline();
+  const state = usePipelineState();
+  const [steps, setSteps] = useState<DraftStep[]>([]);
+  const [validation, setValidation] = useState<string | null>(null);
+
+  const { nodes, edges } = useMemo(() => {
+    if (!pipeline.data) return { nodes: [], edges: [] };
+    const style = getComputedStyle(document.documentElement);
+    const token = (name: string) => style.getPropertyValue(`--${name}`).trim() || "currentColor";
+    const committed = {
+      nodes: toNodes(pipeline.data, state.data, nodeLabel),
+      edges: toEdges(
+        pipeline.data,
+        state.data,
+        { rule: token("rule"), accent: token("accent"), stale: token("stale") },
+        usesMotion(),
+      ),
+    };
+    const lowest = Math.max(...committed.nodes.map((node) => node.position.y), 0);
+    const draft = draftGraph(steps, { x: 40, y: lowest + 150 });
+    return { nodes: [...committed.nodes, ...draft.nodes], edges: [...committed.edges, ...draft.edges] };
+  }, [pipeline.data, state.data, steps]);
+
+  return (
+    <div className="pane" style={{ flexDirection: "row" }}>
+      <div style={{ flex: 1, minWidth: 0, background: "var(--surface)" }} data-testid="pipeline-canvas">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={NODE_TYPES}
+          fitView
+          nodesDraggable={false}
+          nodesConnectable={false}
+          proOptions={{ hideAttribution: true }}
+          onNodeClick={(_, node: Node) => {
+            // Selecting a node focuses its tab - the mechanism that ties the
+            // graph to the pages.
+            if (String(node.id).startsWith("draft-")) return;
+            onOpenNode(node.id, String((node.data as { label: string }).label));
+          }}
+        >
+          {/* The artboard's ground: a 22px dot grid in --grid. */}
+          <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="var(--grid)" />
+        </ReactFlow>
+      </div>
+
+      <StepList
+        steps={steps}
+        onChange={(next) => {
+          setSteps(next);
+          setValidation(null);
+        }}
+        onValidate={async () => {
+          const result = await api<{ valid: boolean; problems: string[] }>(
+            "/pipelines/current/validate",
+            { method: "POST" },
+          );
+          setValidation(result.valid ? `valid · ${steps.length} steps` : result.problems.join(" · "));
+        }}
+        validation={validation}
+      />
+    </div>
+  );
+}

--- a/frontend/src/canvas/StepList.tsx
+++ b/frontend/src/canvas/StepList.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+
+import type { DraftStep } from "@/canvas/graph";
+
+/** The 1.1 pipeline builder: a list, not a drag surface.
+ *
+ * Dragging nodes into place is #51 and is wanted; it is not on the path to
+ * this sub-phase's exit criterion, and a step list expresses
+ * SNV -> Savitzky-Golay -> PCA perfectly well.
+ */
+
+const STEPS: { kind: string; type: DraftStep["type"]; parameters: string }[] = [
+  { kind: "SNV", type: "preprocess", parameters: "population statistics per row" },
+  { kind: "MSC", type: "preprocess", parameters: "reference: mean" },
+  { kind: "SG d1 w11", type: "preprocess", parameters: "window 11 · poly 2 · deriv 1" },
+  { kind: "Mean centre", type: "preprocess", parameters: "column means" },
+  { kind: "Autoscale", type: "preprocess", parameters: "ddof 1" },
+  { kind: "PCA", type: "estimator", parameters: "5 components" },
+];
+
+interface Props {
+  steps: DraftStep[];
+  onChange: (steps: DraftStep[]) => void;
+  onValidate: () => void;
+  validation: string | null;
+}
+
+export function StepList({ steps, onChange, onValidate, validation }: Props) {
+  const [choice, setChoice] = useState(STEPS[0].kind);
+
+  return (
+    <aside
+      style={{
+        width: 236,
+        flex: "none",
+        borderLeft: "1px solid var(--rule)",
+        background: "var(--panel)",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      <div className="ilabel" style={{ padding: "10px 12px 6px" }}>
+        Build a pipeline
+      </div>
+
+      {steps.length === 0 ? (
+        <div className="empty">No steps yet. The draft appears on the canvas as you add them.</div>
+      ) : (
+        steps.map((step, index) => (
+          <div key={`${step.kind}-${index}`} className="srow" style={{ paddingLeft: 12 }}>
+            <span className="mono" style={{ fontSize: 10, color: "var(--ink3)" }}>
+              {index + 1}
+            </span>
+            <span>{step.kind}</span>
+            <button
+              className="tabx"
+              aria-label={`Remove ${step.kind}`}
+              style={{ marginLeft: "auto" }}
+              onClick={() => onChange(steps.filter((_, position) => position !== index))}
+            >
+              ×
+            </button>
+          </div>
+        ))
+      )}
+
+      <div style={{ display: "flex", gap: 6, padding: "10px 12px" }}>
+        <select
+          aria-label="Step"
+          className="mono"
+          value={choice}
+          onChange={(event) => setChoice(event.target.value)}
+          style={{
+            flex: 1,
+            height: 24,
+            borderRadius: 3,
+            border: "1px solid var(--rule)",
+            background: "var(--surface)",
+            color: "var(--ink)",
+            font: "inherit",
+            fontSize: 11,
+          }}
+        >
+          {STEPS.map((step) => (
+            <option key={step.kind} value={step.kind}>
+              {step.kind}
+            </option>
+          ))}
+        </select>
+        <button
+          className="btn"
+          style={{ height: 24 }}
+          onClick={() => onChange([...steps, STEPS.find((step) => step.kind === choice)!])}
+        >
+          Add
+        </button>
+      </div>
+
+      <div style={{ padding: "0 12px 10px", display: "flex", gap: 6, alignItems: "center" }}>
+        <button className="btn" style={{ height: 24 }} disabled={steps.length === 0} onClick={onValidate}>
+          Validate
+        </button>
+        {validation ? (
+          <span className="mono" style={{ fontSize: 10.5, color: "var(--accent)" }}>
+            {validation}
+          </span>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/canvas/graph.ts
+++ b/frontend/src/canvas/graph.ts
@@ -1,0 +1,176 @@
+import type { Pipeline, PipelineNode, PipelineState } from "@/api/queries";
+
+/** Pipeline plus run state plus layout, turned into what React Flow draws.
+ *
+ * Pure, and tested: the state and edge encodings are the artboard's rules and
+ * they should not need a browser to check. Layout coordinates come from the
+ * server alongside the pipeline and never from inside `content_hash()` -
+ * design/data-model.md is explicit that moving a node must not change the
+ * science.
+ */
+
+export type NodeState = "complete" | "running" | "queued" | "stale" | "failed" | "not_run";
+
+export interface NodeData extends Record<string, unknown> {
+  label: string;
+  type: string;
+  parameters: string;
+  footer?: string;
+  state: NodeState;
+  progress?: number;
+  draft?: boolean;
+}
+
+export interface FlowNode {
+  id: string;
+  type: "workbench";
+  position: { x: number; y: number };
+  data: NodeData;
+}
+
+export interface FlowEdge {
+  id: string;
+  source: string;
+  target: string;
+  animated: boolean;
+  style: { stroke: string; strokeWidth: number; strokeDasharray?: string };
+}
+
+/** "window 11 · poly 2 · deriv 1" - what the artboard's node bodies carry. */
+export function parameterLine(node: PipelineNode): string {
+  const step = node.step as Record<string, unknown> | undefined;
+  const spec = node.spec as Record<string, unknown> | undefined;
+  const kind = step?.kind ?? spec?.kind ?? node.type;
+  switch (kind) {
+    case "savgol":
+      return `window ${step!.window_length} · poly ${step!.polyorder} · deriv ${step!.deriv}`;
+    case "msc":
+      return `reference: ${step!.reference}`;
+    case "autoscale":
+      return `ddof ${step!.ddof}`;
+    case "kfold":
+      return `${spec!.n_splits} folds · ${spec!.shuffle ? "shuffle · " : ""}seed ${spec!.seed}`;
+    case "pca":
+      return `${spec!.n_components} components`;
+    case "snv":
+      return "population statistics per row";
+    case "mean_centre":
+      return "column means";
+    default:
+      return node.id;
+  }
+}
+
+export function nodeStateOf(
+  id: string,
+  state: PipelineState | undefined,
+): { state: NodeState; progress?: number; footer?: string } {
+  const entry = state?.nodes[id];
+  if (!entry) return { state: "not_run" };
+  return {
+    state: entry.state as NodeState,
+    progress: entry.progress,
+    // Stale carries why it is stale; failed carries what went wrong. Both are
+    // footers in the artboard, and both matter more than the state's name.
+    footer: entry.reason ?? entry.message,
+  };
+}
+
+export function toNodes(
+  pipeline: Pipeline,
+  state: PipelineState | undefined,
+  labelOf: (node: PipelineNode) => string,
+): FlowNode[] {
+  return pipeline.nodes.map((node) => {
+    const status = nodeStateOf(node.id, state);
+    return {
+      id: node.id,
+      type: "workbench" as const,
+      position: state?.layout?.[node.id] ?? { x: 0, y: 0 },
+      data: {
+        label: labelOf(node),
+        type: node.type,
+        parameters: parameterLine(node),
+        state: status.state,
+        progress: status.progress,
+        footer: status.footer,
+      },
+    };
+  });
+}
+
+/** The edge encoding, from the artboard:
+ *
+ * - 1.8px `--accent` along the path a run is currently on - an edge feeding a
+ *   running or queued node
+ * - dashed 4 3 in `--stale` wherever either end is stale, because a stale
+ *   result must stay visible rather than vanish
+ * - 1.4px `--rule` at rest
+ *
+ * Animation rides on the accent path only, and the caller turns it off under
+ * prefers-reduced-motion.
+ */
+export function toEdges(
+  pipeline: Pipeline,
+  state: PipelineState | undefined,
+  colours: { rule: string; accent: string; stale: string },
+  animate: boolean,
+): FlowEdge[] {
+  const stateOf = (id: string) => state?.nodes[id]?.state;
+  return pipeline.nodes.flatMap((node) =>
+    node.inputs.map((input) => {
+      const source = stateOf(input);
+      const target = stateOf(node.id);
+      const stale = source === "stale" || target === "stale";
+      const active = target === "running" || target === "queued";
+      return {
+        id: `${input}->${node.id}`,
+        source: input,
+        target: node.id,
+        animated: active && animate,
+        style: stale
+          ? { stroke: colours.stale, strokeWidth: 1.4, strokeDasharray: "4 3" }
+          : active
+            ? { stroke: colours.accent, strokeWidth: 1.8 }
+            : { stroke: colours.rule, strokeWidth: 1.4 },
+      };
+    }),
+  );
+}
+
+/** The step list's draft, as nodes and edges below the committed graph.
+ *
+ * 1.1 builds a pipeline through this list rather than by dragging; direct
+ * manipulation is #51. A draft has run no steps, so every node is not_run.
+ */
+export interface DraftStep {
+  kind: string;
+  parameters: string;
+  type: "preprocess" | "estimator";
+}
+
+export function draftGraph(
+  steps: DraftStep[],
+  origin: { x: number; y: number },
+): { nodes: FlowNode[]; edges: FlowEdge[] } {
+  const nodes = steps.map((step, index) => ({
+    id: `draft-${index}`,
+    type: "workbench" as const,
+    position: { x: origin.x + 170 * index, y: origin.y },
+    data: {
+      label: step.kind,
+      type: step.type,
+      parameters: step.parameters,
+      state: "not_run" as const,
+      draft: true,
+    },
+  }));
+  const edges = nodes.slice(1).map((node, index) => ({
+    id: `draft-${index}->${index + 1}`,
+    source: nodes[index].id,
+    target: node.id,
+    animated: false,
+    style: { stroke: "currentColor", strokeWidth: 1.4, strokeDasharray: "4 3" },
+  }));
+  return { nodes, edges };
+}

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -14,6 +14,7 @@ import {
 import { DatasetView } from "@/screens/DatasetView";
 import { EmptyProject } from "@/screens/EmptyProject";
 import { Import } from "@/screens/Import";
+import { PipelineCanvas } from "@/canvas/PipelineCanvas";
 import { SpectraView } from "@/screens/SpectraView";
 import { Inspector } from "@/shell/Inspector";
 import { Sidebar } from "@/shell/Sidebar";
@@ -63,9 +64,11 @@ function Pane({
   datasets,
   onImported,
   onCloseImport,
+  onOpenNode,
 }: {
   tab: Tab | undefined;
   datasets: DatasetEntry[] | undefined;
+  onOpenNode: (id: string, label: string) => void;
   onImported: (versionId: string, name: string) => void;
   onCloseImport: () => void;
 }) {
@@ -73,6 +76,7 @@ function Pane({
     return <Import onImported={onImported} onCancel={onCloseImport} />;
   }
 
+  if (tab?.kind === "pipeline") return <PipelineCanvas onOpenNode={onOpenNode} />;
   if (tab?.kind === "spectra") return <SpectraView nodeId={tab.id} title={tab.title} />;
 
   const found = datasets
@@ -155,6 +159,17 @@ export function Shell() {
     [],
   );
 
+  const openNode = useCallback(
+    (id: string, label: string) => {
+      const node = pipeline.data?.nodes.find((candidate) => candidate.id === id);
+      open(
+        { id, kind: node?.type === "estimator" ? "results" : "spectra", title: label },
+        false,
+      );
+    },
+    [open, pipeline.data],
+  );
+
   const activeTab = state.tabs.find((tab) => tab.id === state.activeId);
   const splitTab = state.tabs.find((tab) => tab.id === state.splitId);
   const samples = datasets.data?.[0]?.versions.at(-1);
@@ -174,6 +189,12 @@ export function Shell() {
               {samples.n_samples} × {samples.n_variables}
             </span>
           ) : null}
+          <button
+            className="btn"
+            onClick={() => open({ id: "pipeline", kind: "pipeline", title: "Pipeline" }, false)}
+          >
+            Pipeline
+          </button>
           <button className="btn" onClick={openImport}>
             Import…
           </button>
@@ -229,11 +250,11 @@ export function Shell() {
             <EmptyProject onImport={openImport} />
           ) : state.splitId ? (
             <div className="split">
-              <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} />
-              <Pane tab={splitTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} />
+              <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} />
+              <Pane tab={splitTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} />
             </div>
           ) : (
-            <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} />
+            <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} />
           )}
         </main>
 

--- a/stub/fixtures/pipeline_state.json
+++ b/stub/fixtures/pipeline_state.json
@@ -48,7 +48,8 @@
       "state": "complete"
     },
     "pca_d": {
-      "state": "complete"
+      "state": "failed",
+      "message": "5 components were asked of a matrix of rank 4. Reduce n_components, or add samples or variables."
     }
   },
   "layout": {

--- a/stub/generate_fixtures.py
+++ b/stub/generate_fixtures.py
@@ -474,6 +474,16 @@ def node_states(pipeline: Pipeline) -> dict[str, Any]:
     states["autoscale_c"] = {"state": "stale", "reason": "upstream changed"}
     states["pca_c"] = {"state": "not_run"}
     states["centre_b"] = {"state": "not_run"}
+    # The fifth state. Its message is the one jobs.json's failing run ends on,
+    # because the node that failed and the run that failed are the same event
+    # seen from two places.
+    states["pca_d"] = {
+        "state": "failed",
+        "message": (
+            "5 components were asked of a matrix of rank 4. Reduce n_components, "
+            "or add samples or variables."
+        ),
+    }
     return {
         "pipeline_id": str(pipeline.pipeline_id),
         "nodes": states,


### PR DESCRIPTION
The signature screen. React Flow, as the issue asks, with a custom node type — the artboard fixes the geometry (132 × 70, a 17px mono header carrying the node *type*, the label over its parameters, a footer where there is something to say), and React Flow's default node is none of that.

## The encodings, which are the substance here

- **Five states in form as well as colour**, so they survive greyscale and colour blindness: complete solid · running with an accent border and its progress *inside* the node · stale dashed over a 135° `--staleSoft` hatch at 0.72 · failed with a 3px left stripe · not-yet-run a dashed outline. All five are on screen simultaneously and the e2e reads back `border-style`, `border-left-width` and `background-image` to prove it.
- **Edges:** `--accent` at 1.8px into a node a run is working on, dashed `4 3` in `--stale` wherever either end is stale, `--rule` at 1.4px at rest. Animation rides only on the accent path, and is off entirely under `prefers-reduced-motion`.
- **The footers carry the useful part** — the stale node says `edited - downstream stale`, the failed one names the rank-4 matrix.
- **Layout lives beside the pipeline, never inside `content_hash()`.** A test asserts the pipeline payload carries no layout at all: `design/data-model.md` is explicit that moving a node must not change the science.
- **Selecting a node opens its tab**, the mechanism tying the graph to the pages.
- **The pipeline is built through a step list**, not by dragging: SNV → SG d1 w11 → PCA appends three nodes and `Validate` reports `valid · 3 steps`. Direct manipulation is #51.

## One fixture change

The generator only produced four of the five states. `pca_d` now fails, with the same rank-4 message `jobs.json`'s failing run ends on — the node that failed and the run that failed are one event seen from two places. Regenerating touched `pipeline_state.json` and nothing else.

## Evidence

`pnpm e2e` 20 passed (4 new), `pnpm test` 33 passed (9 new — parameter lines, state footers, and every edge rule, checked against the committed fixture without a browser), typecheck / lint / build clean, `uv run pytest` 484.

Closes #46