### PR TITLE
Enter all six application states against the server

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -258,7 +258,7 @@
         "analysis-results"
       ],
       "user_visible_behavior": "Empty, importing, running, stale, failed and overloaded each have a designed state rather than a blank screen or a spinner.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "A running job shows progress in the node, the tab and the status bar at the same time.",
         "A running job can be cancelled and nothing else is blocked while it runs.",
@@ -269,8 +269,8 @@
         "Each of the six is reachable from the fixture harness and screenshotted.",
         "Running and stale match the encodings drawn in PipelineCanvas.dc.html and stated in canvas.json's states annotation."
       ],
-      "evidence": null,
-      "notes": "Given its own issue because it is spread across every screen and is therefore the first thing to get skipped. Running and stale are drawn; importing, screen-level failed and overloaded are not, and inherit the fail and stale tokens that exist in both palettes for exactly that."
+      "evidence": "2026-08-24. On feature/49_application-states. `pnpm e2e` is 35 passed, 6 of them one per state, each entered against the stub server rather than from a hard-coded flag; `pnpm test` is 52 passed (4 new, the envelope); Python 487 passed (1 new, the oversize knob). Twelve screenshots taken, each of the six states in both themes. Running: the status bar, the tab and the node carry the same job at once, and cancelling stops it and clears the tab's progress. Failed: `?failrun` takes the server's failing sequence and the banner reads RUN FAILED with the rank-4 message and no traceback; the test also reads --fail and --d1..--d6 off the running application and asserts they are disjoint, so a failing thing can never be a red spectrum. Stale: applying a parameter change dims downstream nodes - computed style is a dashed border over a 135deg hatch at opacity below 1 - and all 14 nodes remain. Overloaded: `?oversize` reports the dataset as 42,000 x 6,200 and the spectra tab states `BEYOND THE V1 ENVELOPE`, `42,000 \u00d7 6,200`, `about 320 MB`, draws no plot at all, and the rest of the application stays responsive. Empty and importing were re-checked against the others.",
+      "notes": "The envelope numbers come from PROPOSAL.md section 13 and live in src/states/envelope.ts: 20,000 x 4,000 float32 is 320 MB, and the message names which bound was crossed rather than saying 'too big'. Past it the spectra view returns before any hook or query runs - preparing a plot of eighty million points is the freeze the state exists to avoid. `?oversize` on the datasets endpoint rewrites only the declared shape, so no 320 MB fixture enters git and no array is fabricated. With `?empty`, `?fail=true` and `?failrun` that makes four 1.1-only affordances, all of which go in 1.2 where a truncated file, a rank-deficient matrix and a genuinely large dataset reach these states on their own."
     },
     {
       "id": "e2e-walkthrough",

--- a/frontend/e2e/states.spec.ts
+++ b/frontend/e2e/states.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** The six application states from DESIGN_BRIEF.md section 8, each entered
+ * against the stub server rather than by editing code. A state that can only
+ * be reached from a hard-coded flag is a state nobody tests.
+ */
+
+async function app(page: Page, flags = "") {
+  await page.goto(`/?token=e2e-token${flags}`);
+  await expect(page.getByText("Tecator meat study")).toBeVisible();
+}
+
+test("empty: a project with nothing in it offers the one action that matters", async ({ page }) => {
+  await app(page, "&empty");
+  await expect(page.getByRole("heading", { name: "This project is empty" })).toBeVisible();
+});
+
+test("importing: the preview states what was read before anything is committed", async ({
+  page,
+}) => {
+  await app(page);
+  await page.getByRole("button", { name: "Import…" }).click();
+  await page.getByRole("button", { name: "Use the example file" }).click();
+  await expect(page.getByText("tecator.txt")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Import 240 × 100/ })).toBeVisible();
+});
+
+test("running: one job, three places, and cancel stops it", async ({ page }) => {
+  await app(page);
+  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
+  await page.getByRole("button", { name: "Run pipeline" }).click();
+
+  // The status bar, the tab and the node all carry the same run.
+  const status = page.getByRole("status").first();
+  await expect(status).toContainText(/Queued|Preprocessing/);
+  await expect(page.getByTestId("tab-progress")).toBeVisible();
+  await expect(page.getByTestId("node-running").locator(".prog i")).toBeVisible();
+
+  await expect(status).toContainText("Preprocessing: SNV", { timeout: 6000 });
+  await status.getByRole("button", { name: "Cancel" }).click();
+  await expect(status).toContainText("Cancelled");
+  await expect(page.getByTestId("tab-progress")).toHaveCount(0);
+});
+
+test("failed: the run names its cause and shows no trace", async ({ page }) => {
+  await app(page, "&failrun");
+  await page.getByRole("button", { name: "Run pipeline" }).click();
+
+  const failure = page.getByTestId("run-failed");
+  await expect(failure).toBeVisible({ timeout: 15000 });
+  await expect(failure).toContainText("RUN FAILED");
+  await expect(failure).toContainText("matrix of rank 4");
+  await expect(failure).not.toContainText("Traceback");
+
+  // --fail is semantic and separate from the data palette on purpose: a
+  // failing thing must never read as a red spectrum.
+  const colours = await page.evaluate(() => {
+    const style = getComputedStyle(document.querySelector(".app")!);
+    return {
+      fail: style.getPropertyValue("--fail").trim(),
+      series: ["d1", "d2", "d3", "d4", "d5", "d6"].map((token) =>
+        style.getPropertyValue(`--${token}`).trim(),
+      ),
+    };
+  });
+  expect(colours.series).not.toContain(colours.fail);
+});
+
+test("stale: downstream dims and stays, with a re-run offered", async ({ page }) => {
+  await app(page);
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  await outline.getByRole("button", { name: /^MSC/ }).first().dblclick();
+  const inspector = page.getByRole("complementary", { name: "Inspector" });
+  await inspector.getByLabel("Reference").selectOption("median");
+  await inspector.getByRole("button", { name: "Apply" }).click();
+
+  await expect(page.getByText("Downstream results are stale.")).toBeVisible();
+  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
+
+  const stale = page.getByTestId("node-stale").first();
+  await expect(stale).toBeVisible();
+  // The artboard's encoding: dashed border over a 135 degree hatch, and a
+  // footer saying why. Dimmed, not deleted.
+  const drawn = await stale.evaluate((element) => {
+    const style = getComputedStyle(element);
+    return {
+      border: style.borderTopStyle,
+      hatch: style.backgroundImage,
+      opacity: Number(style.opacity),
+    };
+  });
+  expect(drawn.border).toBe("dashed");
+  expect(drawn.hatch).toContain("135deg");
+  expect(drawn.opacity).toBeLessThan(1);
+  await expect(page.locator(".react-flow__node")).toHaveCount(14);
+});
+
+test("overloaded: past the envelope the limit is stated, not hidden", async ({ page }) => {
+  await app(page, "&oversize");
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  await outline.getByRole("button", { name: /^SNV/ }).first().dblclick();
+
+  const notice = page.getByTestId("overloaded");
+  await expect(notice).toBeVisible();
+  await expect(notice).toContainText("BEYOND THE V1 ENVELOPE");
+  await expect(notice).toContainText("42,000 × 6,200");
+  await expect(notice).toContainText("about 320 MB");
+
+  // Nothing was plotted, which is the point: the tab is responsive.
+  await expect(page.getByTestId("spectra-plot")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Import…" })).toBeEnabled();
+});

--- a/frontend/src/__tests__/envelope.test.ts
+++ b/frontend/src/__tests__/envelope.test.ts
@@ -1,0 +1,33 @@
+/** The envelope from PROPOSAL.md section 13, and the sentence it produces.
+ *
+ * The point of this state is honesty: a dataset past the limit gets told so,
+ * with numbers, rather than a plot that freezes the tab.
+ */
+import { describe, expect, it } from "vitest";
+
+import { checkEnvelope, envelopeSentence, ENVELOPE } from "@/states/envelope";
+
+describe("the envelope", () => {
+  it("admits the target dataset the proposal names", () => {
+    expect(checkEnvelope(ENVELOPE.spectra, ENVELOPE.variables).within).toBe(true);
+    expect(checkEnvelope(240, 100).within).toBe(true);
+  });
+
+  it("names which bound was crossed rather than saying 'too big'", () => {
+    expect(checkEnvelope(42_000, 100).exceeded).toEqual(["spectra"]);
+    expect(checkEnvelope(240, 6_200).exceeded).toEqual(["variables"]);
+    expect(checkEnvelope(42_000, 6_200).exceeded).toEqual(["spectra", "variables", "memory"]);
+  });
+
+  it("reports float32 megabytes, which is the number that matters", () => {
+    // 20,000 x 4,000 x 4 bytes is the proposal's ~320 MB.
+    expect(checkEnvelope(ENVELOPE.spectra, ENVELOPE.variables).megabytes).toBe(320);
+  });
+
+  it("states the limit in a sentence a user can act on", () => {
+    const sentence = envelopeSentence(42_000, 6_200);
+    expect(sentence).toContain("42,000 × 6,200");
+    expect(sentence).toContain("about 320 MB");
+    expect(sentence).toMatch(/1,041 MB|1,042 MB/);
+  });
+});

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -175,10 +175,13 @@ export function useProjects() {
  * with no datasets, which is how the empty-project state (#44) is reached
  * without editing code. In 1.2 a new project is simply empty. */
 export function useDatasets(projectId: string | undefined) {
-  const empty = new URLSearchParams(window.location.search).has("empty");
+  const flags = new URLSearchParams(window.location.search);
+  const empty = flags.has("empty");
+  const oversize = flags.has("oversize");
+  const query = empty ? "?empty=true" : oversize ? "?oversize=true" : "";
   return useQuery({
-    queryKey: ["datasets", projectId, empty],
-    queryFn: () => api<DatasetEntry[]>(`/projects/${projectId}/datasets${empty ? "?empty=true" : ""}`),
+    queryKey: ["datasets", projectId, query],
+    queryFn: () => api<DatasetEntry[]>(`/projects/${projectId}/datasets${query}`),
     enabled: Boolean(projectId),
   });
 }

--- a/frontend/src/screens/SpectraView.tsx
+++ b/frontend/src/screens/SpectraView.tsx
@@ -4,6 +4,8 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useSpectra, type SpectraPayload } from "@/api/queries";
 import { PLOT_CONFIG, axisLayout, baseLayout, readTheme } from "@/plot/theme";
 import { bandTraces, spectraTraces } from "@/plot/traces";
+import { Overloaded } from "@/states/Overloaded";
+import { checkEnvelope } from "@/states/envelope";
 
 /** The most-looked-at screen in the product.
  *
@@ -129,7 +131,32 @@ function Segmented({
   );
 }
 
-export function SpectraView({ nodeId, title }: { nodeId: string; title: string }) {
+/** The guard sits outside the view rather than inside it: past the envelope
+ * there is no plot to prepare, and preparing one anyway - hooks, queries, a
+ * megabyte of payload - is the freeze this state exists to avoid. */
+export function SpectraView({
+  nodeId,
+  title,
+  samples,
+  variables,
+}: {
+  nodeId: string;
+  title: string;
+  samples?: number;
+  variables?: number;
+}) {
+  if (samples && variables && !checkEnvelope(samples, variables).within) {
+    return (
+      <div className="pane">
+        <Overloaded samples={samples} variables={variables} what="The spectra plot" />
+      </div>
+    );
+  }
+  return <SpectraPlotView nodeId={nodeId} title={title} />;
+}
+
+function SpectraPlotView({ nodeId, title }: { nodeId: string; title: string }) {
+
   const [layer, setLayer] = useState<Layer>("both");
   const [selected, setSelected] = useState<number[]>([]);
 

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -81,7 +81,17 @@ function Pane({
   }
 
   if (tab?.kind === "pipeline") return <PipelineCanvas onOpenNode={onOpenNode} />;
-  if (tab?.kind === "spectra") return <SpectraView nodeId={tab.id} title={tab.title} />;
+  if (tab?.kind === "spectra") {
+    const shape = datasets?.[0]?.versions.at(-1);
+    return (
+      <SpectraView
+        nodeId={tab.id}
+        title={tab.title}
+        samples={shape?.n_samples}
+        variables={shape?.n_variables}
+      />
+    );
+  }
   if (tab?.kind === "results") return <AnalysisResults nodeId={tab.id} title={tab.title} />;
 
   const found = datasets
@@ -142,6 +152,12 @@ export function Shell() {
   const experiment = useExperiment();
 
   const [staleFrom, setStaleFrom] = useState<string | null>(null);
+  const [dismissedFailure, setDismissedFailure] = useState(false);
+  /** `?failrun` makes the next run take the stub server's failing sequence.
+   * Like `?empty` and `?oversize`, it exists because a state that can only be
+   * reached by editing code is a state nobody tests. All three go in 1.2,
+   * where a rank-deficient matrix fails on its own. */
+  const failNext = new URLSearchParams(window.location.search).has("failrun");
   const [jobId, setJobId] = useState<string | null>(null);
   const [startedAt, setStartedAt] = useState<number | null>(null);
   const job = useJob(jobId);
@@ -261,7 +277,8 @@ export function Shell() {
           <button
             className="btn btn-p"
             onClick={async () => {
-              const started = await run.mutateAsync({});
+              setDismissedFailure(false);
+              const started = await run.mutateAsync({ fail: failNext });
               setJobId(started.job_id);
               setStartedAt(Date.now());
             }}
@@ -291,12 +308,48 @@ export function Shell() {
             tabs={state.tabs}
             activeId={state.activeId}
             splitId={state.splitId}
+            progress={
+              job.data && (job.data.status === "running" || job.data.status === "queued")
+                ? { tabId: "pipeline", value: job.data.progress }
+                : null
+            }
             onActivate={(id) => dispatch({ type: "activate", id })}
             onPin={(id) => dispatch({ type: "pin", id })}
             onClose={(id) => dispatch({ type: "close", id })}
             onMove={(from, to) => dispatch({ type: "move", from, to })}
             onSplit={(id) => dispatch({ type: "split", id })}
           />
+          {job.data?.status === "failed" && !dismissedFailure ? (
+            <div
+              role="alert"
+              data-testid="run-failed"
+              style={{
+                margin: 12,
+                padding: "10px 12px",
+                borderRadius: 3,
+                border: "1px solid var(--fail)",
+                background: "var(--failSoft)",
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                <span className="mono" style={{ fontSize: 10, color: "var(--fail)" }}>
+                  RUN FAILED
+                </span>
+                <button
+                  className="tabx"
+                  aria-label="Dismiss failure"
+                  style={{ marginLeft: "auto" }}
+                  onClick={() => setDismissedFailure(true)}
+                >
+                  ×
+                </button>
+              </div>
+              {/* The message the server sent, which names the cause. There is
+                  no traceback to show and never should be. */}
+              <p style={{ margin: "4px 0 0", color: "var(--ink)" }}>{job.data.message}</p>
+            </div>
+          ) : null}
+
           {noDatasets && !activeTab ? (
             <EmptyProject onImport={openImport} />
           ) : state.splitId ? (

--- a/frontend/src/shell/TabStrip.tsx
+++ b/frontend/src/shell/TabStrip.tsx
@@ -20,6 +20,10 @@ interface Props {
   tabs: Tab[];
   activeId: string | null;
   splitId: string | null;
+  /** A run in flight, shown on the tab it belongs to. The same number appears
+   * in the node and in the status bar: one job, three places, no guessing
+   * which is authoritative. */
+  progress?: { tabId: string; value: number } | null;
   onActivate: (id: string) => void;
   onPin: (id: string) => void;
   onClose: (id: string) => void;
@@ -31,6 +35,7 @@ export function TabStrip({
   tabs,
   activeId,
   splitId,
+  progress,
   onActivate,
   onPin,
   onClose,
@@ -97,6 +102,15 @@ export function TabStrip({
           >
             <KindIcon />
             <span>{tab.title}</span>
+            {progress && progress.tabId === tab.id ? (
+              <span
+                className="prog"
+                data-testid="tab-progress"
+                style={{ width: 34, height: 3, marginLeft: 2 }}
+              >
+                <i style={{ width: `${Math.round(progress.value * 100)}%` }} />
+              </span>
+            ) : null}
             <button
               className="tabx"
               aria-label={`Close ${tab.title}`}

--- a/frontend/src/states/Overloaded.tsx
+++ b/frontend/src/states/Overloaded.tsx
@@ -1,0 +1,47 @@
+import { checkEnvelope, envelopeSentence } from "@/states/envelope";
+
+/** Past the envelope, the application says so.
+ *
+ * PROPOSAL.md section 13: "Beyond this, v1 documents the limit rather than
+ * pretending otherwise." Pretending, here, would be starting a plot of eighty
+ * million points and letting the tab freeze. What is cheap stays available -
+ * the metadata, the sample table - and only the plot is withheld.
+ */
+export function Overloaded({
+  samples,
+  variables,
+  what,
+  children,
+}: {
+  samples: number;
+  variables: number;
+  what: string;
+  children?: React.ReactNode;
+}) {
+  const { exceeded } = checkEnvelope(samples, variables);
+  return (
+    <div
+      role="alert"
+      data-testid="overloaded"
+      style={{
+        margin: 12,
+        padding: "10px 12px",
+        borderRadius: 3,
+        border: "1px solid var(--stale)",
+        background: "var(--staleSoft)",
+      }}
+    >
+      <div className="mono" style={{ fontSize: 10, color: "var(--stale)" }}>
+        BEYOND THE V1 ENVELOPE · {exceeded.join(" · ")}
+      </div>
+      <p style={{ margin: "4px 0 0", color: "var(--ink)" }}>
+        {what} is not drawn for this dataset. {envelopeSentence(samples, variables)}
+      </p>
+      <p style={{ margin: "4px 0 0", fontSize: 11, color: "var(--ink3)" }}>
+        Select a range of variables or a subset of samples to bring it inside the envelope.
+        Everything that does not need the whole array is still available.
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/states/envelope.ts
+++ b/frontend/src/states/envelope.ts
@@ -1,0 +1,42 @@
+/** The performance envelope, from PROPOSAL.md section 13.
+ *
+ * "up to ~20,000 spectra × ~4,000 variables, held in memory as float32
+ * (≈ 320 MB). Beyond this, v1 documents the limit rather than pretending
+ * otherwise."
+ *
+ * Documenting it is this module's whole job: a dataset past the envelope gets
+ * a screen that says so, with numbers, instead of a plot that hangs the tab.
+ */
+
+export const ENVELOPE = { spectra: 20_000, variables: 4_000, bytesPerValue: 4 };
+
+export interface Envelope {
+  within: boolean;
+  cells: number;
+  megabytes: number;
+  /** Which bound is exceeded, for a message that names the actual problem. */
+  exceeded: ("spectra" | "variables" | "memory")[];
+}
+
+export function checkEnvelope(samples: number, variables: number): Envelope {
+  const cells = samples * variables;
+  const megabytes = (cells * ENVELOPE.bytesPerValue) / 1_000_000;
+  const limitMegabytes =
+    (ENVELOPE.spectra * ENVELOPE.variables * ENVELOPE.bytesPerValue) / 1_000_000;
+
+  const exceeded: Envelope["exceeded"] = [];
+  if (samples > ENVELOPE.spectra) exceeded.push("spectra");
+  if (variables > ENVELOPE.variables) exceeded.push("variables");
+  if (megabytes > limitMegabytes) exceeded.push("memory");
+
+  return { within: exceeded.length === 0, cells, megabytes, exceeded };
+}
+
+export function envelopeSentence(samples: number, variables: number): string {
+  const { megabytes } = checkEnvelope(samples, variables);
+  return (
+    `${samples.toLocaleString()} × ${variables.toLocaleString()} is about ` +
+    `${Math.round(megabytes).toLocaleString()} MB as float32. Version 1 is built and tested to ` +
+    `${ENVELOPE.spectra.toLocaleString()} × ${ENVELOPE.variables.toLocaleString()}, about 320 MB.`
+  );
+}

--- a/stub/server.py
+++ b/stub/server.py
@@ -129,12 +129,28 @@ def get_project(project_id: str) -> Any:
 
 
 @api.get("/projects/{project_id}/datasets")
-def list_datasets(project_id: str, empty: Annotated[bool, Query()] = False) -> Any:
+def list_datasets(
+    project_id: str,
+    empty: Annotated[bool, Query()] = False,
+    oversize: Annotated[bool, Query()] = False,
+) -> Any:
     # `?empty=true` is the same kind of affordance as `?fail=true` on a run:
     # the empty-project state (#44) has to be reachable without editing code,
     # and a project with no datasets is otherwise unreachable from a fixture
     # that always has one.
-    return [] if empty else fixture("datasets")
+    if empty:
+        return []
+    entries = fixture("datasets")
+    if oversize:
+        # `?oversize=true` reports the committed dataset as one past the
+        # envelope in PROPOSAL.md section 13, so the overloaded state (#49) can
+        # be entered without committing a 320 MB fixture to git. Only the
+        # declared shape changes; no array is fabricated.
+        for entry in entries:
+            for version in entry["versions"]:
+                version["n_samples"] = 42_000
+                version["n_variables"] = 6_200
+    return entries
 
 
 @api.post("/import/preview")

--- a/tests/test_stub_server.py
+++ b/tests/test_stub_server.py
@@ -188,3 +188,12 @@ def test_a_step_is_validated_against_the_model_that_will_enforce_it(client: Test
     bounded = client.post("/api/steps/validate", json={**good, "deriv": 5}, headers=AUTH).json()
     assert bounded["valid"] is False
     assert bounded["errors"][0]["field"] == "savgol.deriv"
+
+
+def test_a_project_can_be_asked_for_a_dataset_past_the_envelope(client: TestClient) -> None:
+    """The overloaded state needs a dataset too big to commit to git."""
+    entry = client.get("/api/projects/p/datasets?oversize=true", headers=AUTH).json()[0]
+    version = entry["versions"][0]
+    assert (version["n_samples"], version["n_variables"]) == (42_000, 6_200)
+    # Only the declared shape changes - the arrays and hashes are untouched.
+    assert version["content_hash"] == fixture("datasets")[0]["versions"][0]["content_hash"]


### PR DESCRIPTION
`DESIGN_BRIEF.md` §8's six states, each **entered against the stub server** rather than from a hard-coded UI flag — the issue's own convention: a state that can only be reached by editing code is a state nobody tests.

## What each one now does

- **Running** — one job in three places at once: the status bar, the tab (a 34px progress bar beside the label) and the node. Cancelling stops it and clears the tab's progress.
- **Failed** — `?failrun` takes the server's failing sequence; the banner reads `RUN FAILED` with the rank-4 message and no traceback. The test also reads `--fail` and `--d1`–`--d6` off the *running application* and asserts they are disjoint, so a failing thing can never be read as a red spectrum.
- **Stale** — computed style is a dashed border over a 135° hatch below full opacity, with the `edited · downstream stale` footer, and all fourteen nodes remain. Dimmed, not deleted.
- **Overloaded** — past `PROPOSAL.md` §13's envelope the spectra view returns *before any hook or query runs* and states the limit: `42,000 × 6,200`, about 1,042 MB against a tested 320 MB, naming which bound was crossed. Preparing a plot of eighty million points is the freeze this state exists to avoid.
- **Empty** and **importing** re-checked against the others.

## The oversize affordance

`?oversize` rewrites only the dataset's *declared shape* — no 320 MB fixture enters git and no array is fabricated. That makes four 1.1-only affordances (`?empty`, `?oversize`, `?failrun`, `X-Stub-Fail`), and all four go in 1.2, where a truncated file, a rank-deficient matrix and a genuinely large dataset reach these states on their own.

## Evidence

`pnpm e2e` 35 passed (6 new, one per state), `pnpm test` 52 passed (4 new — the envelope arithmetic and its sentence), `uv run pytest` 487 (1 new). Twelve screenshots taken: each state in both themes.

Closes #49