### PR TITLE
Hand off a finished Phase 1.1 and bump the version to 0.2.0

### DIFF
--- a/frontend/src/shell/Inspector.tsx
+++ b/frontend/src/shell/Inspector.tsx
@@ -166,7 +166,7 @@ export function Inspector({
           ["Content hash", version?.v.content_hash ?? datasets?.[0]?.versions[0]?.content_hash ?? "—"],
           ["Pipeline", pipeline?.pipeline_id ?? "—"],
           ["Project", project?.project_id ?? "—"],
-          ["App version", "0.1.0"],
+          ["App version", "0.2.0"],
         ]}
       />
       {version ? (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chemometrics-workbench"
-version = "0.1.0"
+version = "0.2.0"
 description = "Open-source, local-first chemometrics workbench"
 requires-python = ">=3.12"
 license = "MIT"

--- a/src/chemometrics_workbench/__init__.py
+++ b/src/chemometrics_workbench/__init__.py
@@ -1,3 +1,3 @@
 """Open-source, local-first chemometrics workbench."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/stub/fixtures/experiment.json
+++ b/stub/fixtures/experiment.json
@@ -2633,7 +2633,7 @@
     }
   },
   "environment": {
-    "app_version": "0.1.0",
+    "app_version": "0.2.0",
     "python_version": "3.12.3",
     "platform": "Linux-6.8.0-138-generic-x86_64-with-glibc2.39",
     "packages": {

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "chemometrics-workbench"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Rewrites `session-handoff.md` for a completed Phase 1.1 — thirteen features passing, #40–#50 and #53 closed, #50's walkthrough green — and records the Phase 1.2 plan agreed with the maintainer: the A–O feature chain, its exit criterion, and the three decisions taken so they are not re-argued.

Also bumps the package version from 0.1.0 to 0.2.0 ahead of tagging the walking skeleton. `stub/fixtures/experiment.json` is regenerated rather than hand-edited, so `app_version` keeps coming from `chemometrics_workbench.__version__`; the only fixture byte that changes is that field.

No feature status changes. `uv run pytest` passes locally (497 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UR4VWkMrX6FJnAn8NNyj1