### PR TITLE
Build the analysis panels and settle design question 11.1

### DIFF
--- a/design/DESIGN_BRIEF.md
+++ b/design/DESIGN_BRIEF.md
@@ -160,7 +160,11 @@ No mobile or tablet layouts · no marketing or landing page · no onboarding tou
 
 ## 11. Open design questions
 
-1. How do plots coexist within a single analysis tab — a fixed grid, a resizable split, or user-arranged panels?
+**§11.1 is settled.** *How do plots coexist within a single analysis tab?* **A titled panel grid, in one tab** — the answer `AnalysisResults.dc.html` drew and #48 built: scores, loadings, explained variance and diagnostics, each in a 24px-titled panel on `--surface`, two per row at 1440. Not a resizable split and not user-arranged panels: at the design width the grid fits without a scroll, and every panel keeps its title so a screenshot of one is self-describing. The row is laid out so Phase 2's predicted-vs-measured panel arrives beside the others rather than replacing them.
+
+Remaining:
+
+1. ~~How do plots coexist within a single analysis tab?~~ **Settled above.**
 2. When two models are compared, is that a third tab or a split of two existing tabs?
 3. Does the canvas need groups or subgraphs once a project has forty nodes, or is pan/zoom plus the sidebar outline enough?
 4. Where do dataset *versions* appear — as nodes on the canvas, or only in the sidebar tree?

--- a/feature_list.json
+++ b/feature_list.json
@@ -231,7 +231,7 @@
         "app-shell"
       ],
       "user_visible_behavior": "A PCA result opens as one tab holding a scores plot with its Hotelling T2 ellipse, a loadings plot and a scree plot, without becoming a cramped dashboard.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "The scores plot draws the T2 ellipse from the limit in the fixture, not from a value computed in the browser.",
         "Both score axes select their component.",
@@ -242,8 +242,8 @@
         "Numbers align with tabular numerals.",
         "The panel grid matches design/canvas/AnalysisResults.dc.html, which is drawn in the dark palette, and leaves room for the Phase 2 predicted-vs-measured panel rather than a layout that has to be torn up."
       ],
