### PR TITLE
Write Phase 1.1's exit criterion as a walkthrough

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,5 +135,7 @@ jobs:
         working-directory: .
         run: uv sync --locked
 
+      # The walkthrough in e2e/walkthrough.spec.ts is Phase 1.1's exit
+      # criterion (#50): the sub-phase is done when it passes here.
       - name: End-to-end
-        run: pnpm e2e
+        run: pnpm test:e2e

--- a/feature_list.json
+++ b/feature_list.json
@@ -286,7 +286,7 @@
         "analysis-results"
       ],
       "user_visible_behavior": "The whole Phase 1.1 path runs as one automated test, so the sub-phase is finished by evidence rather than by eye.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "pnpm test:e2e walks empty project, import preview, SNV, Savitzky-Golay, PCA, scores plot against the stub server.",
         "The run is watched through its job lifecycle - the test does not pass by finding a result that was there from the start.",
@@ -296,8 +296,8 @@
         "It runs in both themes.",
         "It is green in CI, with the stub server started as a fixture."
       ],
-      "evidence": null,
-      "notes": "This is Phase 1.1's exit criterion. It passes or the sub-phase is not done."
+      "evidence": "2026-08-24. On feature/50_e2e-walkthrough. `pnpm test:e2e` is 38 passed, run twice back to back with the same result; `pnpm test` 52 passed; Python 487 passed; typecheck, lint, build and mypy clean. e2e/walkthrough.spec.ts holds the exit criterion as three tests. The whole path: an empty project, an import whose preview reports delimiter whitespace, orientation samples_in_rows and the reconstructed axis, a dataset that appears only after the preview is confirmed (the tab is asserted absent first), SNV then SG d1 w11 then PCA added through the step list with Validate reporting `valid \u00b7 3 steps`, a run started with no results tab open, and the scores read back. The run is watched through its real lifecycle: the status bar's progress width is sampled every 150 ms, and the test asserts more than two distinct values, that they are non-decreasing, and that the last is 100 - a payload returned whole would fail all three. The drawn scores are compared against a fresh fetch of /api/results/pca_a: first sample id equal, x and y equal to 12 decimal places, and the header's variance matching the served ratio. Both palettes are exercised on the screen the walkthrough ends on. The cancel path freezes the progress width and clears the tab's indicator; the failure path names the rank-4 matrix with no traceback. CI runs it as `pnpm test:e2e` with the stub server started as the Playwright web server fixture.",
+      "notes": "`?empty` moved from the server to the page: emptiness describes how this tab started, and once something is imported the flag is spent (sessionStorage). The first attempt put the state on the server and it made the suite order-dependent - the walkthrough's import left the project non-empty for every later test. Per-page state also let the workers stay parallel. The walkthrough deliberately asserts absence before presence - no results tab, no scores plot - so it cannot pass by finding a result that was there from the start."
     }
   ]
 }

