### PR TITLE
Generate the inspector's parameter forms from the schema

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -207,7 +207,7 @@
         "pipeline-canvas"
       ],
       "user_visible_behavior": "The right sidebar shows whatever is selected - node parameters, model metrics, dataset metadata, provenance - and is the only place a pipeline parameter is edited in this sub-phase.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "Every preprocessing step the schema can express has an editable form.",
         "An even Savitzky-Golay window is refused by the form with a specific message, matching what models.py refuses.",
@@ -218,8 +218,8 @@
         "The provenance section collapses and shows the environment record from the fixture.",
         "The inspector matches the artboards in both themes: .ihead block, .ilabel in mono uppercase, .kv rows with the value in mono tabular numerals."
       ],
-      "evidence": null,
-      "notes": "Where form validation could drift from models.py, generate it from the schema rather than restating the rules."
+      "evidence": "2026-08-24. On feature/47_inspector. `pnpm e2e` is 24 passed, 4 of them this feature; `pnpm test` is 41 passed (8 new, the generated form and the staleness walk); Python is 486 passed (3 new: the served schema, model-backed step validation, and the fixture register). Asserted in the browser: selecting the Savitzky-Golay node fills a typed form with window_length 11, polyorder 2 and deriv 1; entering deriv 5 refuses with `Deriv must be at most 2` from the schema's own bounds and disables Apply; entering an even window is accepted by the form and refused by the model with its own sentence, `window_length must be odd`; changing MSC's reference to median and applying raises `Downstream results are stale.`, increases the count of stale nodes on the canvas and leaves all 14 nodes in place - a stale result dims, it does not vanish - and Re-run starts a job. Provenance is collapsed until asked for and truncates in the middle (`sha256:e435\u202690d7`). Screenshots taken in both themes.",
+      "notes": "The parameter form is generated from `models.py`'s JSON Schema, served at GET /api/schema/steps and committed as stub/fixtures/step_schema.json - so a field's type, bounds, enum and default come from the same place the backend enforces them. The cross-field rules (odd window, polyorder below window, deriv below polyorder, start below end) live in model_validator and have no JSON Schema form, so the stub server validates the step against PreprocessStep at POST /api/steps/validate and the message the user reads is the model's own. That is the one place the stub server computes anything, and it is on purpose: the alternative is restating models.py in TypeScript and drifting from it. Editing marks the node and everything downstream stale through a pure graph walk (src/inspector/stale.ts, tested against the fixture); the pipeline-state query holds its data so a tab switch does not refetch the optimistic update away."
     },
     {
       "id": "analysis-results",

--- a/frontend/e2e/inspector.spec.ts
+++ b/frontend/e2e/inspector.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** The inspector: a typed form built from the schema, a message that comes
+ * from the model, and an edit that marks downstream results stale. */
+
+async function selectNode(page: Page, name: RegExp) {
+  await page.goto("/?token=e2e-token");
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  await outline.getByRole("button", { name }).first().dblclick();
+  return page.getByRole("complementary", { name: "Inspector" });
+}
+
+test("a preprocessing node gets a typed form with the schema's own bounds", async ({ page }) => {
+  const inspector = await selectNode(page, /SG d1 w11/);
+
+  await expect(inspector.getByLabel("Window Length")).toHaveValue("11");
+  await expect(inspector.getByLabel("Polyorder")).toHaveValue("2");
+  await expect(inspector.getByLabel("Deriv")).toHaveValue("1");
+
+  // The bound comes from models.py: deriv is ge=0, le=2.
+  await inspector.getByLabel("Deriv").fill("5");
+  await expect(inspector.getByRole("alert")).toHaveText("Deriv must be at most 2");
+  await expect(inspector.getByRole("button", { name: "Apply" })).toBeDisabled();
+});
+
+test("a rule the schema cannot express is answered by the model itself", async ({ page }) => {
+  const inspector = await selectNode(page, /SG d1 w11/);
+
+  // An even window is legal JSON Schema and illegal chemometrics. The form
+  // does not know that; models.py does, and its sentence is what appears.
+  await inspector.getByLabel("Window Length").fill("10");
+  await expect(inspector.getByRole("button", { name: "Apply" })).toBeEnabled();
+  await inspector.getByRole("button", { name: "Apply" }).click();
+  await expect(inspector.getByRole("alert")).toHaveText("window_length must be odd");
+});
+
+test("an accepted edit marks downstream nodes stale and offers a re-run", async ({ page }) => {
+  const inspector = await selectNode(page, /^MSC/);
+  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
+  const staleBefore = await page.getByTestId("node-stale").count();
+
+  await page.getByRole("tab", { name: /MSC/ }).click();
+  await inspector.getByLabel("Reference").selectOption("median");
+  await inspector.getByRole("button", { name: "Apply" }).click();
+
+  await expect(page.getByText("Downstream results are stale.")).toBeVisible();
+
+  await page.getByRole("tab", { name: "Pipeline" }).click();
+  expect(await page.getByTestId("node-stale").count()).toBeGreaterThan(staleBefore);
+
+  // A stale result dims; it does not vanish. Every node is still on the canvas.
+  await expect(page.locator(".react-flow__node")).toHaveCount(14);
+
+  await page.getByRole("button", { name: "Re-run" }).click();
+  await expect(page.getByRole("status").first()).toContainText(/Queued|Preprocessing/);
+});
+
+test("provenance is collapsed until asked for, and hashes are truncated in the middle", async ({
+  page,
+}) => {
+  const inspector = await selectNode(page, /tecator_raw/);
+  const toggle = inspector.getByRole("button", { name: /Provenance record/ });
+  await expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+  await toggle.click();
+  await expect(toggle).toHaveAttribute("aria-expanded", "true");
+  await expect(inspector.getByText("sha256:e435…90d7")).toBeVisible();
+});

--- a/frontend/src/__tests__/inspector.test.ts
+++ b/frontend/src/__tests__/inspector.test.ts
@@ -1,0 +1,96 @@
+/** The inspector's two rules that must not drift.
+ *
+ * One: the parameter form is generated from `models.py`'s schema, so its
+ * bounds are the model's bounds. Two: editing a parameter marks everything
+ * computed from it stale - and stale means dimmed, never deleted.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { Pipeline } from "@/api/queries";
+import { checkBounds, specFor, stepSpecs, type StepSchema } from "@/inspector/schema";
+import { downstreamOf } from "@/inspector/stale";
+
+const FIXTURES = path.resolve(import.meta.dirname, "../../../stub/fixtures");
+const read = <T,>(name: string) =>
+  JSON.parse(readFileSync(path.join(FIXTURES, `${name}.json`), "utf8")) as T;
+
+const schema = read<StepSchema>("step_schema");
+const pipeline = read<Pipeline>("pipeline");
+
+describe("the form is generated, not restated", () => {
+  it("covers every preprocessing step the schema can express", () => {
+    const kinds = stepSpecs(schema).map((spec) => spec.kind);
+    expect(kinds).toEqual(
+      expect.arrayContaining([
+        "snv",
+        "msc",
+        "savgol",
+        "mean_centre",
+        "autoscale",
+        "normalise",
+        "baseline",
+        "range_select",
+      ]),
+    );
+  });
+
+  it("takes each field's bounds from the model", () => {
+    const savgol = specFor(schema, "savgol")!;
+    const deriv = savgol.fields.find((field) => field.name === "deriv")!;
+    expect(deriv.kind).toBe("integer");
+    expect([deriv.minimum, deriv.maximum]).toEqual([0, 2]);
+
+    const window = savgol.fields.find((field) => field.name === "window_length")!;
+    expect(window.exclusiveMinimum).toBe(2);
+  });
+
+  it("reads an enum as a choice and an optional field as optional", () => {
+    const msc = specFor(schema, "msc")!;
+    expect(msc.fields[0].options).toEqual(["mean", "median", "supplied"]);
+
+    const baseline = specFor(schema, "baseline")!;
+    expect(baseline.fields.find((field) => field.name === "lam")!.optional).toBe(true);
+    expect(baseline.fields.find((field) => field.name === "method")!.optional).toBe(false);
+  });
+
+  it("refuses a value the model would refuse, with a specific message", () => {
+    const savgol = specFor(schema, "savgol")!;
+    const deriv = savgol.fields.find((field) => field.name === "deriv")!;
+    expect(checkBounds(deriv, 3)).toBe("Deriv must be at most 2");
+    expect(checkBounds(deriv, 1.5)).toBe("Deriv must be a whole number");
+    expect(checkBounds(deriv, 1)).toBeNull();
+
+    const p = specFor(schema, "baseline")!.fields.find((field) => field.name === "p")!;
+    expect(checkBounds(p, 1)).toBe("P must be less than 1");
+    expect(checkBounds(p, "")).toBeNull(); // optional
+  });
+
+  // The cross-field rules are deliberately absent here: they live in
+  // model_validator, have no JSON Schema form, and are checked by the server
+  // so the message is the model's own.
+  it("does not pretend to know the cross-field rules", () => {
+    const savgol = specFor(schema, "savgol")!;
+    const window = savgol.fields.find((field) => field.name === "window_length")!;
+    expect(checkBounds(window, 10)).toBeNull();
+  });
+});
+
+describe("editing marks downstream stale", () => {
+  it("follows every branch below the edited node", () => {
+    expect(downstreamOf(pipeline, "snv").sort()).toEqual(
+      ["centre_a", "pca_a", "snv_savgol", "split_d", "centre_d", "pca_d"].sort(),
+    );
+  });
+
+  it("stops at a leaf and never includes the node itself", () => {
+    expect(downstreamOf(pipeline, "pca_a")).toEqual([]);
+    expect(downstreamOf(pipeline, "msc")).toEqual(["centre_b", "pca_b"]);
+  });
+
+  it("marks the whole graph when the source is edited", () => {
+    expect(downstreamOf(pipeline, "source")).toHaveLength(pipeline.nodes.length - 1);
+  });
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -1,5 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
+import type { StepSchema } from "@/inspector/schema";
+
 import { api } from "./client";
 
 /** The payload shapes are the stub server's, generated from the kernels by
@@ -33,6 +35,7 @@ export interface DatasetVersion {
     imported_at?: string;
   } | null;
   derived_from: string | null;
+  array_path: string;
   created_at: string;
 }
 
@@ -189,6 +192,10 @@ export function usePipelineState() {
   return useQuery({
     queryKey: ["pipeline-state"],
     queryFn: () => api<PipelineState>("/pipelines/current/state"),
+    // Run state changes because something in this session changed it - an edit
+    // marking downstream nodes stale, or a run advancing. Refetching on every
+    // remount would throw those away, and 1.1 has nothing else writing it.
+    staleTime: Infinity,
   });
 }
 
@@ -208,6 +215,14 @@ export function useSpectra(nodeId: string | undefined) {
     enabled: Boolean(nodeId),
     // The decimated payload is the largest thing crossing the wire; holding it
     // means switching between two nodes does not refetch either.
+    staleTime: Infinity,
+  });
+}
+
+export function useStepSchema() {
+  return useQuery({
+    queryKey: ["step-schema"],
+    queryFn: () => api<StepSchema>("/schema/steps"),
     staleTime: Infinity,
   });
 }

--- a/frontend/src/inspector/ParameterForm.tsx
+++ b/frontend/src/inspector/ParameterForm.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+
+import { api } from "@/api/client";
+import { checkBounds, type FieldSpec, type StepSpec } from "@/inspector/schema";
+
+/** The typed editor for one preprocessing step.
+ *
+ * Field bounds come from the schema and are checked as you type. The rules
+ * that span fields are checked by the server against `models.py` itself, so
+ * "window_length must be odd" is the model's sentence, not one written here.
+ */
+
+interface Props {
+  spec: StepSpec;
+  values: Record<string, string>;
+  onChange: (values: Record<string, string>) => void;
+  onApply: () => void;
+}
+
+function Field({
+  field,
+  value,
+  problem,
+  onChange,
+}: {
+  field: FieldSpec;
+  value: string;
+  problem: string | null;
+  onChange: (value: string) => void;
+}) {
+  const border = problem ? "var(--fail)" : "var(--rule)";
+  return (
+    <div style={{ padding: "3px 12px" }}>
+      <div className="kv" style={{ padding: 0, alignItems: "center" }}>
+        <b title={field.description}>{field.title}</b>
+        {field.kind === "enum" ? (
+          <select
+            aria-label={field.title}
+            className="mono"
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            style={{
+              width: 116,
+              height: 22,
+              borderRadius: 3,
+              border: `1px solid ${border}`,
+              background: "var(--surface)",
+              color: "var(--ink)",
+              font: "inherit",
+              fontSize: 11.5,
+            }}
+          >
+            {field.options?.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <input
+            aria-label={field.title}
+            className="mono"
+            inputMode="numeric"
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            style={{
+              width: 116,
+              height: 22,
+              padding: "0 6px",
+              textAlign: "right",
+              borderRadius: 3,
+              border: `1px solid ${border}`,
+              background: "var(--surface)",
+              color: "var(--ink)",
+              font: "inherit",
+              fontSize: 11.5,
+              fontVariantNumeric: "tabular-nums",
+            }}
+          />
+        )}
+      </div>
+      {problem ? (
+        <p role="alert" style={{ margin: "2px 0 0", fontSize: 10.5, color: "var(--fail)" }}>
+          {problem}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function ParameterForm({ spec, values, onChange, onApply }: Props) {
+  const [serverProblems, setServerProblems] = useState<Record<string, string>>({});
+  const [checking, setChecking] = useState(false);
+
+  const bounds = Object.fromEntries(
+    spec.fields.map((field) => [field.name, checkBounds(field, values[field.name] ?? "")]),
+  );
+  const problems = { ...serverProblems, ...bounds };
+  const blocked = Object.values(problems).some(Boolean);
+
+  const apply = async () => {
+    setChecking(true);
+    // The cross-field rules live in model_validator and have no JSON Schema
+    // form; asking the model is cheaper and more honest than restating them.
+    const payload: Record<string, unknown> = { kind: spec.kind };
+    for (const field of spec.fields) {
+      const raw = values[field.name];
+      if (raw === "" || raw === undefined) continue;
+      payload[field.name] = field.kind === "enum" ? raw : Number(raw);
+    }
+    const result = await api<{ valid: boolean; errors: { field: string; message: string }[] }>(
+      "/steps/validate",
+      { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) },
+    );
+    setChecking(false);
+    if (result.valid) {
+      setServerProblems({});
+      onApply();
+      return;
+    }
+    // A field-level complaint lands on its field; a cross-field one - which
+    // Pydantic reports against the model rather than a field - belongs to the
+    // form as a whole.
+    const names = new Set(spec.fields.map((field) => field.name));
+    setServerProblems(
+      Object.fromEntries(
+        result.errors.map((error) => {
+          const leaf = error.field.split(".").at(-1) ?? "step";
+          return [names.has(leaf) ? leaf : "step", error.message];
+        }),
+      ),
+    );
+  };
+
+  return (
+    <div style={{ padding: "6px 0 10px", borderBottom: "1px solid var(--rule)" }}>
+      <div className="ilabel" style={{ padding: "2px 12px 4px" }}>
+        Parameters
+      </div>
+      {spec.fields.length === 0 ? (
+        <div className="empty">This step has no parameters.</div>
+      ) : (
+        spec.fields.map((field) => (
+          <Field
+            key={field.name}
+            field={field}
+            value={values[field.name] ?? ""}
+            problem={problems[field.name] ?? null}
+            onChange={(next) => {
+              setServerProblems({});
+              onChange({ ...values, [field.name]: next });
+            }}
+          />
+        ))
+      )}
+      {serverProblems.step ? (
+        <p role="alert" style={{ margin: "2px 12px 0", fontSize: 10.5, color: "var(--fail)" }}>
+          {serverProblems.step}
+        </p>
+      ) : null}
+      {spec.fields.length > 0 ? (
+        <div style={{ padding: "8px 12px 0" }}>
+          <button className="btn" style={{ height: 24 }} disabled={blocked || checking} onClick={apply}>
+            {checking ? "Checking…" : "Apply"}
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/inspector/Provenance.tsx
+++ b/frontend/src/inspector/Provenance.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+/** Provenance, collapsed by default: content hash, pipeline hash, app version.
+ * Hashes are mono and truncated in the middle - `sha256:9f3c…a71b` - because
+ * the ends are what a person compares. */
+
+function middle(hash: string): string {
+  return hash.length > 22 ? `${hash.slice(0, 11)}…${hash.slice(-4)}` : hash;
+}
+
+export function Provenance({ entries }: { entries: [string, string][] }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div style={{ borderBottom: "1px solid var(--rule)" }}>
+      <button
+        className="srow"
+        aria-expanded={open}
+        style={{ height: 30, paddingLeft: 12, color: "var(--ink2)" }}
+        onClick={() => setOpen(!open)}
+      >
+        <span>Provenance record</span>
+        <span className="sdim mono">{open ? "−" : "+"}</span>
+      </button>
+      {open ? (
+        <div style={{ padding: "0 0 8px" }}>
+          {entries.map(([label, value]) => (
+            <div className="kv" key={label}>
+              <b>{label}</b>
+              <span title={value}>{middle(value)}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/inspector/schema.ts
+++ b/frontend/src/inspector/schema.ts
@@ -1,0 +1,133 @@
+/** Parameter forms built from `models.py`'s own JSON Schema.
+ *
+ * The rule from #47: where the form and the schema could drift, generate from
+ * the schema rather than restating it. A field's type, its bounds, its enum
+ * and its default all come from the served schema, so a form can neither
+ * refuse what the backend allows nor allow what it refuses.
+ *
+ * What cannot be generated is the cross-field rules - an odd Savitzky-Golay
+ * window, `polyorder` below it - because they live in `model_validator` and
+ * JSON Schema has no way to say them. Those are checked by asking the server,
+ * so the message a user reads is the model's own.
+ */
+
+export interface FieldSpec {
+  name: string;
+  title: string;
+  description?: string;
+  kind: "number" | "integer" | "enum" | "unsupported";
+  options?: string[];
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  default?: unknown;
+  optional: boolean;
+}
+
+export interface StepSpec {
+  kind: string;
+  title: string;
+  fields: FieldSpec[];
+}
+
+interface JsonSchemaField {
+  type?: string;
+  title?: string;
+  description?: string;
+  const?: string;
+  default?: unknown;
+  enum?: string[];
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  anyOf?: JsonSchemaField[];
+}
+
+export interface StepSchema {
+  $defs: Record<
+    string,
+    { title: string; properties: Record<string, JsonSchemaField & { const?: string }> }
+  >;
+}
+
+/** Pydantic writes an optional field as `anyOf: [{...}, {type: "null"}]`. The
+ * shape of the field is the half that is not null. */
+function unwrap(field: JsonSchemaField): { field: JsonSchemaField; optional: boolean } {
+  if (!field.anyOf) return { field, optional: false };
+  const real = field.anyOf.find((option) => option.type !== "null");
+  return { field: { ...field, ...real }, optional: field.anyOf.some((o) => o.type === "null") };
+}
+
+function toField(name: string, raw: JsonSchemaField): FieldSpec {
+  const { field, optional } = unwrap(raw);
+  const options = field.enum ?? (field.const ? [field.const] : undefined);
+  const kind = options
+    ? "enum"
+    : field.type === "integer"
+      ? "integer"
+      : field.type === "number"
+        ? "number"
+        : "unsupported";
+  return {
+    name,
+    title: field.title ?? name,
+    description: field.description,
+    kind,
+    options,
+    minimum: field.minimum,
+    maximum: field.maximum,
+    exclusiveMinimum: field.exclusiveMinimum,
+    exclusiveMaximum: field.exclusiveMaximum,
+    default: field.default,
+    optional,
+  };
+}
+
+export function stepSpecs(schema: StepSchema): StepSpec[] {
+  return Object.values(schema.$defs).map((definition) => ({
+    kind: definition.properties.kind.const ?? definition.title.toLowerCase(),
+    title: definition.title,
+    // `kind` is the discriminator, not a parameter: it names the step and is
+    // never edited.
+    fields: Object.entries(definition.properties)
+      .filter(([name]) => name !== "kind")
+      .map(([name, field]) => toField(name, field)),
+  }));
+}
+
+export function specFor(schema: StepSchema | undefined, kind: string): StepSpec | undefined {
+  return schema ? stepSpecs(schema).find((spec) => spec.kind === kind) : undefined;
+}
+
+/** The bounds a single field can be checked against without asking anyone.
+ * Returns the message to show, or null when the value is allowed. */
+export function checkBounds(field: FieldSpec, value: number | string | null): string | null {
+  if (value === null || value === "") {
+    return field.optional ? null : `${field.title} is required`;
+  }
+  if (field.kind === "enum") {
+    return field.options?.includes(String(value))
+      ? null
+      : `${field.title} must be one of ${field.options?.join(", ")}`;
+  }
+  const number = Number(value);
+  if (Number.isNaN(number)) return `${field.title} must be a number`;
+  if (field.kind === "integer" && !Number.isInteger(number)) {
+    return `${field.title} must be a whole number`;
+  }
+  if (field.minimum !== undefined && number < field.minimum) {
+    return `${field.title} must be at least ${field.minimum}`;
+  }
+  if (field.maximum !== undefined && number > field.maximum) {
+    return `${field.title} must be at most ${field.maximum}`;
+  }
+  if (field.exclusiveMinimum !== undefined && number <= field.exclusiveMinimum) {
+    return `${field.title} must be greater than ${field.exclusiveMinimum}`;
+  }
+  if (field.exclusiveMaximum !== undefined && number >= field.exclusiveMaximum) {
+    return `${field.title} must be less than ${field.exclusiveMaximum}`;
+  }
+  return null;
+}

--- a/frontend/src/inspector/stale.ts
+++ b/frontend/src/inspector/stale.ts
@@ -1,0 +1,24 @@
+import type { Pipeline } from "@/api/queries";
+
+/** Editing a parameter invalidates what was computed from it.
+ *
+ * Everything downstream of the edited node becomes stale - not deleted, not
+ * hidden. A stale result stays readable; that is the whole reason the state
+ * exists and why the canvas draws it dimmed rather than dropping it.
+ */
+export function downstreamOf(pipeline: Pipeline, nodeId: string): string[] {
+  const stale = new Set<string>();
+  let frontier = [nodeId];
+  while (frontier.length > 0) {
+    const next: string[] = [];
+    for (const node of pipeline.nodes) {
+      if (stale.has(node.id)) continue;
+      if (node.inputs.some((input) => frontier.includes(input))) {
+        stale.add(node.id);
+        next.push(node.id);
+      }
+    }
+    frontier = next;
+  }
+  return [...stale];
+}

--- a/frontend/src/screens/SpectraView.tsx
+++ b/frontend/src/screens/SpectraView.tsx
@@ -181,7 +181,10 @@ export function SpectraView({ nodeId, title }: { nodeId: string; title: string }
       >
         <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
           <Segmented layer={isSource ? "raw" : layer} onChange={setLayer} disabled={isSource} />
-          <span className="mono" style={{ fontSize: 11, color: "var(--ink3)" }}>
+          <span
+            className="mono"
+            style={{ fontSize: 11, color: "var(--ink3)", whiteSpace: "nowrap" }}
+          >
             {primary.n_spectra} spectra · {selected.length} highlighted ·{" "}
             {decimation.variables_total} variables
           </span>

--- a/frontend/src/shell/Inspector.tsx
+++ b/frontend/src/shell/Inspector.tsx
@@ -1,16 +1,28 @@
-import type { DatasetEntry, PipelineNode, PipelineState } from "@/api/queries";
+import { useEffect, useState } from "react";
+
+import type { DatasetEntry, Pipeline, PipelineNode, PipelineState, Project } from "@/api/queries";
+import { useStepSchema } from "@/api/queries";
+import { ParameterForm } from "@/inspector/ParameterForm";
+import { Provenance } from "@/inspector/Provenance";
+import { specFor } from "@/inspector/schema";
 import type { Tab } from "@/shell/tabs";
 
-/** The inspector's frame. What fills it per selection is #47; what it must do
- * here is be context-sensitive - a different heading and a different set of
- * facts depending on what the active tab shows - and collapse. */
+/** The right sidebar, and in Phase 1.1 the only place a parameter is edited.
+ *
+ * Context-sensitive: a dataset shows its metadata and its source, a
+ * preprocessing node shows a typed form built from the schema, an estimator
+ * shows its metrics. Provenance sits at the foot of all of them, collapsed.
+ */
 
 interface Props {
   tab: Tab | undefined;
+  project: Project | undefined;
   datasets: DatasetEntry[] | undefined;
-  nodes: PipelineNode[] | undefined;
+  pipeline: Pipeline | undefined;
   state: PipelineState | undefined;
+  metrics: Record<string, number | null> | undefined;
   collapsed: boolean;
+  onEdit: (nodeId: string) => void;
 }
 
 function Kv({ label, value }: { label: string; value: string | number }) {
@@ -23,10 +35,37 @@ function Kv({ label, value }: { label: string; value: string | number }) {
 }
 
 function short(hash: string): string {
-  return hash.length > 20 ? `${hash.slice(0, 11)}…${hash.slice(-4)}` : hash;
+  return hash.length > 22 ? `${hash.slice(0, 11)}…${hash.slice(-4)}` : hash;
 }
 
-export function Inspector({ tab, datasets, nodes, state, collapsed }: Props) {
+/** The step's current values, as strings, so the form has one representation. */
+function valuesOf(node: PipelineNode): Record<string, string> {
+  const step = (node.step ?? node.spec ?? {}) as Record<string, unknown>;
+  return Object.fromEntries(
+    Object.entries(step)
+      .filter(([name]) => name !== "kind")
+      .map(([name, value]) => [name, value === null ? "" : String(value)]),
+  );
+}
+
+export function Inspector({
+  tab,
+  project,
+  datasets,
+  pipeline,
+  state,
+  metrics,
+  collapsed,
+  onEdit,
+}: Props) {
+  const schema = useStepSchema();
+  const node = pipeline?.nodes.find((candidate) => candidate.id === tab?.id);
+  const [values, setValues] = useState<Record<string, string>>({});
+
+  // A different node is a different form. Reset to what the pipeline says
+  // rather than carrying the last node's numbers across.
+  useEffect(() => setValues(node ? valuesOf(node) : {}), [node]);
+
   if (collapsed) return <aside className="insp rail" aria-label="Inspector" />;
 
   if (!tab) {
@@ -43,17 +82,30 @@ export function Inspector({ tab, datasets, nodes, state, collapsed }: Props) {
   const version = datasets
     ?.flatMap((entry) => entry.versions.map((v) => ({ entry, v })))
     .find((pair) => pair.v.version_id === tab.id);
-  const node = nodes?.find((candidate) => candidate.id === tab.id);
+  const status = node ? state?.nodes[node.id] : undefined;
+  const spec = node?.step ? specFor(schema.data, String(node.step.kind)) : undefined;
 
   return (
-    <aside className="insp" aria-label="Inspector">
+    <aside className="insp" aria-label="Inspector" style={{ overflowY: "auto" }}>
       <div className="ihead">
         <span className="ilabel">
-          {version ? "Dataset version" : node ? "Node" : tab.kind === "experiment" ? "Experiment" : "Selection"}
+          {version ? "Dataset version" : node ? node.type : tab.kind}
         </span>
         <span style={{ fontWeight: 600, fontSize: 13 }}>
           {version ? `${version.entry.dataset.name} · v${version.v.version}` : tab.title}
         </span>
+        {status ? (
+          <span
+            className="mono"
+            style={{
+              fontSize: 10,
+              color: status.state === "stale" ? "var(--stale)" : status.state === "failed" ? "var(--fail)" : "var(--ink3)",
+            }}
+          >
+            {status.state}
+            {status.reason ? ` · ${status.reason}` : ""}
+          </span>
+        ) : null}
       </div>
 
       {version ? (
@@ -61,16 +113,8 @@ export function Inspector({ tab, datasets, nodes, state, collapsed }: Props) {
           <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
             <Kv label="Samples" value={version.v.n_samples} />
             <Kv label="Variables" value={version.v.n_variables} />
-            <Kv label="Content hash" value={short(version.v.content_hash)} />
-            <Kv label="Derived from" value={version.v.derived_from ? "v1" : "—"} />
+            <Kv label="Targets" value={Object.keys(version.v.targets).join(", ") || "—"} />
             <Kv label="Created" value={version.v.created_at.slice(0, 10)} />
-          </div>
-          <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
-            <div className="ilabel" style={{ padding: "2px 12px 4px" }}>
-              Variable axis
-            </div>
-            <Kv label="Kind" value={version.v.axis.kind} />
-            <Kv label="Unit" value={version.v.axis.unit ?? "—"} />
           </div>
           {version.v.source ? (
             <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
@@ -82,24 +126,55 @@ export function Inspector({ tab, datasets, nodes, state, collapsed }: Props) {
                 label="Reader"
                 value={`${version.v.source.reader} ${version.v.source.reader_version}`}
               />
-              <Kv label="File hash" value={short(version.v.source.file_hash)} />
             </div>
           ) : null}
         </>
       ) : null}
 
-      {node ? (
+      {spec ? (
+        <ParameterForm
+          spec={spec}
+          values={values}
+          onChange={setValues}
+          onApply={() => onEdit(node!.id)}
+        />
+      ) : node ? (
         <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
           <Kv label="Type" value={node.type} />
-          {node.step?.kind ? <Kv label="Step" value={String(node.step.kind)} /> : null}
           <Kv label="Inputs" value={node.inputs.join(", ") || "—"} />
-          <Kv label="Run state" value={state?.nodes[node.id]?.state ?? "unknown"} />
+          {node.spec
+            ? Object.entries(node.spec)
+                .filter(([name]) => name !== "kind")
+                .map(([name, value]) => <Kv key={name} label={name} value={String(value)} />)
+            : null}
         </div>
       ) : null}
 
-      {/* The parameter editors, the metrics table and the provenance record
-          are #47. This frame is what they mount into. */}
-      <div style={{ padding: "9px 12px", color: "var(--ink2)" }}>Provenance record</div>
+      {metrics ? (
+        <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>
+          <div className="ilabel" style={{ padding: "2px 12px 4px" }}>
+            Metrics
+          </div>
+          {Object.entries(metrics).map(([label, value]) => (
+            <Kv key={label} label={label} value={value === null ? "—" : value.toFixed(4)} />
+          ))}
+        </div>
+      ) : null}
+
+      <Provenance
+        entries={[
+          ["Content hash", version?.v.content_hash ?? datasets?.[0]?.versions[0]?.content_hash ?? "—"],
+          ["Pipeline", pipeline?.pipeline_id ?? "—"],
+          ["Project", project?.project_id ?? "—"],
+          ["App version", "0.1.0"],
+        ]}
+      />
+      {version ? (
+        <div className="kv" style={{ paddingTop: 8 }}>
+          <b>Array</b>
+          <span title={version.v.array_path}>{short(version.v.array_path)}</span>
+        </div>
+      ) : null}
     </aside>
   );
 }

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useReducer, useRef, useState } from "react";
 
-import type { DatasetEntry } from "@/api/queries";
+import { useQueryClient } from "@tanstack/react-query";
+
+import type { DatasetEntry, PipelineState } from "@/api/queries";
 import {
   useCancelJob,
   useDatasets,
@@ -21,6 +23,7 @@ import { Sidebar } from "@/shell/Sidebar";
 import { StatusBar } from "@/shell/StatusBar";
 import { TabStrip } from "@/shell/TabStrip";
 import { FlaskIcon, KIND_ICONS } from "@/shell/icons";
+import { downstreamOf } from "@/inspector/stale";
 import { emptyTabs, tabsReducer, type Tab } from "@/shell/tabs";
 
 /** The frame every screen opens inside. The measurements are the artboard's -
@@ -128,6 +131,7 @@ export function Shell() {
   const sidebar = useResizable(248, 180, 420, "left");
   const inspector = useResizable(292, 220, 460, "right");
 
+  const queryClient = useQueryClient();
   const projects = useProjects();
   const project = projects.data?.[0];
   const datasets = useDatasets(project?.project_id);
@@ -135,6 +139,7 @@ export function Shell() {
   const pipelineState = usePipelineState();
   const experiment = useExperiment();
 
+  const [staleFrom, setStaleFrom] = useState<string | null>(null);
   const [jobId, setJobId] = useState<string | null>(null);
   const [startedAt, setStartedAt] = useState<number | null>(null);
   const job = useJob(jobId);
@@ -170,13 +175,57 @@ export function Shell() {
     [open, pipeline.data],
   );
 
+  /** Editing a parameter invalidates everything computed from it. The results
+   * stay on screen, dimmed - a stale result must not vanish. */
+  const markStale = useCallback(
+    (nodeId: string) => {
+      if (!pipeline.data) return;
+      const affected = [nodeId, ...downstreamOf(pipeline.data, nodeId)];
+      queryClient.setQueryData<PipelineState>(["pipeline-state"], (current) =>
+        current
+          ? {
+              ...current,
+              nodes: {
+                ...current.nodes,
+                ...Object.fromEntries(
+                  affected.map((id) => [
+                    id,
+                    {
+                      ...current.nodes[id],
+                      state: "stale",
+                      reason: id === nodeId ? "edited - downstream stale" : "upstream changed",
+                    },
+                  ]),
+                ),
+              },
+            }
+          : current,
+      );
+      setStaleFrom(nodeId);
+    },
+    [pipeline.data, queryClient],
+  );
+
   const activeTab = state.tabs.find((tab) => tab.id === state.activeId);
   const splitTab = state.tabs.find((tab) => tab.id === state.splitId);
   const samples = datasets.data?.[0]?.versions.at(-1);
   const noDatasets = datasets.isSuccess && datasets.data.length === 0;
 
+  /** An estimator node's headline numbers, in .kv form with tabular numerals.
+   * The full results table is #48; this is what fits in 292px. */
+  const metricsFor = (tab: Tab | undefined) => {
+    const node = pipeline.data?.nodes.find((candidate) => candidate.id === tab?.id);
+    if (node?.type !== "estimator" || !experiment.data) return undefined;
+    const variance = experiment.data.metrics.explained_variance ?? [];
+    return {
+      "PC1 variance": variance[0] ?? null,
+      "PC1-5 cumulative": variance.slice(0, 5).reduce((total, item) => total + item, 0) || null,
+      components: (node.spec?.n_components as number) ?? null,
+    };
+  };
+
   return (
-    <div className={`app ${theme}`}>
+    <div className={`app ${theme}`} style={{ position: "relative" }}>
       <div className="tbar">
         <div className="tb-l">
           <FlaskIcon />
@@ -265,14 +314,53 @@ export function Shell() {
           <div style={{ flex: 1, display: "flex", minWidth: 0 }}>
             <Inspector
               tab={activeTab}
+              project={project}
               datasets={datasets.data}
-              nodes={pipeline.data?.nodes}
+              pipeline={pipeline.data}
               state={pipelineState.data}
+              metrics={metricsFor(activeTab)}
               collapsed={inspectorCollapsed}
+              onEdit={markStale}
             />
           </div>
         </div>
       </div>
+
+      {staleFrom ? (
+        <div
+          role="status"
+          style={{
+            position: "absolute",
+            right: 304,
+            bottom: 36,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "6px 10px",
+            borderRadius: 3,
+            border: "1px solid var(--stale)",
+            background: "var(--staleSoft)",
+            fontSize: 11.5,
+          }}
+        >
+          <span style={{ color: "var(--stale)" }}>Downstream results are stale.</span>
+          <button
+            className="btn"
+            style={{ height: 22 }}
+            onClick={async () => {
+              const started = await run.mutateAsync({});
+              setJobId(started.job_id);
+              setStartedAt(Date.now());
+              setStaleFrom(null);
+            }}
+          >
+            Re-run
+          </button>
+          <button className="tabx" aria-label="Dismiss" onClick={() => setStaleFrom(null)}>
+            ×
+          </button>
+        </div>
+      ) : null}
 
       <StatusBar
         job={job.data}

--- a/frontend/src/styles/shell.css
+++ b/frontend/src/styles/shell.css
@@ -93,3 +93,7 @@ td.n{color:var(--ink)}
  * artboard's rows are one line each. */
 .srow span:not(.sdim){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .sdim{flex:none;padding-left:6px}
+
+/* A pill is one line. At 1440 with both sidebars open the spectra header has
+ * little room, and a wrapped pill reads as two broken ones. */
+.pill{white-space:nowrap;flex:none}

--- a/stub/fixtures/step_schema.json
+++ b/stub/fixtures/step_schema.json
@@ -1,0 +1,262 @@
+{
+  "$defs": {
+    "Autoscale": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "autoscale",
+          "default": "autoscale",
+          "title": "Kind",
+          "type": "string"
+        },
+        "ddof": {
+          "default": 1,
+          "description": "Denominator convention for the standard deviation.",
+          "maximum": 1,
+          "minimum": 0,
+          "title": "Ddof",
+          "type": "integer"
+        }
+      },
+      "title": "Autoscale",
+      "type": "object"
+    },
+    "BaselineCorrect": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "baseline",
+          "default": "baseline",
+          "title": "Kind",
+          "type": "string"
+        },
+        "method": {
+          "default": "asls",
+          "enum": [
+            "asls",
+            "rubberband",
+            "polynomial"
+          ],
+          "title": "Method",
+          "type": "string"
+        },
+        "order": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Polynomial order, when method is polynomial.",
+          "title": "Order"
+        },
+        "lam": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Smoothness, when method is asls.",
+          "title": "Lam"
+        },
+        "p": {
+          "anyOf": [
+            {
+              "exclusiveMaximum": 1,
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Asymmetry, when method is asls.",
+          "title": "P"
+        }
+      },
+      "title": "BaselineCorrect",
+      "type": "object"
+    },
+    "MSC": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "msc",
+          "default": "msc",
+          "title": "Kind",
+          "type": "string"
+        },
+        "reference": {
+          "default": "mean",
+          "enum": [
+            "mean",
+            "median",
+            "supplied"
+          ],
+          "title": "Reference",
+          "type": "string"
+        }
+      },
+      "title": "MSC",
+      "type": "object"
+    },
+    "MeanCentre": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "mean_centre",
+          "default": "mean_centre",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "title": "MeanCentre",
+      "type": "object"
+    },
+    "Normalise": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "normalise",
+          "default": "normalise",
+          "title": "Kind",
+          "type": "string"
+        },
+        "norm": {
+          "default": "l2",
+          "enum": [
+            "l1",
+            "l2",
+            "max",
+            "area"
+          ],
+          "title": "Norm",
+          "type": "string"
+        }
+      },
+      "title": "Normalise",
+      "type": "object"
+    },
+    "RangeSelect": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "range_select",
+          "default": "range_select",
+          "title": "Kind",
+          "type": "string"
+        },
+        "start": {
+          "title": "Start",
+          "type": "number"
+        },
+        "end": {
+          "title": "End",
+          "type": "number"
+        }
+      },
+      "required": [
+        "start",
+        "end"
+      ],
+      "title": "RangeSelect",
+      "type": "object"
+    },
+    "SNV": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "snv",
+          "default": "snv",
+          "title": "Kind",
+          "type": "string"
+        }
+      },
+      "title": "SNV",
+      "type": "object"
+    },
+    "SavitzkyGolay": {
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "const": "savgol",
+          "default": "savgol",
+          "title": "Kind",
+          "type": "string"
+        },
+        "window_length": {
+          "exclusiveMinimum": 2,
+          "title": "Window Length",
+          "type": "integer"
+        },
+        "polyorder": {
+          "minimum": 0,
+          "title": "Polyorder",
+          "type": "integer"
+        },
+        "deriv": {
+          "default": 0,
+          "maximum": 2,
+          "minimum": 0,
+          "title": "Deriv",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "window_length",
+        "polyorder"
+      ],
+      "title": "SavitzkyGolay",
+      "type": "object"
+    }
+  },
+  "discriminator": {
+    "mapping": {
+      "autoscale": "#/$defs/Autoscale",
+      "baseline": "#/$defs/BaselineCorrect",
+      "mean_centre": "#/$defs/MeanCentre",
+      "msc": "#/$defs/MSC",
+      "normalise": "#/$defs/Normalise",
+      "range_select": "#/$defs/RangeSelect",
+      "savgol": "#/$defs/SavitzkyGolay",
+      "snv": "#/$defs/SNV"
+    },
+    "propertyName": "kind"
+  },
+  "oneOf": [
+    {
+      "$ref": "#/$defs/SNV"
+    },
+    {
+      "$ref": "#/$defs/MSC"
+    },
+    {
+      "$ref": "#/$defs/SavitzkyGolay"
+    },
+    {
+      "$ref": "#/$defs/MeanCentre"
+    },
+    {
+      "$ref": "#/$defs/Autoscale"
+    },
+    {
+      "$ref": "#/$defs/Normalise"
+    },
+    {
+      "$ref": "#/$defs/BaselineCorrect"
+    },
+    {
+      "$ref": "#/$defs/RangeSelect"
+    }
+  ]
+}

--- a/stub/generate_fixtures.py
+++ b/stub/generate_fixtures.py
@@ -65,6 +65,7 @@ from uuid import UUID, uuid5
 import numpy as np
 import scipy
 from numpy.typing import NDArray
+from pydantic import TypeAdapter
 
 import chemometrics_workbench as cw
 from chemometrics_workbench import preprocessing, validation
@@ -86,6 +87,7 @@ from chemometrics_workbench.models import (
     PCASpec,
     Pipeline,
     PreprocessNode,
+    PreprocessStep,
     Project,
     ResolvedSplit,
     SavitzkyGolay,
@@ -456,6 +458,23 @@ def error_payload() -> dict[str, Any]:
     }
 
 
+def step_schema() -> dict[str, Any]:
+    """The preprocessing steps' own JSON Schema, straight out of `models.py`.
+
+    NOT a guess, and deliberately not written by hand: the inspector builds its
+    parameter forms from this, so a field's type, its bounds, its enum and its
+    default come from the same place the backend enforces them. Restating them
+    in TypeScript is how a form ends up refusing what the schema allows, or
+    allowing what it refuses.
+
+    The cross-field rules - an odd Savitzky-Golay window, `polyorder` below it,
+    `start` below `end` - live in `model_validator` and have no JSON Schema
+    equivalent. The stub server validates against the model itself instead of
+    restating them; see `/steps/validate`.
+    """
+    return TypeAdapter(PreprocessStep).json_schema()
+
+
 def node_states(pipeline: Pipeline) -> dict[str, Any]:
     """Run state per node, for the canvas.
 
@@ -679,6 +698,7 @@ def main() -> None:
         write("import_preview", import_preview(version, tecator)),
         write("jobs", job_sequences(experiment.experiment_id)),
         write("error", error_payload()),
+        write("step_schema", step_schema()),
         write(
             "spectra",
             {

--- a/stub/server.py
+++ b/stub/server.py
@@ -44,6 +44,9 @@ import uvicorn
 from fastapi import APIRouter, Depends, FastAPI, Header, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
+from pydantic import TypeAdapter, ValidationError
+
+from chemometrics_workbench.models import PreprocessStep
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 # Production mode serves the built frontend from here. STUB_BUNDLE overrides it,
@@ -142,6 +145,47 @@ def import_preview() -> Any:
 @api.post("/import")
 def import_dataset() -> Any:
     return fixture("datasets")[0]
+
+
+@api.get("/schema/steps")
+def step_schema() -> Any:
+    """The preprocessing steps' JSON Schema, generated from models.py (#41).
+
+    Phase 1.2: served from the live models rather than from a file, which is a
+    change of source and not of shape.
+    """
+    return fixture("step_schema")
+
+
+@api.post("/steps/validate")
+def validate_step(step: dict[str, Any]) -> Any:
+    """Validate one step against the model that will enforce it.
+
+    This is the one place the stub server computes something, and it does so
+    on purpose. The cross-field rules - an odd Savitzky-Golay window,
+    `polyorder` below it, `start` below `end` - live in `model_validator` and
+    have no JSON Schema equivalent, so a form that checked them itself would be
+    restating `models.py` in TypeScript and drifting from it. Validating
+    against the model means the message the user reads is the model's own.
+
+    Phase 1.2: the same call, with the step going on to be stored.
+    """
+    try:
+        TypeAdapter(PreprocessStep).validate_python(step)
+    except ValidationError as error:
+        return {
+            "valid": False,
+            "errors": [
+                {
+                    # Pydantic prefixes its own message; the part after the
+                    # comma is what a person needs to read.
+                    "field": ".".join(str(part) for part in problem["loc"]) or "step",
+                    "message": problem["msg"].removeprefix("Value error, "),
+                }
+                for problem in error.errors()
+            ],
+        }
+    return {"valid": True, "errors": []}
 
 
 # --- Pipelines -----------------------------------------------------------

--- a/tests/test_stub_fixtures.py
+++ b/tests/test_stub_fixtures.py
@@ -51,6 +51,9 @@ EXPECTED_FILES = {
     "error",
     "spectra",
     "pca",
+    # The preprocessing steps' own JSON Schema, which the inspector builds its
+    # parameter forms from (#47) rather than restating the constraints.
+    "step_schema",
 }
 
 

--- a/tests/test_stub_server.py
+++ b/tests/test_stub_server.py
@@ -163,3 +163,28 @@ def test_a_project_can_be_asked_to_look_empty(client: TestClient) -> None:
     """The empty-project state is unreachable from a fixture that has a dataset."""
     assert client.get("/api/projects/p/datasets?empty=true", headers=AUTH).json() == []
     assert client.get("/api/projects/p/datasets", headers=AUTH).json() == fixture("datasets")
+
+
+def test_the_step_schema_is_the_models_own(client: TestClient) -> None:
+    schema = client.get("/api/schema/steps", headers=AUTH).json()
+    kinds = {entry["properties"]["kind"]["const"] for entry in schema["$defs"].values()}
+    assert {"snv", "msc", "savgol", "mean_centre", "autoscale", "normalise"} <= kinds
+    assert schema["$defs"]["SavitzkyGolay"]["properties"]["deriv"]["maximum"] == 2
+
+
+def test_a_step_is_validated_against_the_model_that_will_enforce_it(client: TestClient) -> None:
+    """The cross-field rules have no JSON Schema form, so the model checks them."""
+    good = {"kind": "savgol", "window_length": 11, "polyorder": 2, "deriv": 1}
+    assert client.post("/api/steps/validate", json=good, headers=AUTH).json() == {
+        "valid": True,
+        "errors": [],
+    }
+
+    even = client.post("/api/steps/validate", json={**good, "window_length": 10}, headers=AUTH)
+    body = even.json()
+    assert body["valid"] is False
+    assert body["errors"][0]["message"] == "window_length must be odd"
+
+    bounded = client.post("/api/steps/validate", json={**good, "deriv": 5}, headers=AUTH).json()
+    assert bounded["valid"] is False
+    assert bounded["errors"][0]["field"] == "savgol.deriv"


### PR DESCRIPTION
The right sidebar, and in 1.1 the only place a pipeline parameter is edited.

## The convention this issue set, taken literally

> The form's validation mirrors `models.py` and does not invent rules of its own. Where the two could drift, generate from the schema rather than restating it.

So the forms are **generated from `models.py`'s own JSON Schema** — type, bounds, enum, default and description all come from the same place the backend enforces them. `stub/generate_fixtures.py` writes `step_schema.json`; the server offers it at `GET /api/schema/steps`; `src/inspector/schema.ts` turns it into fields.

**The cross-field rules cannot be generated** — an odd Savitzky-Golay window, `polyorder` below it, `deriv` below that, `start` below `end` all live in `model_validator`, and JSON Schema has no way to say them. Restating them in TypeScript is precisely the drift the convention warns about, so `POST /api/steps/validate` validates the step against `PreprocessStep` itself and the sentence the user reads is the model's own: `window_length must be odd`.

That is the one place the stub server computes anything rather than routing a fixture, and it is deliberate — noted in the handler.

## The rest

- **Editing marks downstream stale** through a pure graph walk (`src/inspector/stale.ts`), and offers a re-run. The results dim and stay readable; they do not vanish, which is the whole reason the state exists.
- **Metrics** as `.kv` rows with tabular numerals; **provenance** collapsed at the foot, hashes truncated in the middle (`sha256:e435…90d7`).
- Context-sensitive: dataset metadata and source for a version, a typed form for a preprocessing node, spec and metrics for an estimator.

## Evidence

`pnpm e2e` 24 passed (4 new), `pnpm test` 41 passed (8 new), `uv run pytest` 486 (3 new). In the browser: `Deriv must be at most 2` comes from the schema and disables Apply; an even window passes the form and is refused by the model; applying a real change to MSC raises the stale banner, increases the stale nodes on the canvas and leaves all 14 in place; Re-run starts a job.

`tests/test_stub_fixtures.py` caught the new fixture not being registered — which is exactly what that test exists for.

Closes #47