-      "evidence": null,
-      "notes": "Answers open design question DESIGN_BRIEF.md section 11.1 - the artboard shows one tab holding a panel grid. The artboard also shows predicted-vs-measured on a PLS model, which is Phase 2, not this feature."
+      "evidence": "2026-08-24. On feature/48_analysis-results. `pnpm e2e` is 29 passed, 5 of them this feature; `pnpm test` is 48 passed (7 new, the panel traces); Python unchanged at 486; typecheck, lint and build clean. Asserted in the browser: one tab holds Scores, Loadings, Explained variance and Diagnostics as titled panels, with the header reading `PCA 5 components \u00b7 240 \u00d7 100`, PC1 68.9% and cumulative 99.9%; the scores axes read `PC 1 (68.9%)` and `PC 2 (28.4%)` and changing the y axis to PC 3 relabels it `PC 3 (1.6%)`; the loadings axis reads `wavelength_nm (nm)`. The T2 ellipse's semi-axes were read back off the running plot and compared against sqrt(limit * eigenvalue) computed from a fresh fetch of /api/results/pca_a - equal to 9 decimal places, so the ellipse is the server's limit and not a browser statistic. The diagnostics block lists 28 of 240 samples beyond a limit, in cells that computed-style as tabular-nums. Hovering the scores cloud names a sample. DESIGN_BRIEF.md section 11 now records 11.1 as settled. Screenshots in both themes.",
+      "notes": "Nothing is computed here: scores, loadings, variances, T2, SPE and both limits arrive as data. The only arithmetic is the ellipse's points, which is drawing the limit that was sent - the unit test pins it to sqrt(limit * eigenvalue). The explained-variance bars are layout shapes rather than a `bar` trace, because the gl2d bundle carries scatter and scattergl only and a second Plotly bundle for five rectangles would cost about a megabyte; an invisible marker trace carries the hover. A sample beyond a limit is drawn in --stale, off the data palette, because an outlier is a warning rather than a series. The second row is laid out so Phase 2's predicted-vs-measured panel arrives beside Explained variance and Diagnostics rather than replacing them."
     },
     {
       "id": "application-states",

--- a/frontend/e2e/analysis.spec.ts
+++ b/frontend/e2e/analysis.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** The analysis tab: the artboard's panel grid, the T² ellipse drawn from the
+ * served limit, and an outlier that can be hovered to name its sample. */
+
+async function openResults(page: Page) {
+  await page.goto("/?token=e2e-token");
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  await outline.getByRole("button", { name: /PCA 5 PC/ }).first().dblclick();
+  await expect(page.getByTestId("scores-plot")).toBeVisible();
+  await expect(page.locator(".gl-container canvas").first()).toBeVisible();
+}
+
+test("one tab holds the panel grid that answers question 11.1", async ({ page }) => {
+  await openResults(page);
+  for (const panel of ["Scores", "Loadings", "Explained variance", "Diagnostics"]) {
+    await expect(page.getByText(panel, { exact: true })).toBeVisible();
+  }
+  // The headline numbers the artboard puts in the header, in the accent ink.
+  const header = page.getByTestId("analysis-header");
+  await expect(header).toContainText("PCA 5 components · 240 × 100");
+  await expect(header).toContainText("PC1");
+  await expect(header).toContainText("68.9%");
+  await expect(header).toContainText("99.9%");
+});
+
+test("the axes carry their components and the loadings axis its real unit", async ({ page }) => {
+  await openResults(page);
+  await expect(page.getByTestId("scores-plot")).toContainText("PC 1 (68.9%)");
+  await expect(page.getByTestId("scores-plot")).toContainText("PC 2 (28.4%)");
+  await expect(page.getByTestId("loadings-plot")).toContainText("wavelength_nm (nm)");
+
+  await page.getByLabel("Scores y axis").selectOption("2");
+  await expect(page.getByTestId("scores-plot")).toContainText("PC 3 (1.6%)");
+});
+
+test("the ellipse comes from the fixture's limit, not from the browser", async ({ page }) => {
+  await openResults(page);
+  const measured = await page.evaluate(() => {
+    const plot = document.querySelector("[data-testid=scores-plot]") as HTMLElement & {
+      data?: { name?: string; x?: number[]; y?: number[] }[];
+    };
+    const ellipse = (plot.data ?? []).find((trace) => trace.name === "T² limit");
+    return { x: Math.max(...(ellipse?.x ?? [])), y: Math.max(...(ellipse?.y ?? [])) };
+  });
+
+  const served = await page.evaluate(async () => {
+    const response = await fetch("/api/results/pca_a", {
+      headers: { Authorization: `Bearer ${sessionStorage.getItem("token")}` },
+    });
+    const pca = await response.json();
+    return {
+      x: Math.sqrt(pca.diagnostics.hotelling_t2_limit * pca.eigenvalues[0]),
+      y: Math.sqrt(pca.diagnostics.hotelling_t2_limit * pca.eigenvalues[1]),
+    };
+  });
+
+  expect(measured.x).toBeCloseTo(served.x, 9);
+  expect(measured.y).toBeCloseTo(served.y, 9);
+});
+
+test("the diagnostics block lists what the limits put outside, in tabular numerals", async ({
+  page,
+}) => {
+  await openResults(page);
+  await expect(page.getByText("Hotelling T² limit")).toBeVisible();
+  await expect(page.getByText("SPE limit")).toBeVisible();
+
+  const rows = page.locator("table tbody tr");
+  await expect(rows.first()).toBeVisible();
+  const alignment = await page
+    .locator("table td.n")
+    .first()
+    .evaluate((cell) => getComputedStyle(cell).fontVariantNumeric);
+  expect(alignment).toContain("tabular-nums");
+});
+
+test("hovering a score names its sample", async ({ page }) => {
+  await openResults(page);
+  const plot = page.getByTestId("scores-plot");
+  const box = (await plot.boundingBox())!;
+  // Sweep the middle of the cloud until Plotly puts a hover label up.
+  for (let fraction = 0.3; fraction < 0.7; fraction += 0.02) {
+    await page.mouse.move(box.x + box.width * fraction, box.y + box.height * 0.5);
+    if (await page.locator(".hovertext").count()) break;
+  }
+  await expect(page.locator(".hovertext")).toBeVisible();
+  await expect(page.locator(".hovertext")).toContainText(/C\d{3}|E\d{3}/);
+});

--- a/frontend/src/__tests__/analysis.test.ts
+++ b/frontend/src/__tests__/analysis.test.ts
@@ -1,0 +1,119 @@
+/** The analysis panels draw what the kernel computed, and nothing else.
+ *
+ * The rule from #48: nothing is computed in the frontend. Scores, loadings,
+ * variances, T², SPE and both limits arrive as data. The one piece of
+ * arithmetic is turning the limit and the eigenvalues into the points of an
+ * ellipse, which is drawing rather than deciding - and it is checked here
+ * against the limit the fixture carries.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import type { PcaPayload } from "@/api/queries";
+import {
+  ellipseTrace,
+  loadingsTraces,
+  outliers,
+  scoresTrace,
+  varianceFigure,
+} from "@/plot/analysis";
+import type { PlotTheme } from "@/plot/theme";
+
+const FIXTURES = path.resolve(import.meta.dirname, "../../../stub/fixtures");
+const pca = (JSON.parse(readFileSync(path.join(FIXTURES, "pca.json"), "utf8")) as Record<string, PcaPayload>)
+  .pca_a;
+
+const theme: PlotTheme = {
+  ink: "#0F1A18",
+  ink3: "#6E7D79",
+  surface: "#FFFFFF",
+  grid: "#EDF1F0",
+  band: "#CBD7D4",
+  stale: "#9A6206",
+  series: ["#0072B2", "#E69F00", "#009E73", "#CC79A7", "#56B4E9", "#D55E00"],
+  font: "sans",
+  mono: "mono",
+};
+
+describe("the T² ellipse", () => {
+  const ellipse = ellipseTrace(pca, 0, 1, theme);
+
+  it("has the semi-axes the served limit and eigenvalues imply", () => {
+    const limit = pca.diagnostics.hotelling_t2_limit;
+    expect(Math.max(...(ellipse.x as number[]))).toBeCloseTo(
+      Math.sqrt(limit * pca.eigenvalues[0]),
+      10,
+    );
+    expect(Math.max(...(ellipse.y as number[]))).toBeCloseTo(
+      Math.sqrt(limit * pca.eigenvalues[1]),
+      10,
+    );
+  });
+
+  it("closes, so it reads as a boundary rather than an arc", () => {
+    const x = ellipse.x as number[];
+    const y = ellipse.y as number[];
+    expect(x[0]).toBeCloseTo(x.at(-1)!, 12);
+    expect(y[0]).toBeCloseTo(y.at(-1)!, 12);
+  });
+});
+
+describe("the scores plot", () => {
+  const trace = scoresTrace(pca, 0, 1, theme);
+
+  it("plots the components asked for, and names every point", () => {
+    expect(trace.x).toEqual(pca.scores.map((row) => row[0]));
+    expect(trace.y).toEqual(pca.scores.map((row) => row[1]));
+    expect((trace.text as string[])[0]).toBe(pca.samples[0].sample_id);
+    expect(String(trace.hovertemplate)).toContain("%{text}");
+  });
+
+  it("marks a sample beyond the served limit in --stale, off the data palette", () => {
+    const colours = (trace.marker as { color: string[] }).color;
+    pca.diagnostics.hotelling_t2.forEach((value, index) => {
+      const expected = value > pca.diagnostics.hotelling_t2_limit ? theme.stale : theme.series[0];
+      expect(colours[index]).toBe(expected);
+    });
+    expect(colours).toContain(theme.stale);
+  });
+});
+
+it("draws loadings against the axis in its real units", () => {
+  const traces = loadingsTraces(pca, [0, 1], theme);
+  expect(traces).toHaveLength(2);
+  expect(traces[0].x).toEqual(pca.loadings.axis.values);
+  expect(traces[0].y).toEqual(pca.loadings.components[0]);
+  expect(pca.loadings.axis.unit).toBe("nm");
+});
+
+it("shows per-component variance as bars and the cumulative as a line", () => {
+  const { data, shapes } = varianceFigure(pca, theme);
+
+  // The bars are shapes, because the loaded bundle has no bar trace and a
+  // second bundle for five rectangles is not worth a megabyte.
+  expect(shapes).toHaveLength(pca.explained_variance_ratio.length);
+  expect(shapes[0].y1).toBeCloseTo(pca.explained_variance_ratio[0] * 100, 10);
+  expect(shapes[0].y0).toBe(0);
+  expect(shapes[0].fillcolor).toBe(theme.series[0]);
+
+  const cumulative = data[1];
+  expect(cumulative.yaxis).toBe("y2");
+  expect((cumulative.y as number[]).at(-1)).toBeCloseTo(
+    pca.cumulative_explained_variance.at(-1)! * 100,
+    10,
+  );
+});
+
+it("lists exactly the samples the served limits put outside", () => {
+  const beyond = outliers(pca);
+  const expected = pca.samples.filter(
+    (_, index) =>
+      pca.diagnostics.hotelling_t2[index] > pca.diagnostics.hotelling_t2_limit ||
+      pca.diagnostics.spe[index] > pca.diagnostics.spe_limit,
+  );
+  expect(beyond.map((row) => row.sample)).toEqual(expected.map((sample) => sample.sample_id));
+  expect(beyond.length).toBeGreaterThan(0);
+  expect(beyond.length).toBeLessThan(pca.n_samples);
+});

--- a/frontend/src/__tests__/traces.test.ts
+++ b/frontend/src/__tests__/traces.test.ts
@@ -24,6 +24,7 @@ const theme: PlotTheme = {
   surface: "#FFFFFF",
   grid: "#EDF1F0",
   band: "#CBD7D4",
+  stale: "#9A6206",
   series: ["#0072B2", "#E69F00", "#009E73", "#CC79A7", "#56B4E9", "#D55E00"],
   font: "sans",
   mono: "mono",

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -132,6 +132,33 @@ export interface SpectraPayload {
   band: { n_spectra: number; y_lower: number[]; y_median: number[]; y_upper: number[] };
 }
 
+/** One estimator node's results. Every number is the kernel's: scores,
+ * loadings, variances, T², SPE and both limits arrive as data. */
+export interface PcaPayload {
+  node_id: string;
+  task: string;
+  n_components: number;
+  n_samples: number;
+  n_variables: number;
+  rank: number;
+  samples: { index: number; sample_id: string }[];
+  scores: number[][];
+  loadings: {
+    axis: { kind: string; unit: string | null; values: number[] };
+    components: number[][];
+  };
+  eigenvalues: number[];
+  explained_variance_ratio: number[];
+  cumulative_explained_variance: number[];
+  diagnostics: {
+    hotelling_t2: number[];
+    hotelling_t2_limit: number;
+    spe: number[];
+    spe_limit: number;
+    alpha: number;
+  };
+}
+
 export interface Job {
   job_id: string;
   experiment_id: string;
@@ -215,6 +242,15 @@ export function useSpectra(nodeId: string | undefined) {
     enabled: Boolean(nodeId),
     // The decimated payload is the largest thing crossing the wire; holding it
     // means switching between two nodes does not refetch either.
+    staleTime: Infinity,
+  });
+}
+
+export function useResults(nodeId: string | undefined) {
+  return useQuery({
+    queryKey: ["results", nodeId],
+    queryFn: () => api<PcaPayload>(`/results/${nodeId}`),
+    enabled: Boolean(nodeId),
     staleTime: Infinity,
   });
 }