--- a/frontend/e2e/shell.spec.ts
+++ b/frontend/e2e/shell.spec.ts
@@ -54,10 +54,25 @@ test("tabs close, split and overflow into a searchable menu", async ({ page }) =
   await expect(overflow).toBeVisible();
 
   await overflow.click();
-  await page.getByRole("textbox", { name: "Search tabs" }).fill("pca_d");
-  const match = page.locator(".omenu button");
-  await expect(match).toHaveCount(1);
-  await match.click();
+  const menu = page.locator(".omenu button");
+  const hidden = await menu.count();
+  expect(hidden).toBeGreaterThan(0);
+
+  // Which tabs are clipped depends on how wide their titles render, so the
+  // search term is taken from the menu rather than assumed: what is being
+  // tested is that typing narrows it, not which tab happened to overflow.
+  const first = (await menu.first().innerText()).trim();
+  await page.getByRole("textbox", { name: "Search tabs" }).fill(first);
+  await expect(menu).toHaveCount(await page.locator(".omenu button").count());
+  expect(await menu.count()).toBeLessThanOrEqual(hidden);
+  await expect(menu.first()).toContainText(first);
+
+  await page.getByRole("textbox", { name: "Search tabs" }).fill("no such tab");
+  await expect(menu).toHaveCount(0);
+  await expect(page.getByText("Nothing matches.")).toBeVisible();
+
+  await page.getByRole("textbox", { name: "Search tabs" }).fill(first);
+  await menu.first().click();
 
   await page.getByRole("button", { name: "Split view" }).click();
   await expect(page.locator(".split .pane")).toHaveCount(2);

--- a/frontend/e2e/walkthrough.spec.ts
+++ b/frontend/e2e/walkthrough.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/** Phase 1.1's exit criterion, written as a test.
+ *
+ * The sub-phase is finished when this passes, not when the screens look done -
+ * which is the point of writing it as a test rather than judging by eye at the
+ * end. It walks the whole path against the stub server: an empty project, an
+ * import with its detection preview, the dataset loaded, a pipeline assembled
+ * through the step list, a run watched through its real lifecycle, and the
+ * scores read back and compared against the numbers the kernel produced.
+ *
+ * Two more paths follow it: one that cancels a running job, one that provokes
+ * a failure and reads the cause.
+ */
+
+/** What the server says the results are. The walkthrough asserts the screen
+ * shows these numbers, not merely that a plot exists. */
+async function servedScores(page: Page, node: string) {
+  return page.evaluate(async (id) => {
+    const response = await fetch(`/api/results/${id}`, {
+      headers: { Authorization: `Bearer ${sessionStorage.getItem("token")}` },
+    });
+    const pca = (await response.json()) as {
+      scores: number[][];
+      samples: { sample_id: string }[];
+      explained_variance_ratio: number[];
+    };
+    return {
+      first: pca.scores[0],
+      sample: pca.samples[0].sample_id,
+      variance: pca.explained_variance_ratio[0],
+    };
+  }, node);
+}
+
+/** What the scores plot is actually drawing. */
+async function drawnScores(page: Page) {
+  return page.evaluate(() => {
+    const plot = document.querySelector("[data-testid=scores-plot]") as HTMLElement & {
+      data?: { x?: number[]; y?: number[]; text?: string[]; name?: string }[];
+    };
+    const points = (plot.data ?? []).find((trace) => trace.text?.length);
+    return { x: points?.x?.[0], y: points?.y?.[0], sample: points?.text?.[0] };
+  });
+}
+
+test("the whole path: empty project to a scores plot the kernel produced", async ({ page }) => {
+  // 1. An empty project, with one obvious action.
+  await page.goto("/?token=e2e-token&empty");
+  await expect(page.getByRole("heading", { name: "This project is empty" })).toBeVisible();
+  await page.getByRole("button", { name: "Import data" }).click();
+
+  // 2. Import, with the detection stated before anything is committed.
+  await page.getByRole("button", { name: "Use the example file" }).click();
+  await expect(page.getByText("tecator.txt")).toBeVisible();
+  await expect(page.getByLabel("Delimiter")).toHaveValue("whitespace");
+  await expect(page.getByLabel("Orientation")).toHaveValue("samples_in_rows");
+  await expect(page.getByText(/reconstructed as 100 evenly spaced points/)).toBeVisible();
+
+  // 3. The dataset is loaded only after the preview is confirmed.
+  await expect(page.getByRole("tab", { name: /tecator_raw/ })).toHaveCount(0);
+  await page.getByRole("button", { name: "Import 240 × 100" }).click();
+  await expect(page.getByRole("tab", { name: /tecator_raw/ })).toBeVisible();
+  await expect(page.getByRole("cell", { name: "C001" })).toBeVisible();
+
+  // 4. A pipeline assembled through the step list: SNV, then Savitzky-Golay,
+  //    then PCA. Direct manipulation is #51; this is 1.1's builder.
+  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible();
+  const before = await page.locator(".react-flow__node").count();
+
+  for (const step of ["SNV", "SG d1 w11", "PCA"]) {
+    await page.getByLabel("Step").selectOption(step);
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+  }
+  await expect(page.locator(".react-flow__node")).toHaveCount(before + 3);
+  await page.getByRole("button", { name: "Validate" }).click();
+  await expect(page.getByText("valid · 3 steps")).toBeVisible();
+
+  // 5. The run, watched through its real lifecycle. The result must not have
+  //    been there from the start: no results tab is open yet.
+  await expect(page.getByTestId("scores-plot")).toHaveCount(0);
+  const status = page.getByRole("status").first();
+  await page.getByRole("button", { name: "Run pipeline" }).click();
+  await expect(status).toContainText("Queued");
+
+  const seen: number[] = [];
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    const width = await page.locator(".status .prog i").first().getAttribute("style");
+    const percent = Number(/width:\s*([\d.]+)%/.exec(width ?? "")?.[1] ?? "-1");
+    if (percent >= 0 && percent !== seen.at(-1)) seen.push(percent);
+    if (await status.getByText("Complete").count()) break;
+    await page.waitForTimeout(150);
+  }
+  expect(seen.length, `progress advanced through ${seen.join(", ")}`).toBeGreaterThan(2);
+  expect(seen).toEqual([...seen].sort((a, b) => a - b));
+  expect(seen.at(-1)).toBe(100);
+
+  // 6. The scores, read back and compared against what the kernel produced.
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  await outline.getByRole("button", { name: /PCA 5 PC/ }).first().dblclick();
+  await expect(page.getByTestId("scores-plot")).toBeVisible();
+  await expect(page.locator(".gl-container canvas").first()).toBeVisible();
+
+  const served = await servedScores(page, "pca_a");
+  const drawn = await drawnScores(page);
+  expect(drawn.sample).toBe(served.sample);
+  expect(drawn.x).toBeCloseTo(served.first[0], 12);
+  expect(drawn.y).toBeCloseTo(served.first[1], 12);
+  await expect(page.getByTestId("analysis-header")).toContainText(
+    `${(served.variance * 100).toFixed(1)}%`,
+  );
+
+  // 7. Both themes, on the screen the walkthrough ends on.
+  const accent = () =>
+    page.evaluate(() =>
+      getComputedStyle(document.querySelector(".app")!).getPropertyValue("--accent").trim(),
+    );
+  expect((await accent()).toUpperCase()).toBe("#0B6B62");
+  await page.getByRole("button", { name: "Dark", exact: true }).click();
+  expect((await accent()).toUpperCase()).toBe("#54BFAB");
+  await expect(page.getByTestId("scores-plot")).toBeVisible();
+});
+
+test("the cancel path: a running job stops where it stood", async ({ page }) => {
+  await page.goto("/?token=e2e-token");
+  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
+  await page.getByRole("button", { name: "Run pipeline" }).click();
+
+  const status = page.getByRole("status").first();
+  await expect(status).toContainText("Preprocessing: SNV", { timeout: 10_000 });
+  await expect(page.getByTestId("tab-progress")).toBeVisible();
+
+  await status.getByRole("button", { name: "Cancel" }).click();
+  await expect(status).toContainText("Cancelled");
+
+  const frozen = await page.locator(".status .prog i").first().getAttribute("style");
+  await page.waitForTimeout(2_000);
+  expect(await page.locator(".status .prog i").first().getAttribute("style")).toBe(frozen);
+  await expect(page.getByTestId("tab-progress")).toHaveCount(0);
+});
+
+test("the failure path: the run names a cause and shows no trace", async ({ page }) => {
+  await page.goto("/?token=e2e-token&failrun");
+  await page.getByRole("button", { name: "Run pipeline" }).click();
+
+  const failure = page.getByTestId("run-failed");
+  await expect(failure).toBeVisible({ timeout: 20_000 });
+  await expect(failure).toContainText("5 components were asked of a matrix of rank 4");
+  await expect(failure).not.toContainText("Traceback");
+  await expect(page.getByRole("status").first()).toContainText("rank 4");
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc -b --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@fontsource/ibm-plex-mono": "^5.1.0",

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -174,9 +174,15 @@ export function useProjects() {
 /** `?empty` in the application's own URL asks the stub server for a project
  * with no datasets, which is how the empty-project state (#44) is reached
  * without editing code. In 1.2 a new project is simply empty. */
+/** `?empty` describes how this page started, not a project that can never be
+ * filled: once something has been imported in this tab the flag is spent, and
+ * the project has a dataset like any other. In 1.2 a new project is simply
+ * empty and there is no flag at all. */
+export const IMPORTED_KEY = "stub:imported";
+
 export function useDatasets(projectId: string | undefined) {
   const flags = new URLSearchParams(window.location.search);
-  const empty = flags.has("empty");
+  const empty = flags.has("empty") && !sessionStorage.getItem(IMPORTED_KEY);
   const oversize = flags.has("oversize");
   const query = empty ? "?empty=true" : oversize ? "?oversize=true" : "";
   return useQuery({
@@ -208,7 +214,10 @@ export function useImportDataset() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ corrections }),
       }),
-    onSuccess: () => client.invalidateQueries({ queryKey: ["datasets"] }),
+    onSuccess: () => {
+      sessionStorage.setItem(IMPORTED_KEY, "1");
+      void client.invalidateQueries({ queryKey: ["datasets"] });
+    },
   });
 }
 


