### PR TITLE
Phase 1.2 · Pipeline executor

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -168,7 +168,7 @@
         "drop-msc-supplied"
       ],
       "user_visible_behavior": "A pipeline runs from a real dataset: each node's output is computed once, cached on disk, and recomputed only when it or something upstream of it changes.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "The pipeline the 1.1 fixture publishes executes end to end and reproduces the fixture's arrays.",
         "Editing one node recomputes it and its descendants, and nothing else.",
@@ -177,8 +177,26 @@
         "A step that fails names the node it failed at.",
         "Moving a node on the canvas does not invalidate a cached result."
       ],
+      "evidence": "2026-08-27. On feature/83_pipeline-executor. New module src/chemometrics_workbench/executor.py and 22 tests in tests/test_executor.py; uv run pytest is 625 passed, 1 skipped (603 before), ruff check, ruff format --check and mypy over 40 source files all clean. End to end: the pipeline the 1.1 fixture publishes - rebuilt in the test and asserted node for node against pipeline.json, because stub/ is deleted in #89 - runs against Tecator in a real project directory and reproduces every array spectra.json serves except centre_d. The agreement is to 2e-6 on eight nodes and 5e-5 on autoscale_c, and both numbers are measured rather than chosen: the same chain computed in float64 agrees with the fixture to 5.0e-07, which is its 6-decimal rounding, and going through the array store's float32 moves the worst node to 1.3e-06 - except autoscale_c, where a first derivative cancels most of the signal and autoscaling then divides by a small standard deviation, measured at 2.8e-05. centre_d is a deliberate divergence, raised as #97: the fixture fits it on all 240 samples and metrics-and-validation.md §9 requires refitting on the training fold alone. The test computes both, asserts the fixture holds the fit-on-everything number (4.9e-07) and that the executor differs from it by more than 1e-4 (1.2e-03), and then reproduces the executor's own value from fold arithmetic done by hand. Every sample's displayed row comes from the fold that held it out, checked over all 240 rather than on one row. Caching: keys are a merkle chain - a node's own JSON, the source keyed on the dataset version, chained through its inputs' keys - so a second run recomputes nothing, editing branch C's Savitzky-Golay recomputes exactly savgol and autoscale_c, and editing centre_d below the split recomputes only centre_d. A pipeline with a different pipeline_id and name hashes every node identically and reruns nothing, which is what makes moving a node on the canvas safe: layout coordinates live in pipeline_state.json, outside the model the key is taken from. A different dataset version reruns everything. A pruned array file and a corrupt cache.json each cost a recomputation rather than an error. Every node's output is read back out of the store before its successors see it, so a run that hit the cache and a run that recomputed agree bit for bit - checked with assert_array_equal, not allclose. RangeSelect takes its axis off the DatasetVersion: start=900 end=1000 keeps the 51 channels the axis says and nothing about the recipe knows what a nanometre is. Failures name the node: a one-variable window then SNV is \"node 'scatter' (snv) failed: SNV with ddof=1 needs more than 1 variables\", the same below a split adds \"on a training fold of 216 samples\", a split below a split, a train_test split with no splitter yet, a version whose array is not the shape it records, and a missing array file are each refused by name. Leave-one-out is the other splitter that works, checked on 8 samples against 8 hand-computed leave-one-out means. Estimator nodes are walked and reported in Run.pending_estimators, not fitted - what a fitted estimator stores is #87's subject.",
+      "notes": "preprocessing.from_spec is the seam and already covers every step the schema can express. The kernels stay pure - no caching or job logic leaks into preprocessing.py. Estimator fitting is deliberately not here: it is #87's subject, and the executor reports estimator nodes in Run.pending_estimators rather than guessing at what a fitted one should store. The fixture's centre_d array cannot be reproduced under metrics-and-validation.md §9 and the divergence is raised as #97."
+    },
+    {
+      "id": "fixture-centre-d-fold-fit",
+      "priority": 9,
+      "area": "backend",
+      "issue": 97,
+      "title": "The fixture's centre_d array is fitted on all samples, and the executor differs",
+      "depends_on": [
+        "pipeline-executor"
+      ],
+      "user_visible_behavior": "The spectra view of a node below a split shows what actually happened to each sample - the fold that held it out - rather than a mean taken over the samples it is being validated against.",
+      "status": "not_started",
+      "verification": [
+        "The decision is recorded: either spectra.json is regenerated with the out-of-fold array, or the exception is written where the fixture rule is stated.",
+        "#87 asserts whichever was chosen, and does not assert the other."
+      ],
       "evidence": "",
-      "notes": "preprocessing.from_spec is the seam and already covers every step the schema can express. The kernels stay pure - no caching or job logic leaks into preprocessing.py."
+      "notes": "Found in #83 and measured there: fit-on-everything agrees with the fixture to 4.9e-07, out of fold differs by 1.2e-03. metrics-and-validation.md §9 requires the fold fit; the fixture's run_preprocessing says in its own docstring that it does no fold handling. Blocks nothing - #86 and #87 both need to know which array centre_d holds."
     },
     {
       "id": "pipeline-validator",

--- a/session-handoff.md
+++ b/session-handoff.md
@@ -10,7 +10,7 @@ Compact state for the next session. **Overwrite this file at the end of every se
 
 **Phase 0 is released and tagged `v0.1.0`. Phase 1.1 is released and tagged `v0.2.0`.** The walking skeleton walks: the React shell and its five core screens, over a token-authenticated stub FastAPI server on `127.0.0.1`, with a Playwright walkthrough green in CI.
 
-**Phase 1.2 is six features in, of fifteen.** The project directory and the array store are real, all three readers are written, and the schema no longer advertises a step the executor could not run.
+**Phase 1.2 is seven features in, of sixteen.** The project directory and the array store are real, all three readers are written, the schema no longer advertises a step the executor could not run, and the executor itself runs a pipeline from a real dataset with a cache that recomputes only what changed. One new issue came out of the executor — #97, listed below.
 
 **1.2's exit criterion:** #50's walkthrough passes against the real backend, on a file the user picks, with `stub/` deleted (#90).
 
@@ -23,7 +23,8 @@ Compact state for the next session. **Overwrite this file at the end of every se
 | E | JCAMP-DX reader | #80 | C | passing |
 | F | Import endpoints | #81 | B, C | not started |
 | G | Drop `MSC(reference="supplied")` | #82 | A | passing |
-| H | Pipeline executor | #83 | B, G | not started |
+| H | Pipeline executor | #83 | B, G | passing |
+| H′ | The fixture's `centre_d` array | #97 | H | not started |
 | I | Pipeline validator | #84 | H | not started |
 | J | Real jobs | #85 | H | not started |
 | K | Server-side decimation and the density band | #86 | H | not started |
@@ -32,7 +33,7 @@ Compact state for the next session. **Overwrite this file at the end of every se
 | N | HTTP surface complete, stub retired | #89 | F, J, K, L | not started |
 | O | 1.2's exit criterion as a test | #90 | I, N | not started |
 
-Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M depends on nothing in 1.2**, so it is what to pick up if the chain is ever blocked.
+Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M depends on nothing in 1.2**, so it is what to pick up if the chain is ever blocked. **H′ (#97) blocks nothing**, but #86 and #87 both need its answer before they assert anything about `centre_d`.
 
 ## Current work
 
@@ -49,6 +50,7 @@ Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M dep
 1. **The project directory and the array store land in 1.2; SQLite stays in 1.3.** Files are real from 1.2 — a restart loses the project *list*, not the data.
 2. **All three readers land in 1.2** — done, and #78's interface survived being generalised by #79 and re-proven by #80.
 3. **`MSC(reference="supplied")` is removed from the enum** (#82) — done. The kernel keeps the capability; the schema stops claiming a saved pipeline can express it. Re-adding it means adding the spectrum's field too, which is additive and needs no migration. This closes the question open since pull request #22.
+4. **Estimator fitting is #87's, not the executor's** (taken in #83). `execute` walks estimator nodes and reports them in `Run.pending_estimators` rather than fitting them, because what a fitted estimator stores — with which diagnostics and which limits — is exactly what #87 specifies. Guessing at it in #83 would have been the invented contract Phase 1.1 existed to avoid.
 
 ### What to be careful about in 1.2
 
@@ -71,6 +73,14 @@ Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M dep
 ## Carried forward from the specifications
 
 Findings that change downstream work, recorded here because they are easy to miss inside long documents.
+
+From #83 (the executor), which #84 to #87 all build on:
+
+- **A node below a split has one array per fold, and displays them assembled out of fold.** `metrics-and-validation.md` §9 refits every node downstream of a split on the training fold alone; the array such a node shows takes each sample's row from the fold that held it out. This is why the fixture's `centre_d` is not reproduced — **#97**, measured there rather than argued.
+- **Cache keys are a merkle chain, not a flag.** A node's key is its own JSON plus its inputs' keys, with the source keyed on the dataset version. Editing a node changes its key and its descendants' and nothing else's, so staleness is arithmetic. Layout coordinates are not in the model at all, so a node cannot be moved into a cache miss.
+- **Every node's output is read back out of the store before its successors see it.** Otherwise a run that hit the cache and a run that recomputed would disagree in the last digits — a cache that changes an answer. The cost is that all numbers carry float32 truncation from the first node on; the fixture comparison measures it at 1.3e-06 worst case, and at 2.8e-05 for `autoscale_c`, where a derivative cancels the signal and autoscaling divides by what is left.
+- **`Run.pending_estimators` is the seam #87 picks up.** The executor names the estimator nodes it did not fit rather than skipping them silently.
+- **A second `RangeSelect` below a first one fails, by design.** The axis comes from the `DatasetVersion`, and the first selection has already dropped variables, so the second is refused on the shape with its node named. Threading a per-node axis through the walk would make a recipe's meaning depend on where its node sits — a schema question, not an executor one.
 
 From #78–#80 (the readers), which #81 builds on:
 

--- a/src/chemometrics_workbench/executor.py
+++ b/src/chemometrics_workbench/executor.py
@@ -1,0 +1,476 @@
+"""The pipeline executor: the only path from a dataset to a result.
+
+`PROPOSAL.md` §11 puts one rule above the rest — the kernels are pure
+functions over arrays with no knowledge of the application, and the executor
+holds the orchestration. So nothing here reaches into `preprocessing.py`, and
+nothing about caching, folds or jobs is added to it. `from_spec` is the seam,
+and after #82 it needs exactly one thing the recipe does not carry: the
+variable axis for `RangeSelect`, which belongs to the `DatasetVersion`.
+
+## What a node's output is
+
+One array per node, `n_samples x n_variables`, stored through #77's array
+store — float32 on disk, float64 at the kernel boundary, converted at that
+boundary and nowhere else.
+
+Every node's output is read back out of the store before the nodes below it
+see it. A node therefore computes from what is on disk, not from the float64
+it would have held in memory, and a run that hit the cache agrees with a run
+that recomputed to the last bit. The alternative is a cache that changes an
+answer, which is worse than a slow one.
+
+A node *below a split* has one array per fold instead, because
+`metrics-and-validation.md` §9 says every node downstream of the split is
+refitted on the training fold alone. Fold `i`'s array holds every sample
+transformed with fold `i`'s fitted parameters; the training rows are the ones
+that fitted them and the held-out rows are the ones pushed through, which is
+the same array indexed two ways rather than two arrays to keep in step.
+
+The single array such a node *displays* is assembled out of fold: each sample
+takes the row from the fold that held it out. Every sample appears exactly
+once — that is what `validate_partition` guarantees — so the assembled array
+is the same shape as an unsplit node's, and every row in it was produced by
+parameters that never saw that row.
+
+## Caching, and what invalidates it
+
+Each node has a key: the SHA-256 of its own JSON together with the keys of its
+inputs, with the source node keyed on the dataset version instead. A merkle
+chain, so editing a node changes that node's key and every descendant's, and
+nothing else's — which is the staleness rule stated as arithmetic rather than
+maintained as a separate flag.
+
+The key is derived from the same node JSON `Pipeline.content_hash` uses, and
+canvas coordinates live in `pipeline_state.json` outside the model entirely.
+A node cannot be moved into a cache miss.
+
+The index from key to stored path is `cache.json` in the project directory.
+The arrays themselves are content-addressed by the store, so two nodes that
+compute the same values share one file.
+
+## What is not here
+
+**Estimators.** An `EstimatorNode` is walked and reported in
+`Run.pending_estimators`, not fitted: what a fitted estimator stores, and with
+which diagnostics and limits, is #87's subject, and guessing at it here would
+be the invented contract Phase 1.1 existed to avoid.
+
+**Jobs.** `execute` runs to completion in the calling thread. Progress,
+cancellation and failure reporting are #85, which wraps this.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+from chemometrics_workbench import preprocessing
+from chemometrics_workbench.models import (
+    DatasetVersion,
+    KFoldSplit,
+    LeaveOneOut,
+    NodeId,
+    Pipeline,
+    PipelineNode,
+    ResolvedSplit,
+)
+from chemometrics_workbench.project import ProjectError, read_array, write_array, write_json
+from chemometrics_workbench.validation import Fold, k_fold, leave_one_out, validate_partition
+
+__all__ = [
+    "CACHE_FILE",
+    "ExecutorError",
+    "NodeOutput",
+    "Run",
+    "execute",
+    "node_keys",
+]
+
+CACHE_FILE = "cache.json"
+
+
+class ExecutorError(Exception):
+    """A pipeline could not be executed, naming the node it stopped at.
+
+    One exception rather than a hierarchy, for the reason `ProjectError` is
+    one: the only caller that distinguishes cases is the HTTP layer, and it
+    turns all of them into the same error body. What the caller needs is the
+    node id, and every message carries it.
+    """
+
+
+@dataclass(frozen=True)
+class NodeOutput:
+    """Where one node's result is stored, and whether it had to be computed."""
+
+    node_id: NodeId
+    key: str
+    array_paths: tuple[str, ...]
+    content_hashes: tuple[str, ...]
+    n_samples: int
+    n_variables: int
+    from_cache: bool
+
+    @property
+    def array_path(self) -> str:
+        """The one array for a node above a split; fold zero's below one.
+
+        Callers that mean "the array to draw" want `Run.display`, which
+        assembles the out-of-fold rows. This is the stored path, and for a
+        split branch there is more than one.
+        """
+        return self.array_paths[0]
+
+    @property
+    def n_folds(self) -> int:
+        return len(self.array_paths)
+
+
+@dataclass(frozen=True)
+class Run:
+    """What one execution produced.
+
+    `displays` holds the arrays in memory because every caller in 1.2 wants
+    them immediately — the spectra endpoint to decimate, the tests to compare.
+    They are on disk as well, at the paths in `outputs`.
+    """
+
+    pipeline_id: str
+    outputs: dict[NodeId, NodeOutput]
+    displays: dict[NodeId, NDArray[np.float64]]
+    resolved_splits: list[ResolvedSplit]
+    pending_estimators: list[NodeId]
+
+    @property
+    def computed(self) -> list[NodeId]:
+        return [nid for nid, out in self.outputs.items() if not out.from_cache]
+
+    @property
+    def reused(self) -> list[NodeId]:
+        return [nid for nid, out in self.outputs.items() if out.from_cache]
+
+
+@dataclass
+class _State:
+    """A node's arrays as the walk carries them.
+
+    `arrays` is one array for a node above a split and one per fold below one.
+    `folds` is the split governing the node, inherited from its input, so a
+    node knows how it must be fitted without looking back up the graph.
+    """
+
+    arrays: list[NDArray[np.float64]]
+    folds: list[Fold] | None
+
+    @property
+    def display(self) -> NDArray[np.float64]:
+        if self.folds is None:
+            return self.arrays[0]
+        assembled = np.empty_like(self.arrays[0])
+        for fold, values in zip(self.folds, self.arrays, strict=True):
+            assembled[fold.test] = values[fold.test]
+        return assembled
+
+
+def execute(
+    directory: str | Path,
+    pipeline: Pipeline,
+    version: DatasetVersion,
+    *,
+    use_cache: bool = True,
+) -> Run:
+    """Run every preprocessing node in `pipeline` against `version`'s array.
+
+    The dataset is read from the project directory, not passed in: the array
+    store is the only place a dataset's values live, and a caller handing in
+    its own matrix could quietly execute a recipe against something other than
+    the version the experiment records.
+    """
+    path = Path(directory)
+    axis = np.asarray(version.axis.values, dtype=np.float64)
+    keys = node_keys(pipeline, version)
+    index = _load_index(path) if use_cache else {}
+
+    states: dict[NodeId, _State] = {}
+    outputs: dict[NodeId, NodeOutput] = {}
+    splits: list[ResolvedSplit] = []
+    pending: list[NodeId] = []
+    index_changed = False
+
+    for node in _topological(pipeline):
+        if node.type == "estimator":
+            pending.append(node.id)
+            continue
+
+        key = keys[node.id]
+        parent = states[node.inputs[0]] if node.inputs else None
+        folds = _folds_for(node, parent, version.n_samples)
+
+        cached = _from_cache(path, index.get(key), folds) if use_cache else None
+        state = cached or _compute(node, parent, folds, path, version, axis)
+
+        stored: list[str] = []
+        hashes: list[str] = []
+        for values in state.arrays:
+            array_path, content_hash = write_array(path, values)
+            stored.append(array_path)
+            hashes.append(content_hash)
+
+        if cached is None:
+            # Read back what was written, so a node's successors are fed the
+            # stored values rather than the float64 they were computed in.
+            # Otherwise a run that hit the cache and a run that recomputed
+            # would disagree in the last few digits, and a cache would be
+            # something that changes an answer. The narrowing itself stays
+            # where #77 put it, at the store.
+            state = _State(arrays=[read_array(path, p) for p in stored], folds=folds)
+
+        states[node.id] = state
+        if node.type == "split":
+            splits.append(_resolved(node.id, folds))
+
+        if use_cache and index.get(key) != stored:
+            index[key] = stored
+            index_changed = True
+
+        outputs[node.id] = NodeOutput(
+            node_id=node.id,
+            key=key,
+            array_paths=tuple(stored),
+            content_hashes=tuple(hashes),
+            n_samples=int(state.arrays[0].shape[0]),
+            n_variables=int(state.arrays[0].shape[1]),
+            from_cache=cached is not None,
+        )
+
+    if index_changed:
+        _save_index(path, index)
+
+    return Run(
+        pipeline_id=str(pipeline.pipeline_id),
+        outputs=outputs,
+        displays={nid: state.display for nid, state in states.items()},
+        resolved_splits=splits,
+        pending_estimators=pending,
+    )
+
+
+def node_keys(pipeline: Pipeline, version: DatasetVersion) -> dict[NodeId, str]:
+    """The cache key of every node: its own content, chained through its inputs.
+
+    Exposed because staleness is a question the HTTP surface has to answer
+    without running anything — #85 and #87 both need to say "this node's result
+    is out of date" — and re-deriving the rule in two places is how the two
+    answers drift apart.
+    """
+    by_id = {node.id: node for node in pipeline.nodes}
+    keys: dict[NodeId, str] = {}
+
+    def key_of(node_id: NodeId) -> str:
+        if node_id in keys:
+            return keys[node_id]
+        node = by_id[node_id]
+        # The node's own JSON, which is what `Pipeline.content_hash` hashes and
+        # therefore excludes identity, timestamps and anything the canvas
+        # stores about where the node sits.
+        parts = [node.model_dump_json()]
+        if node.type == "source":
+            parts.append(str(version.version_id))
+            parts.append(version.content_hash)
+        parts.extend(key_of(parent) for parent in node.inputs)
+        digest = hashlib.sha256("\x1f".join(parts).encode()).hexdigest()
+        keys[node_id] = digest
+        return digest
+
+    for node in pipeline.nodes:
+        key_of(node.id)
+    return keys
+
+
+# --- the walk -------------------------------------------------------------
+
+
+def _topological(pipeline: Pipeline) -> list[PipelineNode]:
+    """Inputs before the nodes that consume them.
+
+    `Pipeline` has already refused a cycle and an unknown input, so this only
+    has to order what is known to be a DAG.
+    """
+    by_id = {node.id: node for node in pipeline.nodes}
+    ordered: list[PipelineNode] = []
+    seen: set[NodeId] = set()
+
+    def visit(node_id: NodeId) -> None:
+        if node_id in seen:
+            return
+        seen.add(node_id)
+        for parent in by_id[node_id].inputs:
+            visit(parent)
+        ordered.append(by_id[node_id])
+
+    for node in pipeline.nodes:
+        visit(node.id)
+    return ordered
+
+
+def _folds_for(node: PipelineNode, parent: _State | None, n_samples: int) -> list[Fold] | None:
+    """The split governing a node: its own if it is one, else its input's."""
+    if node.type != "split":
+        return parent.folds if parent is not None else None
+
+    if parent is not None and parent.folds is not None:
+        raise ExecutorError(
+            f"node {node.id!r} is a split below another split. Nested resampling is "
+            "not modelled: the inner folds would have no defined relationship to "
+            "the outer ones, and the experiment record has one ResolvedSplit per "
+            "split node with no way to say which outer fold it belonged to."
+        )
+
+    spec = node.spec
+    if isinstance(spec, KFoldSplit):
+        folds = k_fold(n_samples, spec.n_splits, shuffle=spec.shuffle, seed=spec.seed)
+    elif isinstance(spec, LeaveOneOut):
+        folds = leave_one_out(n_samples)
+    else:
+        raise ExecutorError(
+            f"node {node.id!r} asks for the {spec.kind!r} split, which has no splitter "
+            "yet. K-fold and leave-one-out are implemented; train/test, repeated "
+            "K-fold and an external set are not."
+        )
+
+    validate_partition(folds, n_samples)
+    return folds
+
+
+def _compute(
+    node: PipelineNode,
+    parent: _State | None,
+    folds: list[Fold] | None,
+    directory: Path,
+    version: DatasetVersion,
+    axis: NDArray[np.float64],
+) -> _State:
+    """One node's arrays, computed from its input's."""
+    if node.type == "source":
+        try:
+            values = read_array(directory, version.array_path)
+        except ProjectError as error:
+            raise ExecutorError(f"node {node.id!r} could not read the dataset: {error}") from error
+        if values.shape != (version.n_samples, version.n_variables):
+            raise ExecutorError(
+                f"node {node.id!r} read a {values.shape[0]}x{values.shape[1]} array where "
+                f"the version records {version.n_samples}x{version.n_variables}."
+            )
+        return _State(arrays=[values], folds=None)
+
+    assert parent is not None, "only a source node has no input, and it returned above"
+
+    if node.type == "split":
+        # A split changes which rows fit what below it, never the values. Every
+        # fold starts from the same input array - the same object, and one file
+        # in the content-addressed store - and the nodes below diverge from
+        # there.
+        assert folds is not None, "a split node always resolves its folds"
+        return _State(arrays=[parent.arrays[0]] * len(folds), folds=folds)
+
+    if node.type != "preprocess":
+        raise ExecutorError(f"node {node.id!r} has type {node.type!r}, which is not executable.")
+
+    if folds is None:
+        return _State(arrays=[_transform(node, parent.arrays[0], None, axis)], folds=None)
+
+    # §9: refitted on the training fold alone, and the held-out rows pushed
+    # through those parameters. Fitting on `values[fold.train]` and then
+    # transforming every row gives both in one call, because a fitted
+    # transformer treats each row independently of the others.
+    return _State(
+        arrays=[
+            _transform(node, values, fold, axis)
+            for values, fold in zip(parent.arrays, folds, strict=True)
+        ],
+        folds=folds,
+    )
+
+
+def _transform(
+    node: PipelineNode,
+    values: NDArray[np.float64],
+    fold: Fold | None,
+    axis: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Build the step's transformer, fit it, apply it — naming the node if it fails."""
+    assert node.type == "preprocess"
+    try:
+        transformer = preprocessing.from_spec(node.step, axis=axis)
+        transformer.fit(values if fold is None else values[fold.train])
+        return transformer.transform(values)
+    except (ValueError, RuntimeError, NotImplementedError) as error:
+        where = "" if fold is None else f" on a training fold of {fold.train.size} samples"
+        raise ExecutorError(
+            f"node {node.id!r} ({node.step.kind}) failed{where}: {error}"
+        ) from error
+
+
+def _resolved(node_id: NodeId, folds: list[Fold] | None) -> ResolvedSplit:
+    """The index sets a split produced, stored so the run can be repeated (§10)."""
+    assert folds is not None, "a split node always resolves its folds"
+    return ResolvedSplit(
+        node_id=node_id,
+        train_indices=[fold.train.tolist() for fold in folds],
+        test_indices=[fold.test.tolist() for fold in folds],
+    )
+
+
+# --- the cache index ------------------------------------------------------
+
+
+def _from_cache(
+    directory: Path, stored: list[str] | None, folds: list[Fold] | None
+) -> _State | None:
+    """Read a node's arrays back, or `None` if they cannot be served.
+
+    A missing file is a miss rather than an error: the index is a hint about
+    what has been computed, and a project whose `arrays/` has been pruned
+    should recompute rather than refuse to run.
+    """
+    if not stored:
+        return None
+    expected = 1 if folds is None else len(folds)
+    if len(stored) != expected:
+        return None
+    try:
+        arrays = [read_array(directory, path) for path in stored]
+    except ProjectError:
+        return None
+    return _State(arrays=arrays, folds=folds)
+
+
+def _load_index(directory: Path) -> dict[str, list[str]]:
+    """The key-to-paths index, or an empty one if it is absent or unreadable.
+
+    A corrupt index costs a recomputation, which is the cheapest possible
+    failure here and the reason it is not an error.
+    """
+    try:
+        document = json.loads((directory / CACHE_FILE).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(document, dict):
+        return {}
+    return {
+        key: [str(path) for path in value]
+        for key, value in document.items()
+        if isinstance(key, str) and isinstance(value, list)
+    }
+
+
+def _save_index(directory: Path, index: dict[str, list[str]]) -> None:
+    # ponytail: the index only grows - an edited-away node's entry stays, and
+    # so does its array. Pruning wants a mark-and-sweep against the pipelines
+    # in the project, which is #89's business once there is a list of them.
+    write_json(directory / CACHE_FILE, index)

--- a/src/chemometrics_workbench/project.py
+++ b/src/chemometrics_workbench/project.py
@@ -59,6 +59,7 @@ __all__ = [
     "open_project",
     "read_array",
     "write_array",
+    "write_json",
 ]
 
 PROJECT_FILE = "project.json"
@@ -173,14 +174,16 @@ def _write_project_file(path: Path, project: Project) -> None:
     """
     record = project.model_dump(mode="json", exclude={"directory"})
     document = {"layout_version": LAYOUT_VERSION, "project": record}
-    _write_json(path / PROJECT_FILE, document)
+    write_json(path / PROJECT_FILE, document)
 
 
-def _write_json(path: Path, document: Any) -> None:
+def write_json(path: Path, document: Any) -> None:
     """Write JSON through a temporary file, so an interrupted write loses nothing.
 
     A half-written `project.json` is a project the user can no longer open. The
-    rename is atomic on every platform we ship to.
+    rename is atomic on every platform we ship to. Public because every small
+    document written inside a project directory wants the same guarantee - the
+    executor's cache index is the second.
     """
     temporary = path.with_name(path.name + ".tmp")
     try:
@@ -347,4 +350,4 @@ def _write_registry(entries: list[dict[str, str]]) -> None:
         directory.mkdir(parents=True, exist_ok=True)
     except OSError as error:
         raise ProjectError(f"cannot write the project registry: {error.strerror}") from error
-    _write_json(directory / REGISTRY_FILE, entries)
+    write_json(directory / REGISTRY_FILE, entries)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,578 @@
+"""Tests for the pipeline executor.
+
+The claim that matters most is the first one: the pipeline the Phase 1.1
+fixture publishes executes end to end against the real dataset and reproduces
+the arrays that fixture serves. Everything else here is about the executor's
+own behaviour — what it recomputes, what it reuses, and what it refuses.
+
+The one array the executor does *not* reproduce is `centre_d`, and that is a
+finding rather than a failure: see
+`test_a_node_below_a_split_is_refitted_per_fold_which_the_fixture_is_not`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+import numpy as np
+import pytest
+
+from chemometrics_workbench import preprocessing, validation
+from chemometrics_workbench.datasets import load_tecator
+from chemometrics_workbench.executor import (
+    CACHE_FILE,
+    ExecutorError,
+    execute,
+    node_keys,
+)
+from chemometrics_workbench.models import (
+    MSC,
+    SNV,
+    Autoscale,
+    DatasetVersion,
+    EstimatorNode,
+    KFoldSplit,
+    LeaveOneOut,
+    MeanCentre,
+    PCASpec,
+    Pipeline,
+    PreprocessNode,
+    RangeSelect,
+    SavitzkyGolay,
+    SourceNode,
+    SplitNode,
+    TrainTestSplit,
+)
+from chemometrics_workbench.project import create_project, write_array
+
+FIXTURES = Path(__file__).resolve().parents[1] / "stub" / "fixtures"
+
+#: Two effects put a floor under agreement with the fixture, and neither is a
+#: divergence. `generate_fixtures._round` writes six decimal places, worth up
+#: to 5e-7. And the executor works from the array store, which is float32 on
+#: disk by #77's boundary, while the fixture computed in float64 straight out
+#: of `load_tecator()`: computing the same chain in float64 here agrees with
+#: the fixture to 5.0e-07, and through the store the worst node moves to
+#: 1.3e-06. A real divergence is orders of magnitude larger - the one below is
+#: 1.2e-03.
+ROUNDING = 2e-6
+
+#: Except at `autoscale_c`, where float32 is amplified rather than carried: a
+#: first derivative is a difference of neighbours, most of the signal cancels,
+#: and autoscaling then divides by a small standard deviation. Measured at
+#: 2.8e-05 through the store against 5.0e-07 in float64, so the amplification
+#: is the store and not the kernel. Worth its own number rather than one loose
+#: tolerance over every node, which would stop the others saying anything.
+AMPLIFIED_BY_FLOAT32 = 5e-5
+
+
+# --------------------------------------------------------------------------
+# a project with the real dataset in it
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def tecator() -> Any:
+    return load_tecator()
+
+
+@pytest.fixture
+def project(tmp_path: Path, tecator: Any) -> tuple[Path, DatasetVersion]:
+    """A project directory holding Tecator, and the version that describes it."""
+    directory = tmp_path / "project"
+    create_project(directory, "executor tests")
+    array_path, _ = write_array(directory, tecator.spectra)
+    version = DatasetVersion(
+        dataset_id=uuid4(),
+        version=1,
+        content_hash=tecator.source.file_hash,
+        n_samples=tecator.n_samples,
+        n_variables=tecator.n_variables,
+        axis=tecator.axis,
+        sample_ids=list(tecator.sample_ids),
+        array_path=array_path,
+    )
+    return directory, version
+
+
+def _pipeline(version_id: UUID, *nodes: Any) -> Pipeline:
+    return Pipeline(
+        project_id=uuid4(),
+        name="test",
+        nodes=[SourceNode(id="source", version_id=version_id), *nodes],
+    )
+
+
+def fixture_pipeline(version_id: UUID) -> Pipeline:
+    """The four branches `stub/generate_fixtures.py` publishes, rebuilt here.
+
+    Rebuilt rather than imported because `stub/` is deleted in #89 and this
+    test outlives it. The recipe is asserted against the fixture's own
+    `pipeline.json` below, so the copy cannot drift while the fixture lasts.
+    """
+    savgol = SavitzkyGolay(window_length=11, polyorder=2, deriv=1)
+    return _pipeline(
+        version_id,
+        PreprocessNode(id="snv", inputs=("source",), step=SNV()),
+        PreprocessNode(id="centre_a", inputs=("snv",), step=MeanCentre()),
+        EstimatorNode(id="pca_a", inputs=("centre_a",), spec=PCASpec(n_components=5)),
+        PreprocessNode(id="msc", inputs=("source",), step=MSC()),
+        PreprocessNode(id="centre_b", inputs=("msc",), step=MeanCentre()),
+        EstimatorNode(id="pca_b", inputs=("centre_b",), spec=PCASpec(n_components=5)),
+        PreprocessNode(id="savgol", inputs=("source",), step=savgol),
+        PreprocessNode(id="autoscale_c", inputs=("savgol",), step=Autoscale()),
+        EstimatorNode(id="pca_c", inputs=("autoscale_c",), spec=PCASpec(n_components=5)),
+        PreprocessNode(id="snv_savgol", inputs=("snv",), step=savgol),
+        SplitNode(id="split_d", inputs=("snv_savgol",), spec=KFoldSplit(n_splits=10, seed=42)),
+        PreprocessNode(id="centre_d", inputs=("split_d",), step=MeanCentre()),
+        EstimatorNode(id="pca_d", inputs=("centre_d",), spec=PCASpec(n_components=5)),
+    )
+
+
+def _as_stored(values: np.ndarray) -> np.ndarray:
+    """What the array store gives back: float32 on disk, float64 to a kernel.
+
+    A hand-computed comparison has to pass through the same boundary, or it is
+    comparing the executor's stored numbers against float64 ones and calling
+    #77's documented narrowing a divergence.
+    """
+    return values.astype(np.float32).astype(np.float64)
+
+
+def _fixture_rows(node_id: str) -> dict[int, np.ndarray]:
+    """The sample rows `spectra.json` draws for one node, by sample index."""
+    payload = json.loads((FIXTURES / "spectra.json").read_text(encoding="utf-8"))[node_id]
+    return {trace["index"]: np.asarray(trace["y"], dtype=float) for trace in payload["traces"]}
+
+
+# --------------------------------------------------------------------------
+# the claim: the fixture's pipeline runs and reproduces the fixture's arrays
+# --------------------------------------------------------------------------
+
+
+def test_the_recipe_here_is_the_one_the_fixture_publishes(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """`fixture_pipeline` is a copy, so it is checked against the original."""
+    _, version = project
+    published = json.loads((FIXTURES / "pipeline.json").read_text(encoding="utf-8"))
+    mine = json.loads(fixture_pipeline(version.version_id).model_dump_json())
+
+    assert [n["id"] for n in mine["nodes"]] == [n["id"] for n in published["nodes"]]
+    for node, original in zip(mine["nodes"], published["nodes"], strict=True):
+        # Everything but the source's version id, which points at this project.
+        assert {k: v for k, v in node.items() if k != "version_id"} == {
+            k: v for k, v in original.items() if k != "version_id"
+        }
+
+
+def test_the_fixture_pipeline_executes_and_reproduces_the_fixture_arrays(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    run = execute(directory, fixture_pipeline(version.version_id), version)
+
+    # Every preprocessing node ran; the estimators are reported, not fitted.
+    assert set(run.displays) == {
+        "source",
+        "snv",
+        "centre_a",
+        "msc",
+        "centre_b",
+        "savgol",
+        "autoscale_c",
+        "snv_savgol",
+        "split_d",
+        "centre_d",
+    }
+    assert run.pending_estimators == ["pca_a", "pca_b", "pca_c", "pca_d"]
+
+    for node_id in ("source", "snv", "centre_a", "msc", "centre_b", "savgol", "autoscale_c"):
+        computed = run.displays[node_id]
+        tolerance = AMPLIFIED_BY_FLOAT32 if node_id == "autoscale_c" else ROUNDING
+        for index, expected in _fixture_rows(node_id).items():
+            np.testing.assert_allclose(
+                computed[index],
+                expected,
+                atol=tolerance,
+                rtol=0,
+                err_msg=f"{node_id} row {index} does not match the fixture",
+            )
+
+    # Branch D's shared nodes too - the split passes values through unchanged.
+    for node_id in ("snv_savgol", "split_d"):
+        for index, expected in _fixture_rows(node_id).items():
+            np.testing.assert_allclose(
+                run.displays[node_id][index], expected, atol=ROUNDING, rtol=0
+            )
+
+
+def test_a_node_below_a_split_is_refitted_per_fold_which_the_fixture_is_not(
+    project: tuple[Path, DatasetVersion], tecator: Any
+) -> None:
+    """The one array the executor does not reproduce, and why it should not.
+
+    `metrics-and-validation.md` §9: every node downstream of the split is
+    refitted on the training fold alone. The fixture's `run_preprocessing`
+    says in its own docstring that it does no fold handling, so its `centre_d`
+    is a mean over all 240 samples. Reproducing that would mean fitting a
+    node below a split on the rows it is supposed to be validated against.
+
+    Both numbers are computed here so the divergence stays a measured fact.
+    """
+    directory, version = project
+    run = execute(directory, fixture_pipeline(version.version_id), version)
+
+    snv = preprocessing.SNVTransformer().fit_transform(tecator.spectra)
+    savgol = preprocessing.SavitzkyGolayTransformer(11, 2, deriv=1).fit_transform(snv)
+    fitted_on_everything = preprocessing.MeanCentreTransformer().fit_transform(savgol)
+
+    rows = _fixture_rows("centre_d")
+    index, expected = next(iter(rows.items()))
+
+    # What the fixture holds is the mean over all samples...
+    np.testing.assert_allclose(fitted_on_everything[index], expected, atol=ROUNDING)
+    # ...and the executor deliberately differs from it, by far more than rounding.
+    assert np.abs(run.displays["centre_d"][index] - expected).max() > 1e-4
+
+    # What the executor holds is fold arithmetic, done here by hand off its own
+    # stored input, and reproduced exactly rather than approximately.
+    stored_savgol = run.displays["snv_savgol"]
+    folds = validation.k_fold(version.n_samples, 10, seed=42)
+    held_out = next(fold for fold in folds if index in fold.test)
+    by_hand = preprocessing.MeanCentreTransformer().fit(stored_savgol[held_out.train])
+    np.testing.assert_array_equal(
+        run.displays["centre_d"][index], _as_stored(by_hand.transform(stored_savgol))[index]
+    )
+
+
+def test_every_sample_is_displayed_from_the_fold_that_held_it_out(
+    project: tuple[Path, DatasetVersion], tecator: Any
+) -> None:
+    """The assembled array is out of fold for every row, not only the first."""
+    directory, version = project
+    run = execute(directory, fixture_pipeline(version.version_id), version)
+
+    savgol = run.displays["snv_savgol"]
+    folds = validation.k_fold(version.n_samples, 10, seed=42)
+    expected = np.empty_like(savgol)
+    for fold in folds:
+        centred = preprocessing.MeanCentreTransformer().fit(savgol[fold.train])
+        expected[fold.test] = _as_stored(centred.transform(savgol[fold.test]))
+
+    np.testing.assert_array_equal(run.displays["centre_d"], expected)
+
+
+def test_the_split_resolves_its_folds_and_records_them(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    run = execute(directory, fixture_pipeline(version.version_id), version)
+
+    assert [split.node_id for split in run.resolved_splits] == ["split_d"]
+    resolved = run.resolved_splits[0]
+    assert len(resolved.train_indices) == 10
+
+    folds = validation.k_fold(version.n_samples, 10, seed=42)
+    assert resolved.test_indices == [fold.test.tolist() for fold in folds]
+    assert sorted(i for fold in resolved.test_indices for i in fold) == list(
+        range(version.n_samples)
+    )
+
+
+# --------------------------------------------------------------------------
+# the cache, and what invalidates it
+# --------------------------------------------------------------------------
+
+
+def test_a_second_run_recomputes_nothing(project: tuple[Path, DatasetVersion]) -> None:
+    directory, version = project
+    pipeline = fixture_pipeline(version.version_id)
+
+    first = execute(directory, pipeline, version)
+    assert first.reused == []
+
+    second = execute(directory, pipeline, version)
+    assert second.computed == []
+    np.testing.assert_array_equal(first.displays["centre_d"], second.displays["centre_d"])
+
+
+def test_editing_one_node_recomputes_it_and_its_descendants_and_nothing_else(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    execute(directory, fixture_pipeline(version.version_id), version)
+
+    # Branch C's Savitzky-Golay window changes: that node, and what is below it.
+    edited = fixture_pipeline(version.version_id)
+    nodes = [
+        node.model_copy(update={"step": SavitzkyGolay(window_length=9, polyorder=2, deriv=1)})
+        if node.id == "savgol"
+        else node
+        for node in edited.nodes
+    ]
+    run = execute(directory, edited.model_copy(update={"nodes": nodes}), version)
+
+    assert sorted(run.computed) == ["autoscale_c", "savgol"]
+    assert "snv" in run.reused and "centre_a" in run.reused
+
+
+def test_an_edit_below_a_split_does_not_disturb_the_branch_above_it(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    execute(directory, fixture_pipeline(version.version_id), version)
+
+    edited = fixture_pipeline(version.version_id)
+    nodes = [
+        node.model_copy(update={"step": Autoscale()}) if node.id == "centre_d" else node
+        for node in edited.nodes
+    ]
+    run = execute(directory, edited.model_copy(update={"nodes": nodes}), version)
+
+    assert run.computed == ["centre_d"]
+    assert "split_d" in run.reused and "snv_savgol" in run.reused
+
+
+def test_the_cache_key_ignores_everything_that_is_not_the_recipe(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """Moving a node on the canvas must not invalidate a result.
+
+    Layout coordinates live in `pipeline_state.json`, outside the model, so the
+    strongest statement available here is the one that makes that safe: the key
+    is a function of the node's own JSON and its inputs' keys, and of nothing
+    else the pipeline carries. A pipeline with a different id, name and
+    creation time hashes every node identically.
+    """
+    directory, version = project
+    original = fixture_pipeline(version.version_id)
+    renamed = original.model_copy(
+        update={"pipeline_id": uuid4(), "name": "moved about on the canvas"}
+    )
+
+    assert node_keys(renamed, version) == node_keys(original, version)
+
+    execute(directory, original, version)
+    assert execute(directory, renamed, version).computed == []
+
+
+def test_a_different_dataset_is_a_different_key(
+    project: tuple[Path, DatasetVersion], tecator: Any
+) -> None:
+    """The source is keyed on the version, so the same recipe over new data reruns."""
+    directory, version = project
+    pipeline = fixture_pipeline(version.version_id)
+    execute(directory, pipeline, version)
+
+    shifted = tecator.spectra + 1.0
+    array_path, _ = write_array(directory, shifted)
+    other = version.model_copy(
+        update={"version_id": uuid4(), "version": 2, "array_path": array_path}
+    )
+
+    run = execute(directory, fixture_pipeline(other.version_id), other)
+    assert run.reused == []
+
+
+def test_a_pruned_array_is_recomputed_rather_than_refused(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """The index is a hint about what exists, not a promise."""
+    directory, version = project
+    pipeline = fixture_pipeline(version.version_id)
+    first = execute(directory, pipeline, version)
+
+    (directory / first.outputs["centre_a"].array_path).unlink()
+    run = execute(directory, pipeline, version)
+
+    assert "centre_a" in run.computed
+    np.testing.assert_allclose(run.displays["centre_a"], first.displays["centre_a"])
+
+
+def test_a_corrupt_index_costs_a_recomputation_and_nothing_more(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    pipeline = fixture_pipeline(version.version_id)
+    first = execute(directory, pipeline, version)
+
+    (directory / CACHE_FILE).write_text("{ not json", encoding="utf-8")
+    run = execute(directory, pipeline, version)
+
+    assert run.reused == []
+    np.testing.assert_allclose(run.displays["centre_a"], first.displays["centre_a"])
+
+
+def test_use_cache_false_neither_reads_nor_writes_the_index(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    run = execute(directory, fixture_pipeline(version.version_id), version, use_cache=False)
+
+    assert run.reused == []
+    assert not (directory / CACHE_FILE).exists()
+
+
+# --------------------------------------------------------------------------
+# what the executor takes from the dataset rather than the recipe
+# --------------------------------------------------------------------------
+
+
+def test_range_select_reads_its_axis_off_the_dataset_version(
+    project: tuple[Path, DatasetVersion], tecator: Any
+) -> None:
+    """The bounds are in nanometres, and only the version knows what those are."""
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="window", inputs=("source",), step=RangeSelect(start=900.0, end=1000.0)),
+    )
+    run = execute(directory, pipeline, version)
+
+    axis = np.asarray(version.axis.values)
+    kept = int(((axis >= 900.0) & (axis <= 1000.0)).sum())
+    assert run.displays["window"].shape == (version.n_samples, kept)
+    assert run.outputs["window"].n_variables == kept
+    np.testing.assert_allclose(
+        run.displays["window"], tecator.spectra[:, (axis >= 900.0) & (axis <= 1000.0)]
+    )
+
+
+def test_a_version_whose_array_is_not_the_shape_it_records_is_refused(
+    project: tuple[Path, DatasetVersion], tecator: Any
+) -> None:
+    directory, version = project
+    array_path, _ = write_array(directory, tecator.spectra[:, :10])
+    lying = version.model_copy(update={"array_path": array_path})
+
+    with pytest.raises(ExecutorError, match="240x10 array where the version records 240x100"):
+        execute(directory, _pipeline(lying.version_id), lying)
+
+
+def test_a_missing_array_names_the_node_rather_than_raising_a_project_error(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    absent = version.model_copy(update={"array_path": "arrays/not-here.npy"})
+
+    with pytest.raises(ExecutorError, match="node 'source' could not read the dataset"):
+        execute(directory, _pipeline(absent.version_id), absent)
+
+
+# --------------------------------------------------------------------------
+# failure names the node
+# --------------------------------------------------------------------------
+
+
+def test_a_step_that_fails_names_the_node_it_failed_at(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """A one-variable window is legal; SNV over it is not.
+
+    The kernel's own sentence is kept - it says what is wrong with the data -
+    and the node id and step kind go in front of it, because the caller is
+    looking at a canvas and needs to know where to click.
+    """
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="window", inputs=("source",), step=RangeSelect(start=850.0, end=850.1)),
+        PreprocessNode(id="scatter", inputs=("window",), step=SNV()),
+    )
+    with pytest.raises(ExecutorError) as raised:
+        execute(directory, pipeline, version)
+
+    assert "node 'scatter' (snv) failed" in str(raised.value)
+    assert "needs more than 1 variables" in str(raised.value)
+
+
+def test_a_failure_below_a_split_says_which_training_fold_it_was_fitting(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="window", inputs=("source",), step=RangeSelect(start=850.0, end=850.1)),
+        SplitNode(id="split", inputs=("window",), spec=KFoldSplit(n_splits=10, seed=42)),
+        PreprocessNode(id="scatter", inputs=("split",), step=SNV()),
+    )
+    with pytest.raises(ExecutorError, match="on a training fold of 216 samples"):
+        execute(directory, pipeline, version)
+
+
+def test_a_range_select_below_another_one_is_refused_by_the_axis_it_was_given(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """A real limit of taking the axis from the dataset, surfaced rather than guessed.
+
+    `RangeSelect` drops variables, so a second one downstream is being asked to
+    read bounds against an axis that no longer describes its input. The kernel
+    refuses on the shape, and the node it happened at is named. Threading a
+    per-node axis through the walk would make the recipe's meaning depend on
+    where a node sits, which is a schema question and not one to settle here.
+    """
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="window", inputs=("source",), step=RangeSelect(start=850.0, end=852.1)),
+        PreprocessNode(id="narrower", inputs=("window",), step=RangeSelect(start=850.0, end=851.0)),
+    )
+    with pytest.raises(ExecutorError, match=r"node 'narrower' \(range_select\) failed"):
+        execute(directory, pipeline, version)
+
+
+def test_a_split_below_a_split_is_refused_by_name(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        SplitNode(id="outer", inputs=("source",), spec=KFoldSplit(n_splits=5, seed=42)),
+        SplitNode(id="inner", inputs=("outer",), spec=KFoldSplit(n_splits=3, seed=42)),
+    )
+    with pytest.raises(ExecutorError, match="node 'inner' is a split below another split"):
+        execute(directory, pipeline, version)
+
+
+def test_a_split_with_no_splitter_yet_says_so(project: tuple[Path, DatasetVersion]) -> None:
+    """Three of the five split specs have no kernel. That is said, not guessed at."""
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        SplitNode(id="holdout", inputs=("source",), spec=TrainTestSplit(test_size=0.3)),
+    )
+    with pytest.raises(ExecutorError, match="'train_test' split, which has no splitter yet"):
+        execute(directory, pipeline, version)
+
+
+def test_leave_one_out_is_the_other_splitter_that_does_work(
+    project: tuple[Path, DatasetVersion], tecator: Any
+) -> None:
+    """240 folds, each fitting on 239 samples - slow enough to test small."""
+    directory, version = project
+    array_path, _ = write_array(directory, tecator.spectra[:8])
+    small = version.model_copy(
+        update={
+            "version_id": uuid4(),
+            "n_samples": 8,
+            "sample_ids": list(tecator.sample_ids[:8]),
+            "array_path": array_path,
+        }
+    )
+    pipeline = _pipeline(
+        small.version_id,
+        SplitNode(id="loo", inputs=("source",), spec=LeaveOneOut()),
+        PreprocessNode(id="centre", inputs=("loo",), step=MeanCentre()),
+    )
+    run = execute(directory, pipeline, small)
+
+    assert run.outputs["centre"].n_folds == 8
+    stored = _as_stored(tecator.spectra[:8])
+    for i in range(8):
+        others = np.delete(np.arange(8), i)
+        expected = stored[i] - stored[others].mean(axis=0)
+        np.testing.assert_array_equal(run.displays["centre"][i], _as_stored(expected))


### PR DESCRIPTION
`PROPOSAL.md` §11: the executor is the only path from a dataset to a result, and the kernels stay pure functions over arrays. `from_spec` is the seam — nothing about caching, folds or jobs is added to `preprocessing.py`.

New module `src/chemometrics_workbench/executor.py`, 22 tests in `tests/test_executor.py`.

## The end-to-end claim

The pipeline the 1.1 fixture publishes runs against Tecator in a real project directory and reproduces every array `spectra.json` serves — `source`, `snv`, `centre_a`, `msc`, `centre_b`, `savgol`, `autoscale_c`, `snv_savgol`, `split_d` — **except `centre_d`**. The recipe is rebuilt in the test rather than imported (`stub/` dies in #89) and asserted node for node against `pipeline.json`, so the copy cannot drift while the fixture lasts.

Tolerances are measured, not chosen. The same chain in float64 agrees with the fixture to 5.0e-07, which is its own 6-decimal rounding. Through the array store's float32 the worst node moves to 1.3e-06 — except `autoscale_c` at 2.8e-05, where a first derivative cancels most of the signal and autoscaling then divides by the small standard deviation left. Both numbers are in the test's comments.

## `centre_d`, and a new issue

`metrics-and-validation.md` §9 refits every node downstream of a split on the training fold alone. So a node below a split holds one array per fold, and the single array it displays is assembled out of fold — each sample taking the row from the fold that held it out.

The fixture fits `centre_d` on all 240 samples; `generate_fixtures.run_preprocessing` says in its own docstring that it does no fold handling. The test computes both, asserts the fixture holds the fit-on-everything number (4.9e-07 away) and that the executor differs by more than 1e-4 (1.2e-03), then reproduces the executor's own value from fold arithmetic done by hand. **Raised as #97** — which array `centre_d` should hold is a contract decision #86 and #87 both need, not one to settle inside this branch.

## Caching and staleness

Each node's key is its own JSON plus its inputs' keys, with the source keyed on the dataset version — a merkle chain, so staleness is arithmetic rather than a flag maintained beside the graph.

- A second run recomputes nothing.
- Editing branch C's Savitzky-Golay recomputes exactly `savgol` and `autoscale_c`.
- Editing `centre_d`, below the split, recomputes only `centre_d`.
- A pipeline with a different id and name hashes every node identically and reruns nothing — which is what makes moving a node on the canvas safe, since layout lives in `pipeline_state.json`, outside the model the key comes from.
- A pruned array file and a corrupt `cache.json` each cost a recomputation rather than an error.

Every node's output is read back out of the store before its successors see it. Without that, a cache hit and a recomputation disagree in the last digits and the cache becomes something that changes an answer; with it, the two runs are `assert_array_equal`.

## What is deliberately not here

**Estimators.** Walked and reported in `Run.pending_estimators`, not fitted — what a fitted estimator stores, with which diagnostics and limits, is #87's subject.

**Jobs.** `execute` runs in the calling thread; progress, cancellation and failure reporting are #85.

## Also

`project._write_json` becomes `project.write_json`: the cache index wants the same interrupted-write guarantee `project.json` has, and a second copy of it would be the only alternative.

## Evidence

- `uv run pytest` — 625 passed, 1 skipped (603 before).
- `uv run ruff check .`, `ruff format --check .` clean over 60 files; `uv run mypy` clean over 40 source files.
- `uv run python stub/generate_fixtures.py` leaves the fixtures byte-identical — nothing here moved a published number.
- Failures name the node: a one-variable window then SNV gives `node 'scatter' (snv) failed: SNV with ddof=1 needs more than 1 variables`; below a split it adds `on a training fold of 216 samples`. A split below a split, a `train_test` split with no splitter yet, a version whose array is not the shape it records, and a missing array file are each refused by name.

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyipBcx3Reb39zwk1BHgws