--- a/frontend/src/plot/analysis.ts
+++ b/frontend/src/plot/analysis.ts
@@ -1,0 +1,122 @@
+import type { PcaPayload } from "@/api/queries";
+
+import type { PlotTheme } from "./theme";
+
+/** Traces for the analysis panels. Pure, and tested.
+ *
+ * Nothing here computes a statistic. Scores, loadings, variances, T², SPE and
+ * both limits arrive as data; the only arithmetic is turning the limit and the
+ * eigenvalues the server sent into the points of an ellipse, which is drawing,
+ * not deciding.
+ */
+
+export function scoresTrace(pca: PcaPayload, x: number, y: number, theme: PlotTheme) {
+  return {
+    type: "scattergl",
+    mode: "markers",
+    x: pca.scores.map((row) => row[x]),
+    y: pca.scores.map((row) => row[y]),
+    text: pca.samples.map((sample) => sample.sample_id),
+    marker: {
+      size: 5,
+      color: pca.diagnostics.hotelling_t2.map((value) =>
+        // Beyond the limit the server sent, a sample is drawn in --stale: an
+        // outlier is a warning, not a data series.
+        value > pca.diagnostics.hotelling_t2_limit ? theme.stale : theme.series[0],
+      ),
+    },
+    hovertemplate: "%{text}<br>%{x:.3f} · %{y:.3f}<extra></extra>",
+  };
+}
+
+/** The Hotelling T² ellipse, drawn from the limit and the eigenvalues in the
+ * payload. `t²  = Σ tᵢ²/λᵢ ≤ limit` is an ellipse with semi-axes
+ * `√(limit · λᵢ)`; every number in that comes off the wire. */
+export function ellipseTrace(pca: PcaPayload, x: number, y: number, theme: PlotTheme) {
+  const limit = pca.diagnostics.hotelling_t2_limit;
+  const a = Math.sqrt(limit * pca.eigenvalues[x]);
+  const b = Math.sqrt(limit * pca.eigenvalues[y]);
+  const points = Array.from({ length: 121 }, (_, index) => (index / 120) * 2 * Math.PI);
+  return {
+    type: "scattergl",
+    mode: "lines",
+    x: points.map((angle) => a * Math.cos(angle)),
+    y: points.map((angle) => b * Math.sin(angle)),
+    line: { width: 1, color: theme.ink3, dash: "dot" },
+    hoverinfo: "skip",
+    name: "T² limit",
+  };
+}
+
+export function loadingsTraces(pca: PcaPayload, components: number[], theme: PlotTheme) {
+  return components.map((component) => ({
+    type: "scattergl",
+    mode: "lines",
+    x: pca.loadings.axis.values,
+    y: pca.loadings.components[component],
+    line: { width: 1.3, color: theme.series[component % theme.series.length] },
+    name: `PC ${component + 1}`,
+    hovertemplate: `PC ${component + 1}<br>%{x:.1f} · %{y:.4f}<extra></extra>`,
+  }));
+}
+
+/** Per-component variance as bars, cumulative as a line.
+ *
+ * The bars are layout shapes rather than a `bar` trace: the WebGL bundle this
+ * project loads carries scatter and scattergl and nothing else, and a second
+ * bundle for five rectangles would be a megabyte for a shape. The invisible
+ * marker trace over them is what carries the hover readout.
+ */
+export function varianceFigure(pca: PcaPayload, theme: PlotTheme) {
+  const labels = pca.explained_variance_ratio.map((_, index) => `PC${index + 1}`);
+  const percent = pca.explained_variance_ratio.map((value) => value * 100);
+  return {
+    data: [
+      {
+        type: "scattergl",
+        mode: "markers",
+        x: labels,
+        y: percent,
+        marker: { size: 1, color: theme.series[0], opacity: 0 },
+        hovertemplate: "%{x}<br>%{y:.2f}%<extra></extra>",
+      },
+      {
+        type: "scattergl",
+        mode: "lines+markers",
+        x: labels,
+        y: pca.cumulative_explained_variance.map((value) => value * 100),
+        line: { width: 1.3, color: theme.ink3 },
+        marker: { size: 4, color: theme.ink3 },
+        yaxis: "y2",
+        hovertemplate: "cumulative %{y:.2f}%<extra></extra>",
+      },
+    ],
+    shapes: percent.map((value, index) => ({
+      type: "rect",
+      xref: "x",
+      yref: "y",
+      x0: index - 0.32,
+      x1: index + 0.32,
+      y0: 0,
+      y1: value,
+      line: { width: 0 },
+      fillcolor: theme.series[0],
+      layer: "below",
+    })),
+  };
+}
+
+/** Which samples the server's own limits put outside. Comparison, not
+ * statistics: both limits arrived with the payload. */
+export function outliers(pca: PcaPayload): { sample: string; t2: number; spe: number }[] {
+  return pca.samples
+    .map((sample, index) => ({
+      sample: sample.sample_id,
+      t2: pca.diagnostics.hotelling_t2[index],
+      spe: pca.diagnostics.spe[index],
+    }))
+    .filter(
+      (row) =>
+        row.t2 > pca.diagnostics.hotelling_t2_limit || row.spe > pca.diagnostics.spe_limit,
+    );
+}