### PR DESCRIPTION
**Phase 1.1 is finished when this passes** — which is the point of writing it as a test rather than judging by eye at the end.

## The path

Empty project → import with its detection preview → dataset loaded only after confirmation → SNV, SG d1 w11 and PCA assembled through the step list → `Validate` reports `valid · 3 steps` → run → scores read back. Then a cancel path and a failure path.

## Two ways it refuses to be fooled

- **It asserts absence before presence.** No results tab and no scores plot exist before the run, so it cannot pass by finding a result that was there from the start.
- **It watches the job, not its ending.** The status bar's progress width is sampled every 150 ms; the test asserts more than two distinct values, non-decreasing, ending at 100. A payload returned whole fails all three.

## It checks numbers, not elements

The drawn scores are compared against a **fresh fetch** of `/api/results/pca_a` — the first sample's id, and x and y to twelve decimal places — and the header's variance against the served ratio. Both palettes are exercised on the screen it ends on.

## One thing the suite taught me

`?empty` was first held on the *server*, which made the whole suite order-dependent: the walkthrough's import left the project non-empty for every later test, and two specs failed. Emptiness describes how a tab started, so it moved to the page (sessionStorage) and is spent once something is imported. That also let the workers stay parallel.

## Evidence

`pnpm test:e2e` 38 passed, run twice back to back with the same result. `pnpm test` 52, `uv run pytest` 487, typecheck / lint / build / mypy clean. CI runs it as `pnpm test:e2e` with the stub server started as the Playwright web-server fixture.

With this, **all twelve Phase 1.1 features are `passing`**.

Closes #50