### PR TITLE
Say why the shell cannot load instead of spinning

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -298,6 +298,26 @@
       ],
       "evidence": "2026-08-24. On feature/50_e2e-walkthrough. `pnpm test:e2e` is 38 passed, run twice back to back with the same result; `pnpm test` 52 passed; Python 487 passed; typecheck, lint, build and mypy clean. e2e/walkthrough.spec.ts holds the exit criterion as three tests. The whole path: an empty project, an import whose preview reports delimiter whitespace, orientation samples_in_rows and the reconstructed axis, a dataset that appears only after the preview is confirmed (the tab is asserted absent first), SNV then SG d1 w11 then PCA added through the step list with Validate reporting `valid \u00b7 3 steps`, a run started with no results tab open, and the scores read back. The run is watched through its real lifecycle: the status bar's progress width is sampled every 150 ms, and the test asserts more than two distinct values, that they are non-decreasing, and that the last is 100 - a payload returned whole would fail all three. The drawn scores are compared against a fresh fetch of /api/results/pca_a: first sample id equal, x and y equal to 12 decimal places, and the header's variance matching the served ratio. Both palettes are exercised on the screen the walkthrough ends on. The cancel path freezes the progress width and clears the tab's indicator; the failure path names the rank-4 matrix with no traceback. CI runs it as `pnpm test:e2e` with the stub server started as the Playwright web server fixture.",
       "notes": "`?empty` moved from the server to the page: emptiness describes how this tab started, and once something is imported the flag is spent (sessionStorage). The first attempt put the state on the server and it made the suite order-dependent - the walkthrough's import left the project non-empty for every later test. Per-page state also let the workers stay parallel. The walkthrough deliberately asserts absence before presence - no results tab, no scores plot - so it cannot pass by finding a result that was there from the start."
+    },
+    {
+      "id": "shell-load-failure",
+      "priority": 13,
+      "area": "frontend",
+      "title": "The shell says why it cannot load, instead of spinning",
+      "issue": 69,
+      "depends_on": [
+        "app-shell"
+      ],
+      "user_visible_behavior": "Opening the application without a token, or against a server that is not answering, states the problem and what to do about it rather than showing Loading forever.",
+      "status": "passing",
+      "verification": [
+        "Loading without a token shows a message naming the 401 and how to reopen, not a spinner.",
+        "A server that is not answering is distinguished from one that refuses the token.",
+        "The message stays inside the application chrome.",
+        "An end-to-end test covers the tokenless load."
+      ],
+      "evidence": "2026-08-24. On fix/69_shell-load-failure. `pnpm test:e2e` is 40 passed, 2 of them new; `pnpm test` 52 passed; Python 487 passed; typecheck, lint and build clean. Loading http://127.0.0.1:8765/ with no token now shows `401 \u00b7 UNAUTHORIZED`, `Not authenticated`, what happened and how to reopen from the launch URL - asserted in the browser, along with `Loading\u2026` no longer appearing and the top bar reading `No project` rather than claiming to be loading one. Aborting every /api request shows `NO RESPONSE` and `not answering` instead, so a stopped server is told apart from a refused token. The application chrome stays around the message. Screenshot taken.",
+      "notes": "Found by opening the launch URL without its token, which a browser's autocomplete does readily. #49's failed state covered runs and imports; the shell's own load was a seventh case nobody listed, and every end-to-end test opened the application with a valid token, so nothing exercised it. There is no retry: a 401 is not transient, and retrying is what makes a refusal look like a slow load."
     }
   ]
 }

--- a/frontend/e2e/shell.spec.ts
+++ b/frontend/e2e/shell.spec.ts
@@ -109,3 +109,30 @@ test("both themes are the artboard's palettes", async ({ page }) => {
   await page.getByRole("button", { name: "Dark", exact: true }).click();
   expect((await accent()).toUpperCase()).toBe("#54BFAB");
 });
+
+test("without a token the shell says so, rather than loading forever", async ({ page }) => {
+  // The launch URL carries the token once. Opening the bare address - which a
+  // browser's autocomplete does readily - has to say what happened.
+  await page.goto("/");
+
+  const notice = page.getByTestId("cannot-load");
+  await expect(notice).toBeVisible();
+  await expect(notice).toContainText("401 · UNAUTHORIZED");
+  await expect(notice).toContainText("Not authenticated");
+  await expect(notice).toContainText("?token=");
+  await expect(notice).not.toContainText("Traceback");
+
+  // The application chrome stays: this is a window, not a failed browser tab.
+  await expect(page.locator(".tbar")).toBeVisible();
+  await expect(page.getByText("Loading…")).toHaveCount(0);
+});
+
+test("a server that is not answering is told apart from one that refuses", async ({ page }) => {
+  await page.route("**/api/**", (route) => route.abort());
+  await page.goto("/?token=e2e-token");
+
+  const notice = page.getByTestId("cannot-load");
+  await expect(notice).toBeVisible();
+  await expect(notice).toContainText("NO RESPONSE");
+  await expect(notice).toContainText("not answering");
+});

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/api/queries";
 import { DatasetView } from "@/screens/DatasetView";
 import { EmptyProject } from "@/screens/EmptyProject";
+import { CannotLoad } from "@/states/CannotLoad";
 import { Import } from "@/screens/Import";
 import { PipelineCanvas } from "@/canvas/PipelineCanvas";
 import { AnalysisResults } from "@/screens/analysis/AnalysisResults";
