### PR TITLE
Phase 1.2 · Drop MSC(reference="supplied") from the schema

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -147,14 +147,14 @@
         "phase-1-2-feature-list"
       ],
       "user_visible_behavior": "The inspector no longer offers an MSC reference the executor cannot run; the schema advertises only what a saved pipeline can express.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "grep -rn '\"supplied\"' src/ names only the kernel's own parameter, not models.py.",
         "from_spec no longer carries the branch that raises for it.",
         "The regenerated step_schema.json offers two MSC references, and the inspector's form follows.",
         "The suite is green, including the parity cases."
       ],
-      "evidence": "",
+      "evidence": "2026-08-27. On feature/82_drop-msc-supplied. `MSCStep.reference` is `Literal[\"mean\", \"median\"]`; the comment above it records why the third option went and what re-adding it would need, so the next person to want it finds the reason at the field rather than in a closed issue. `grep -rn '\"supplied\"' src/` returns five lines: the kernel's own `MSCReference` literal and its two branches in `MSCTransformer`, plus the models.py comment and the from_spec docstring that both explain the absence - no schema field. `from_spec` lost its `reference_spectrum` parameter entirely rather than keeping a dead argument: the schema can no longer express the case, so there is nothing to pass and nothing to raise about. The kernel call `MSCTransformer(\"supplied\", reference_spectrum=...)` still works and a test asserts it alongside the ValidationError the step now raises - what went is the schema's claim, not the capability. `MSCTransformer`'s error message no longer says the schema carries the choice, because it no longer does. `uv run python stub/generate_fixtures.py` regenerated the fixtures and the only diff is `step_schema.json`'s MSC enum losing `\"supplied\"`; the pipeline and dataset content hashes are unchanged (sha256:9a684f48..., sha256:e435c053...), which is the check that this narrowed a form and not a number. Green: `uv run pytest` is 603 passed, 1 skipped, including the parity cases; `uv run ruff check .` and `ruff format --check .` clean over 58 files; `uv run mypy` clean over 38 source files; `pnpm test` 52 passed with the inspector test now expecting two MSC references; `pnpm e2e` 40 passed, so the inspector's generated form follows the schema without the screen being touched.",
       "notes": "Open since pull request #22; decided with the maintainer on 2026-08-25. Re-adding it later is additive and needs no migration. Lands before the executor is written against the enum."
     },
     {

--- a/frontend/src/__tests__/inspector.test.ts
+++ b/frontend/src/__tests__/inspector.test.ts
@@ -49,7 +49,7 @@ describe("the form is generated, not restated", () => {
 
   it("reads an enum as a choice and an optional field as optional", () => {
     const msc = specFor(schema, "msc")!;
-    expect(msc.fields[0].options).toEqual(["mean", "median", "supplied"]);
+    expect(msc.fields[0].options).toEqual(["mean", "median"]);
 
     const baseline = specFor(schema, "baseline")!;
     expect(baseline.fields.find((field) => field.name === "lam")!.optional).toBe(true);

--- a/session-handoff.md
+++ b/session-handoff.md
@@ -2,58 +2,59 @@
 
 Compact state for the next session. **Overwrite this file at the end of every session** — it is a snapshot, not a log. Read it first, then `feature_list.json`, `git log` on `dev`, and the open issues.
 
-**Updated:** 2026-08-26
+**Updated:** 2026-08-27
 
 ---
 
 ## Where things stand
 
-**Phase 0 is released and tagged `v0.1.0`. Phase 1.1 is released and tagged `v0.2.0`.** The walking skeleton walks: the React shell and its five core screens, over a token-authenticated stub FastAPI server on `127.0.0.1`, with a Playwright walkthrough green in CI. `dev` was merged to `main` and tagged on 2026-08-26, which closes the question the previous handoff left open.
+**Phase 0 is released and tagged `v0.1.0`. Phase 1.1 is released and tagged `v0.2.0`.** The walking skeleton walks: the React shell and its five core screens, over a token-authenticated stub FastAPI server on `127.0.0.1`, with a Playwright walkthrough green in CI.
 
-**Phase 1.2 is open.** `feature_list.json` is now the 1.2 list — fifteen features against issues #76–#90 — and Phase 1.1's list is archived at `docs/phase-1-1/feature_list.json` next to Phase 0's. #76 opened the list and is `passing`.
+**Phase 1.2 is six features in, of fifteen.** The project directory and the array store are real, all three readers are written, and the schema no longer advertises a step the executor could not run.
 
 **1.2's exit criterion:** #50's walkthrough passes against the real backend, on a file the user picks, with `stub/` deleted (#90).
 
-| | Feature | Issue | Depends on |
-| --- | --- | --- | --- |
-| A | Archive the 1.1 list, open the 1.2 list | #76 | — |
-| B | Project directory and array store | #77 | A |
-| C | Reader interface and the CSV/TXT reader | #78 | B |
-| D | XLSX reader | #79 | C |
-| E | JCAMP-DX reader | #80 | C |
-| F | Import endpoints | #81 | B, C |
-| G | Drop `MSC(reference="supplied")` | #82 | A |
-| H | Pipeline executor | #83 | B, G |
-| I | Pipeline validator | #84 | H |
-| J | Real jobs | #85 | H |
-| K | Server-side decimation and the density band | #86 | H |
-| L | Results endpoint | #87 | H |
-| M | The metrics gap | #88 | — |
-| N | HTTP surface complete, stub retired | #89 | F, J, K, L |
-| O | 1.2's exit criterion as a test | #90 | I, N |
+| | Feature | Issue | Depends on | Status |
+| --- | --- | --- | --- | --- |
+| A | Archive the 1.1 list, open the 1.2 list | #76 | — | passing |
+| B | Project directory and array store | #77 | A | passing |
+| C | Reader interface and the CSV/TXT reader | #78 | B | passing |
+| D | XLSX reader | #79 | C | passing |
+| E | JCAMP-DX reader | #80 | C | passing |
+| F | Import endpoints | #81 | B, C | not started |
+| G | Drop `MSC(reference="supplied")` | #82 | A | passing |
+| H | Pipeline executor | #83 | B, G | not started |
+| I | Pipeline validator | #84 | H | not started |
+| J | Real jobs | #85 | H | not started |
+| K | Server-side decimation and the density band | #86 | H | not started |
+| L | Results endpoint | #87 | H | not started |
+| M | The metrics gap | #88 | — | not started |
+| N | HTTP surface complete, stub retired | #89 | F, J, K, L | not started |
+| O | 1.2's exit criterion as a test | #90 | I, N | not started |
 
 Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M depends on nothing in 1.2**, so it is what to pick up if the chain is ever blocked.
 
 ## Current work
 
-**#77 — project directory and the array store — is `in_progress` on `feature/77_project-directory`.** It is the feature everything except #88 waits on: a project is a directory on disk, the arrays are files in it, float32 on disk and float64 at the kernel boundary, and a path registry in the user's config directory stands in for the project list until SQLite arrives in 1.3.
+**#82 — drop `MSC(reference="supplied")` — is done on `feature/82_drop-msc-supplied`**, pull request open against `dev`. Nothing else is `in_progress`.
 
 ## Next action
 
-Finish #77, then **#78 — the reader interface and the CSV/TXT reader**. CSV/TXT is the format carrying every detection problem — decimal commas, orientation, wavelength headers, metadata columns — so the reader interface is designed against it and then proven by #79 and #80 rather than the other way round.
+**#83 — the pipeline executor.** Both its dependencies (#77 and #82) are now `passing`, and it is the widest fan-out left: #84, #85, #86 and #87 all wait on it. **#81, the import endpoints, is equally unblocked** and does not gate the executor, so it is the alternative if the executor wants a longer run at it.
 
-### Three decisions taken with the maintainer, so they are not re-argued
+`preprocessing.from_spec` is the executor's seam, and after #82 it needs exactly one thing from outside the schema: the axis for `RangeSelect`, which #77 provides off the `DatasetVersion`.
 
-1. **The project directory and the array store land in 1.2; SQLite stays in 1.3.** Files are real from 1.2 — a restart loses the project *list*, not the data. This spreads the float32/float64 boundary and the §13 envelope across two sub-phases instead of landing them together in 1.3.
-2. **All three readers land in 1.2** — CSV/TXT, XLSX and JCAMP-DX, as `PROPOSAL.md` §6 puts them in Phase 1. The reader interface is therefore designed against three formats rather than proven on one; CSV/TXT is still the one carrying the detection problems and should be written first.
-3. **`MSC(reference="supplied")` is removed from the enum** (#82), rather than given a field or left to raise. The schema stops advertising something no executor can do, and re-adding it later is additive and needs no migration. This closes the question that has been open since pull request #22.
+### Decisions taken with the maintainer, so they are not re-argued
+
+1. **The project directory and the array store land in 1.2; SQLite stays in 1.3.** Files are real from 1.2 — a restart loses the project *list*, not the data.
+2. **All three readers land in 1.2** — done, and #78's interface survived being generalised by #79 and re-proven by #80.
+3. **`MSC(reference="supplied")` is removed from the enum** (#82) — done. The kernel keeps the capability; the schema stops claiming a saved pipeline can express it. Re-adding it means adding the spectrum's field too, which is additive and needs no migration. This closes the question open since pull request #22.
 
 ### What to be careful about in 1.2
 
-- **The frontend should need no changes at all.** If a screen has to be edited to work against the real backend, the 1.1 contract was wrong, and *that is the finding* — record it rather than quietly adjusting the screen.
+- **The frontend should need no changes at all.** If a screen has to be edited to work against the real backend, the 1.1 contract was wrong, and *that is the finding* — record it rather than quietly adjusting the screen. #82 is the shape to copy: the schema narrowed, the fixture regenerated, and the inspector's generated form followed with no screen touched.
 - **Four affordances die in #89**: `?empty`, `?oversize`, `?failrun` and `X-Stub-Fail`. Grep for them; each has a comment saying it is 1.1-only.
 - **Seven handlers in `stub/server.py` carry `Phase 1.2:` markers** naming the issue that replaces each. Grep `Phase 1.2:`.
-- **`preprocessing.from_spec` is the executor's seam.** It covers every step the schema can express and needs one thing from outside the schema: the axis for `RangeSelect`, which #77 provides off the `DatasetVersion`.
 - **The validator has two warnings specified and nothing emitting them** (#84): a `MeanCentre` or `Autoscale` upstream of a split leaks validation samples into the training statistics and makes RMSECV optimistic; a PLS node with no centring upstream is legal and almost always wrong. `metrics-and-validation.md` §9 and `pls-regression.md` §3. **The 1.1 validate endpoint returns `valid: true` unconditionally** — a stub with a GUESS envelope, and this is what fills it.
 - **The metrics gap (#88) is a Phase 0 inheritance**: SEC, SEP, Q² and `coefficients_original_units` are specified in `metrics-and-validation.md` §5–§6 and not implemented. Nothing verified them in #12.
 - **Tecator at 100 variables never exercised x-axis decimation.** #86 needs a dataset big enough to actually drop points along the wavelength axis.
@@ -65,11 +66,19 @@ Finish #77, then **#78 — the reader interface and the CSV/TXT reader**. CSV/TX
 - **Parity against a commercial package** — `PROPOSAL.md` §19 Q4 is unresolved. The EULA is not public; a licence would have to be confirmed and written permission sought before publishing a comparison.
 - Remaining open questions are in `PROPOSAL.md` §19 — team and pace, funding intent, project name.
 
-**Answered and recorded, so they are not re-opened:** whether Phase 1.1 warranted its own release (yes — `v0.2.0`, 2026-08-26), `MSC(reference="supplied")` (removed from the enum in #82), whether the import and empty-project screens needed artboards first (no), and where 1.2's persistence lands (project directory in 1.2, SQLite in 1.3).
+**Answered and recorded, so they are not re-opened:** whether Phase 1.1 warranted its own release (yes — `v0.2.0`, 2026-08-26), `MSC(reference="supplied")` (removed from the enum in #82, 2026-08-27), whether the import and empty-project screens needed artboards first (no), and where 1.2's persistence lands (project directory in 1.2, SQLite in 1.3).
 
 ## Carried forward from the specifications
 
 Findings that change downstream work, recorded here because they are easy to miss inside long documents.
+
+From #78–#80 (the readers), which #81 builds on:
+
+- **The reader interface is `sniff`, `read` and `head`.** `sniff` returns a `Detection` with a `Choice` for every guess; `read` takes a `Detection` — the one `sniff` returned, or that one with the user's corrections folded in. That is what stops a correction being displayed and then ignored, and it is the shape #81's preview and commit endpoints have to expose.
+- **Everything three formats share lives in `readers/grid.py`.** #79 moved header detection, orientation, column classification, the axis rules and the preview head out of `delimited.py`; `delimited.py` keeps only what text has. #78's 34 tests passing unchanged against that move is the evidence it preserved behaviour.
+- **A correction that cannot be applied is refused, not dropped.** A delimiter correction on a workbook fails; JCAMP's `correctable` is empty because nothing in the file is a guess. Silently ignoring one is the same lie as never offering it.
+- **Three formats, one dataset, agreeing within 1e-4.** `tecator_subset.csv`, `.xlsx` and `.jdx` carry the same eight samples and twelve channels, and a test asserts the three readers agree. Any new reader should join that comparison rather than get its own private fixture.
+- **An axis is read or numbered, never invented.** A headerless text file gets an index axis with a note; JCAMP reads `##FIRSTX`/`##LASTX`/`##NPOINTS` and refuses a file lacking them; `MICROMETERS` is left numbered rather than converted.
 
 From #24 (the R references), which changed what the parity report can claim:
 

--- a/src/chemometrics_workbench/models.py
+++ b/src/chemometrics_workbench/models.py
@@ -196,7 +196,11 @@ class SNV(Frozen):
 
 class MSC(Frozen):
     kind: Literal["msc"] = "msc"
-    reference: Literal["mean", "median", "supplied"] = "mean"
+    # No "supplied": the kernel's MSCTransformer takes a reference spectrum,
+    # but a step has no field to carry one, so a saved pipeline could never
+    # express it and the executor could only raise. Re-adding it means adding
+    # the spectrum's field too, which is additive and needs no migration.
+    reference: Literal["mean", "median"] = "mean"
 
 
 class SavitzkyGolay(Frozen):

--- a/src/chemometrics_workbench/preprocessing.py
+++ b/src/chemometrics_workbench/preprocessing.py
@@ -278,9 +278,9 @@ class MSCTransformer(Transformer):
         if reference == "supplied":
             if reference_spectrum is None:
                 raise ValueError(
-                    "reference='supplied' needs a reference_spectrum. The schema's "
-                    "MSC step carries the choice but not the spectrum itself, so the "
-                    "caller must pass it."
+                    "reference='supplied' needs a reference_spectrum. This is a "
+                    "library call only: the schema's MSC step offers 'mean' and "
+                    "'median', so a saved pipeline never reaches here."
                 )
             supplied = np.asarray(reference_spectrum, dtype=np.float64).ravel()
             if not np.isfinite(supplied).all():
@@ -491,7 +491,6 @@ def from_spec(
     step: PreprocessStep,
     *,
     axis: object | None = None,
-    reference_spectrum: object | None = None,
 ) -> Transformer:
     """Build the transformer a `PreprocessStep` describes.
 
@@ -499,17 +498,17 @@ def from_spec(
     discriminated union is worth having: an unsupported step fails here with
     its name, rather than halfway through a ten-minute cross-validation.
 
-    Two steps need something the schema does not carry. `RangeSelect` needs
+    One step needs something the schema does not carry: `RangeSelect` needs
     the variable axis, which belongs to the dataset rather than to the recipe.
-    `MSC(reference="supplied")` needs the reference spectrum, which the schema
-    has no field for — a real gap, and a schema change rather than something
-    to paper over here.
+    Everything else is built from the step alone. `MSC(reference="supplied")`
+    used to be the second such case; the schema no longer offers it, so there
+    is nothing here to raise about.
     """
     match step:
         case SNV():
             return SNVTransformer()
         case MSC():
-            return MSCTransformer(step.reference, reference_spectrum)
+            return MSCTransformer(step.reference)
         case MeanCentre():
             return MeanCentreTransformer()
         case Autoscale():

--- a/stub/fixtures/step_schema.json
+++ b/stub/fixtures/step_schema.json
@@ -100,8 +100,7 @@
           "default": "mean",
           "enum": [
             "mean",
-            "median",
-            "supplied"
+            "median"
           ],
           "title": "Reference",
           "type": "string"

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from chemometrics_workbench.models import (
     MSC,
@@ -462,10 +463,20 @@ def test_from_spec_needs_the_axis_for_range_selection() -> None:
         from_spec(RangeSelect(start=1.0, end=2.0))
 
 
-def test_from_spec_needs_the_spectrum_for_a_supplied_msc_reference() -> None:
-    """A real schema gap: MSC carries the choice but not the spectrum."""
-    with pytest.raises(ValueError, match="needs a reference_spectrum"):
-        from_spec(MSC(reference="supplied"))
+def test_the_schema_does_not_offer_an_msc_reference_from_spec_cannot_build() -> None:
+    """The gap closed by narrowing the enum rather than by raising in the seam.
+
+    The kernel still takes a supplied reference - it is a legitimate library
+    call - but a step has no field for the spectrum, so the schema no longer
+    claims a saved pipeline can express one.
+    """
+    with pytest.raises(ValidationError):
+        MSC(reference="supplied")
+
+    reference = _spectra().mean(axis=0)
+    kernel = MSCTransformer("supplied", reference_spectrum=reference).fit(_spectra())
+    assert kernel.reference_ is not None
+    np.testing.assert_allclose(kernel.reference_, reference)
 
 
 def test_baseline_parameters_left_unset_in_the_schema_take_the_kernel_defaults() -> None:


### PR DESCRIPTION
`MSCStep.reference` offered `"supplied"`, but a step has no field for the reference spectrum itself, so a saved pipeline could never express that choice and `from_spec` could only raise on it. The schema was advertising a capability the executor does not have — and #83 is about to be written against this enum.

## What changed

- **`models.py`** — the enum narrows to `Literal["mean", "median"]`, with a comment at the field recording why the third option went and what re-adding it would need. The next person to want it finds the reason at the code, not in a closed issue.
- **`preprocessing.from_spec`** — loses its `reference_spectrum` parameter outright rather than keeping a dead argument, and the docstring loses the gap it documented. There is no longer a case to raise about.
- **The kernel is untouched.** `MSCTransformer("supplied", reference_spectrum=...)` is a legitimate library call and stays one; what goes is the schema's claim that a saved pipeline can express it. Its error message no longer says the schema carries the choice, because it no longer does.
- **`step_schema.json` regenerated** — one diff, the MSC enum. The inspector builds its form from that schema, so the form follows with no screen edited.

## Evidence

- `grep -rn '"supplied"' src/` returns the kernel's own `MSCReference` literal and its two branches in `MSCTransformer`, plus the two comments explaining the absence. No schema field.
- Regenerating the fixtures leaves the pipeline and dataset content hashes unchanged (`sha256:9a684f48…`, `sha256:e435c053…`) — this narrowed a form, not a number.
- `uv run pytest` — 603 passed, 1 skipped, including the parity cases.
- `uv run ruff check .` and `ruff format --check .` clean over 58 files; `uv run mypy` clean over 38 source files.
- `pnpm test` — 52 passed, the inspector test now expecting two MSC references. `pnpm e2e` — 40 passed.

A test replaces the one that asserted `from_spec` raised: the step now raises `ValidationError`, and the kernel call is asserted alongside it, so what went and what stayed are recorded in the same place.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyipBcx3Reb39zwk1BHgws