--- a/frontend/src/plot/theme.ts
+++ b/frontend/src/plot/theme.ts
@@ -12,6 +12,9 @@ export interface PlotTheme {
   surface: string;
   grid: string;
   band: string;
+  /** Semantic, and deliberately off the data palette: an outlier is a warning,
+   * never a series. */
+  stale: string;
   series: string[];
   font: string;
   mono: string;
@@ -26,6 +29,7 @@ export function readTheme(element: HTMLElement): PlotTheme {
     surface: token("surface"),
     grid: token("grid"),
     band: token("band"),
+    stale: token("stale"),
     series: ["d1", "d2", "d3", "d4", "d5", "d6"].map(token),
     font: "'IBM Plex Sans', system-ui, sans-serif",
     mono: "'IBM Plex Mono', ui-monospace, monospace",

--- a/frontend/src/screens/analysis/AnalysisResults.tsx
+++ b/frontend/src/screens/analysis/AnalysisResults.tsx
@@ -1,0 +1,326 @@
+import Plotly from "plotly.js-gl2d-dist-min";
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { useResults, type PcaPayload } from "@/api/queries";
+import {
+  ellipseTrace,
+  loadingsTraces,
+  outliers,
+  scoresTrace,
+  varianceFigure,
+} from "@/plot/analysis";
+import { PLOT_CONFIG, axisLayout, baseLayout, readTheme } from "@/plot/theme";
+import { Panel } from "@/screens/analysis/Panel";
+
+/** One analysis tab, a grid of titled panels - the artboard's answer to open
+ * design question 11.1, and the layout Phase 2's predicted-vs-measured panel
+ * drops into rather than one that has to be torn up.
+ *
+ * Nothing here is computed. Scores, loadings, variances, T², SPE and both
+ * limits arrive as data; the ellipse is drawn from the limit the server sent.
+ */
+
+function usePlot(
+  build: (theme: ReturnType<typeof readTheme>) => {
+    data: Record<string, unknown>[];
+    layout: Record<string, unknown>;
+  },
+  deps: unknown[],
+) {
+  const host = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const element = host.current;
+    if (!element) return;
+    const theme = readTheme(element);
+    const { data, layout } = build(theme);
+    void Plotly.react(element, data, { ...baseLayout(theme), ...layout }, PLOT_CONFIG);
+    return () => Plotly.purge(element);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+  return host;
+}
+
+function Scores({ pca }: { pca: PcaPayload }) {
+  const [x, setX] = useState(0);
+  const [y, setY] = useState(1);
+  const host = usePlot(
+    (theme) => ({
+      data: [ellipseTrace(pca, x, y, theme), scoresTrace(pca, x, y, theme)],
+      layout: {
+        xaxis: axisLayout(theme, `PC ${x + 1} (${(pca.explained_variance_ratio[x] * 100).toFixed(1)}%)`),
+        yaxis: axisLayout(theme, `PC ${y + 1} (${(pca.explained_variance_ratio[y] * 100).toFixed(1)}%)`),
+        margin: { l: 48, r: 12, t: 8, b: 38 },
+      },
+    }),
+    [pca, x, y],
+  );
+
+  const choose = (value: number, onChange: (value: number) => void, label: string) => (
+    <select
+      aria-label={label}
+      className="mono"
+      value={value}
+      onChange={(event) => onChange(Number(event.target.value))}
+      style={{
+        height: 18,
+        borderRadius: 3,
+        border: "1px solid var(--rule)",
+        background: "var(--surface)",
+        color: "var(--ink2)",
+        font: "inherit",
+        fontSize: 9.5,
+      }}
+    >
+      {pca.explained_variance_ratio.map((_, index) => (
+        <option key={index} value={index}>
+          PC {index + 1}
+        </option>
+      ))}
+    </select>
+  );
+
+  return (
+    <Panel
+      title="Scores"
+      note={
+        <span style={{ display: "flex", alignItems: "center", gap: 4 }}>
+          {choose(x, setX, "Scores x axis")}
+          {choose(y, setY, "Scores y axis")}
+          <span className="mono" style={{ fontSize: 9.5, color: "var(--ink3)" }}>
+            Hotelling T² {Math.round((1 - pca.diagnostics.alpha) * 100)}%
+          </span>
+        </span>
+      }
+    >
+      <div ref={host} data-testid="scores-plot" style={{ flex: 1, minHeight: 0 }} />
+    </Panel>
+  );
+}
+
+function Loadings({ pca }: { pca: PcaPayload }) {
+  const [count, setCount] = useState(2);
+  const components = Array.from({ length: count }, (_, index) => index);
+  const host = usePlot(
+    (theme) => ({
+      data: loadingsTraces(pca, components, theme),
+      layout: {
+        xaxis: axisLayout(theme, `${pca.loadings.axis.kind} (${pca.loadings.axis.unit ?? ""})`),
+        yaxis: axisLayout(theme, "Loading"),
+        margin: { l: 48, r: 12, t: 8, b: 38 },
+      },
+    }),
+    [pca, count],
+  );
+
+  return (
+    <Panel
+      title="Loadings"
+      note={
+        <select
+          aria-label="Loadings components"
+          className="mono"
+          value={count}
+          onChange={(event) => setCount(Number(event.target.value))}
+          style={{
+            height: 18,
+            borderRadius: 3,
+            border: "1px solid var(--rule)",
+            background: "var(--surface)",
+            color: "var(--ink2)",
+            font: "inherit",
+            fontSize: 9.5,
+          }}
+        >
+          {[1, 2, 3, 5].map((value) => (
+            <option key={value} value={value}>
+              PC 1–{value}
+            </option>
+          ))}
+        </select>
+      }
+    >
+      <div ref={host} data-testid="loadings-plot" style={{ flex: 1, minHeight: 0 }} />
+    </Panel>
+  );
+}
+
+function Variance({ pca }: { pca: PcaPayload }) {
+  const host = usePlot(
+    (theme) => {
+      const figure = varianceFigure(pca, theme);
+      return {
+      data: figure.data,
+      layout: {
+        shapes: figure.shapes,
+        xaxis: axisLayout(theme, "Component"),
+        yaxis: { ...axisLayout(theme, "Explained (%)"), rangemode: "tozero" },
+        yaxis2: {
+          ...axisLayout(theme, "Cumulative (%)"),
+          overlaying: "y",
+          side: "right",
+          range: [0, 105],
+        },
+        margin: { l: 44, r: 42, t: 8, b: 38 },
+      },
+      };
+    },
+    [pca],
+  );
+  const cumulative = pca.cumulative_explained_variance.at(-1)! * 100;
+  return (
+    <Panel title="Explained variance" note={`cumulative ${cumulative.toFixed(1)}%`} width={340}>
+      <div ref={host} data-testid="variance-plot" style={{ flex: 1, minHeight: 0 }} />
+    </Panel>
+  );
+}
+
+function Diagnostics({ pca }: { pca: PcaPayload }) {
+  const beyond = outliers(pca);
+  const { diagnostics } = pca;
+  return (
+    <Panel title="Diagnostics" note={`α = ${diagnostics.alpha}`}>
+      <div style={{ padding: "6px 0", borderBottom: "1px solid var(--rule2)" }}>
+        <div className="kv">
+          <b>Hotelling T² limit</b>
+          <span>{diagnostics.hotelling_t2_limit.toFixed(4)}</span>
+        </div>
+        <div className="kv">
+          <b>SPE limit</b>
+          <span>{diagnostics.spe_limit.toExponential(3)}</span>
+        </div>
+        <div className="kv">
+          <b>Rank</b>
+          <span>{pca.rank}</span>
+        </div>
+        <div className="kv">
+          <b>Beyond a limit</b>
+          <span>
+            {beyond.length} of {pca.n_samples}
+          </span>
+        </div>
+      </div>
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        <table>
+          <thead>
+            <tr>
+              <th style={{ width: 74 }}>Sample</th>
+              <th className="n">T²</th>
+              <th className="n">SPE</th>
+            </tr>
+          </thead>
+          <tbody>
+            {beyond.slice(0, 40).map((row) => (
+              <tr key={row.sample}>
+                <td className="mono" style={{ color: "var(--ink)" }}>
+                  {row.sample}
+                </td>
+                <td
+                  className="n"
+                  style={
+                    row.t2 > diagnostics.hotelling_t2_limit ? { color: "var(--stale)" } : undefined
+                  }
+                >
+                  {row.t2.toFixed(3)}
+                </td>
+                <td
+                  className="n"
+                  style={row.spe > diagnostics.spe_limit ? { color: "var(--stale)" } : undefined}
+                >
+                  {row.spe.toExponential(2)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Panel>
+  );
+}
+
+export function AnalysisResults({ nodeId, title }: { nodeId: string; title: string }) {
+  const results = useResults(nodeId);
+
+  if (!results.data) {
+    return (
+      <div className="pane">
+        <div className="empty" style={{ padding: 16 }}>
+          Loading results…
+        </div>
+      </div>
+    );
+  }
+
+  const pca = results.data;
+  return (
+    <div className="pane">
+      <div
+        data-testid="analysis-header"
+        style={{
+          height: 52,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0 14px",
+          borderBottom: "1px solid var(--rule2)",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
+          <span style={{ fontWeight: 600, fontSize: 13.5 }}>{title}</span>
+          <span className="mono" style={{ fontSize: 11, color: "var(--ink3)" }}>
+            PCA {pca.n_components} components · {pca.n_samples} × {pca.n_variables}
+          </span>
+        </div>
+        <div style={{ display: "flex", alignItems: "stretch" }}>
+          {[
+            ["PC1", `${(pca.explained_variance_ratio[0] * 100).toFixed(1)}%`],
+            ["CUMULATIVE", `${(pca.cumulative_explained_variance.at(-1)! * 100).toFixed(1)}%`],
+          ].map(([label, value]) => (
+            <div
+              key={label}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: 1,
+                padding: "0 11px",
+                borderLeft: "1px solid var(--rule2)",
+              }}
+            >
+              <span className="ilabel" style={{ fontSize: 9 }}>
+                {label}
+              </span>
+              <span
+                className="mono"
+                style={{ fontSize: 14, fontWeight: 600, color: "var(--accentInk)" }}
+              >
+                {value}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          padding: "12px 14px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+        }}
+      >
+        <div style={{ display: "flex", gap: 12, flex: 1, minHeight: 0 }}>
+          <Scores pca={pca} />
+          <Loadings pca={pca} />
+        </div>
+        <div style={{ display: "flex", gap: 12, flex: 1, minHeight: 0 }}>
+          <Variance pca={pca} />
+          <Diagnostics pca={pca} />
+          {/* Predicted vs measured belongs here, and is Phase 2. The row is
+              laid out so it arrives beside these rather than replacing them. */}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/analysis/Panel.tsx
+++ b/frontend/src/screens/analysis/Panel.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+
+/** The artboard's panel: a 24px title bar with the name left and a mono note
+ * right, over a bordered surface. The grid of these is the answer to open
+ * design question 11.1 - one analysis tab, several titled panels. */
+export function Panel({
+  title,
+  note,
+  width,
+  height,
+  children,
+}: {
+  title: string;
+  note?: ReactNode;
+  width?: number | string;
+  height?: number;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      style={{
+        width: width ?? "auto",
+        height,
+        flex: width ? "none" : 1,
+        minWidth: 0,
+        border: "1px solid var(--rule2)",
+        borderRadius: 4,
+        background: "var(--surface)",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          height: 24,
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+          padding: "0 9px",
+          borderBottom: "1px solid var(--rule2)",
+        }}
+      >
+        <span style={{ fontSize: 11, fontWeight: 600 }}>{title}</span>
+        {typeof note === "string" ? (
+          <span className="mono" style={{ fontSize: 9.5, color: "var(--ink3)" }}>
+            {note}
+          </span>
+        ) : (
+          note
+        )}
+      </div>
+      <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -17,6 +17,7 @@ import { DatasetView } from "@/screens/DatasetView";
 import { EmptyProject } from "@/screens/EmptyProject";
 import { Import } from "@/screens/Import";
 import { PipelineCanvas } from "@/canvas/PipelineCanvas";
+import { AnalysisResults } from "@/screens/analysis/AnalysisResults";
 import { SpectraView } from "@/screens/SpectraView";
 import { Inspector } from "@/shell/Inspector";
 import { Sidebar } from "@/shell/Sidebar";
@@ -81,6 +82,7 @@ function Pane({
 
   if (tab?.kind === "pipeline") return <PipelineCanvas onOpenNode={onOpenNode} />;
   if (tab?.kind === "spectra") return <SpectraView nodeId={tab.id} title={tab.title} />;
+  if (tab?.kind === "results") return <AnalysisResults nodeId={tab.id} title={tab.title} />;
 
   const found = datasets
     ?.flatMap((entry) => entry.versions.map((version) => ({ entry, version })))


### PR DESCRIPTION
The PCA output the sub-phase's exit criterion ends on: **one tab, a grid of titled panels** — scores, loadings, explained variance, diagnostics. `DESIGN_BRIEF.md` §11 now records **§11.1 as settled** rather than open, with the reasoning: at 1440 the grid fits without a scroll and every panel keeps its title, so a screenshot of one is self-describing. The second row is laid out so Phase 2's predicted-vs-measured panel arrives *beside* these rather than replacing them.

## Nothing is computed in the frontend

Scores, loadings, variances, T², SPE and both limits arrive as data. The only arithmetic is turning the served limit and eigenvalues into the points of the ellipse — drawing, not deciding — and the e2e pins it honestly: it reads the ellipse's semi-axes back off the running plot and compares them against `√(limit · λ)` from a **fresh fetch** of `/api/results/pca_a`. Equal to 9 decimal places. A statistic computed in the browser fails that test.

## The panels

- Both scores axes are selectable and label their component's share — `PC 1 (68.9%)`, and `PC 3 (1.6%)` after switching.
- Loadings against the wavelength axis in nanometres, 1–5 components.
- A sample beyond a served limit is drawn in `--stale`, off the data palette: an outlier is a warning, not a series.
- Diagnostics lists what the limits put outside (28 of 240) in tabular numerals, with both limits stated above it.
- Hovering a score names its sample.

## One implementation note

The explained-variance bars are **layout shapes**, not a `bar` trace: the gl2d bundle carries scatter and scattergl only, and pulling a second Plotly bundle in for five rectangles would cost about a megabyte. An invisible marker trace carries the hover readout. This was caught by looking at the rendered screen — the `bar` trace had been silently degrading to a line.

## Evidence

`pnpm e2e` 29 passed (5 new), `pnpm test` 48 passed (7 new), `uv run pytest` 486, typecheck / lint / build clean.

Closes #48