@@ -247,7 +248,9 @@ export function Shell() {
       <div className="tbar">
         <div className="tb-l">
           <FlaskIcon />
-          <span className="proj">{project?.name ?? "Loading…"}</span>
+          <span className="proj">
+            {project?.name ?? (projects.isError ? "No project" : "Loading…")}
+          </span>
           <span className="crumb mono">{project?.directory ?? ""}</span>
         </div>
         <div className="tb-r">
@@ -319,7 +322,13 @@ export function Shell() {
             onMove={(from, to) => dispatch({ type: "move", from, to })}
             onSplit={(id) => dispatch({ type: "split", id })}
           />
-          {job.data?.status === "failed" && !dismissedFailure ? (
+          {projects.isError ? (
+            // The shell's own load failed. Everything below depends on the
+            // project, so there is nothing to show but the reason.
+            <CannotLoad error={projects.error} />
+          ) : null}
+
+          {!projects.isError && job.data?.status === "failed" && !dismissedFailure ? (
             <div
               role="alert"
               data-testid="run-failed"
@@ -350,7 +359,7 @@ export function Shell() {
             </div>
           ) : null}
 
-          {noDatasets && !activeTab ? (
+          {projects.isError ? null : noDatasets && !activeTab ? (
             <EmptyProject onImport={openImport} />
           ) : state.splitId ? (
             <div className="split">

--- a/frontend/src/states/CannotLoad.tsx
+++ b/frontend/src/states/CannotLoad.tsx
@@ -1,0 +1,62 @@
+import { ApiError } from "@/api/client";
+
+/** The shell could not load its own project.
+ *
+ * A local-first application can be honest here in a way a web page cannot:
+ * the server is on this machine, so a failure is knowable rather than a guess
+ * about somebody's network. The three cases a user can act on are told apart -
+ * the token was refused, the server is not answering, or the request failed
+ * some other way - and each says what to do next.
+ *
+ * There is no retry loop. A 401 is not transient, and spinning on it is what
+ * this replaces.
+ */
+export function CannotLoad({ error }: { error: unknown }) {
+  const api = error instanceof ApiError ? error : null;
+  const unauthorised = api?.status === 401;
+  const unreachable = !api;
+
+  const heading = unauthorised
+    ? "Not authenticated"
+    : unreachable
+      ? "The workbench server is not answering"
+      : "The workbench server refused the request";
+
+  const explanation = unauthorised
+    ? "This window has no session token, so the server refused every request. The token is handed over once, in the launch URL."
+    : unreachable
+      ? "Nothing is listening on this address. The server runs on this machine and is started with the application, so it has either stopped or was never started."
+      : (api?.message ?? "The request failed.");
+
+  const remedy = unauthorised
+    ? "Reopen the application from its launch URL — the one printed when the server started, ending in ?token=…"
+    : unreachable
+      ? "Start the server again, then reload this window."
+      : "Reload the window. If it keeps failing, restart the application.";
+
+  return (
+    <div className="pane">
+      <div
+        role="alert"
+        data-testid="cannot-load"
+        style={{
+          margin: 16,
+          maxWidth: 560,
+          padding: "12px 14px",
+          borderRadius: 3,
+          border: "1px solid var(--fail)",
+          background: "var(--failSoft)",
+        }}
+      >
+        <div className="mono" style={{ fontSize: 10, color: "var(--fail)" }}>
+          {api ? `${api.status} · ${api.code.toUpperCase()}` : "NO RESPONSE"}
+        </div>
+        <h2 style={{ margin: "4px 0 0", fontSize: 13.5, fontWeight: 600 }}>{heading}</h2>
+        <p style={{ margin: "4px 0 0", color: "var(--ink)", lineHeight: 1.45 }}>{explanation}</p>
+        <p style={{ margin: "6px 0 0", fontSize: 11.5, color: "var(--ink3)", lineHeight: 1.45 }}>
+          {remedy}
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Opening the application without its token — `http://127.0.0.1:8765/` rather than the launch URL — rendered the shell and then sat on `Loading…` for ever. Every request came back 401 and nothing said so, which made an unreachable server, a refused token and a slow first paint indistinguishable.

A local-first application can be honest here in a way a web page cannot: the server is on this machine, so the failure is *knowable* rather than a guess about somebody's network. The three cases are now told apart, and each says what to do next.

- `401 · UNAUTHORIZED` → **Not authenticated**, with how to reopen from the launch URL
- No response at all → **The workbench server is not answering**, with the fact that it starts with the application
- Anything else → the server's own message

**No retry.** A 401 is not transient, and retrying is exactly what makes a refusal look like a slow load. The message keeps the application chrome around it — this is a window, not a browser tab that failed to load — and the top bar reads `No project` rather than claiming to be loading one.

## Why it was missed

#49 covered the six states in `DESIGN_BRIEF.md` §8, where *failed* means a failed **run** or a failed **import**. The shell's own load is a seventh case nobody listed, and every end-to-end test opened the application with a valid token, so nothing exercised it. Two tests now do: one loads the bare address, one aborts every `/api` request.

## Evidence

`pnpm test:e2e` 40 passed (2 new), `pnpm test` 52, `uv run pytest` 487, typecheck / lint / build clean. Asserted in the browser: the message and its status line appear, `Loading…` does not, and the chrome survives.

Closes #69