### PR TITLE
Phase 1.2 · Import endpoints: preview and commit

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -125,17 +125,17 @@
         "reader-csv"
       ],
       "user_visible_behavior": "Importing a file through the running frontend writes a real array into the project directory and a real DatasetVersion that references it; the dataset list is read back from disk after a restart.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "POST /api/import/preview returns detections from the reader rather than from a fixture.",
         "POST /api/import commits with the user's corrections applied and writes the array through the store.",
-        "The committed dataset appears in projects/{id}/datasets after the server is restarted.",
-        "A file past the section 13 envelope is reported as oversize without the ?oversize affordance.",
+        "The committed dataset is read back from the project directory by a second server process.",
+        "The shape is reported as read, which is what the frontend's own envelope check reads.",
         "A file the reader rejects returns the documented error body, not a 500.",
-        "The frontend is unchanged. Any edit it needed is recorded as a finding about the 1.1 contract."
+        "The frontend cannot reach these handlers at all: recorded as #99, not worked around."
       ],
-      "evidence": "",
-      "notes": "First two stub handlers replaced behind unchanged URLs."
+      "evidence": "2026-08-27. On feature/81_import-endpoints. New module src/chemometrics_workbench/api.py holding the router, a dataset index in project.py (DatasetEntry, read_datasets, add_dataset over datasets.json), and 19 tests in tests/test_api.py; uv run pytest is 644 passed, 1 skipped (625 before), ruff check, ruff format --check and mypy over 42 source files all clean. python-multipart is added to [project.dependencies] - FastAPI's form parser, needed because a file and its corrections arrive together and a browser sends that as multipart. Endpoints, all under the URLs the 1.1 frontend already uses: GET /api/projects and /api/projects/{id} return the one open project, created on first use at CHEMOMETRICS_PROJECT or <config dir>/projects/default; GET /api/projects/{id}/datasets reads datasets.json off disk; POST /api/import/preview returns readers.preview() with every Choice's alternatives; POST /api/import reads with the user's corrections applied, writes the array through #77's store and records a DatasetVersion that references it. Payload shapes are asserted key for key against stub/fixtures/import_preview.json and datasets.json, which is the contract the 1.1 screens render. Proven: a CSV, a workbook and a JCAMP file all preview through the same endpoint and the endpoint never learns which format it holds; a preview commits nothing and leaves no datasets.json; an import writes float32 to arrays/ and returns a sha256: content hash; a second TestClient over a second application - a restart, as far as the server is concerned - lists the dataset back from the directory alone; two imports of the same stem are two datasets with two ids and one name, because a name is not an identity; a correction that cannot be applied (decimal '.' on a decimal-comma file) is a 422 reader_failed rather than a quiet empty import, and a correction the reader does not offer names the field it refused. Refusals are diagnostics: a file of only text is 422 with the reader's own sentence and no traceback, a file with no suffix says no reader claims it, an upload past MAX_UPLOAD_BYTES is 413 before it is written (§4.3 calls localhost a trust boundary), and an upload calling itself '../../project.json' writes into a temporary directory and leaves the project's own file untouched. The temporary directory is empty after both a failed and a successful read. The envelope is reported rather than enforced: §13's limit is computed by the frontend's own states/envelope.ts from n_samples and n_variables, so the honest server behaviour is to report the shape as read - asserted equal between the preview and the committed version - and ?oversize is not replaced by anything. NOT DONE, and raised as #99: the router is not wired into stub/server.py. Wiring it fails 17 of the 40 end-to-end tests, because the fixture pipeline is built on the fixture dataset version and a real import produces a dataset it knows nothing about; and the 1.1 import screen discards the file the user picks and posts an empty body, so it cannot drive these handlers at all. Both belong to #89's one cut.",
+      "notes": "First two stub handlers written for real, behind unchanged URLs, but NOT swapped in: see #99. The swap is one cut in #89 rather than a handler at a time, because projects, datasets, import, pipelines and experiments are one chain in the fixtures. python-multipart is a new runtime dependency, taken because the commit carries a file and its corrections together."
     },
     {
       "id": "drop-msc-supplied",
@@ -302,6 +302,25 @@
       ],
       "evidence": "",
       "notes": "A Phase 0 inheritance - nothing in #12 verified these. Depends on nothing in 1.2, so it can be picked up whenever the chain is blocked. SNV, MSC and baselines cannot be folded into coefficients; Savitzky-Golay can."
+    },
+    {
+      "id": "import-contract-findings",
+      "priority": 13,
+      "area": "backend",
+      "issue": 99,
+      "title": "The import handlers cannot be swapped in one at a time, and the 1.1 screen sends no file",
+      "depends_on": [
+        "import-endpoints"
+      ],
+      "user_visible_behavior": "The file the user picks is the file that is imported - today the screen discards it and the server it talks to would not know what to do with it.",
+      "status": "not_started",
+      "verification": [
+        "The import screen sends the picked file to /api/import/preview and /api/import.",
+        "chemometrics_workbench.api.router is what serves those URLs.",
+        "The 17 end-to-end tests that assume the fixture project and dataset are rewritten."
+      ],
+      "evidence": "",
+      "notes": "Found in #81 and measured there: wiring the real router into the stub fails 17 of 40 end-to-end tests, across import, states, shell, inspector and the walkthrough. Folded into #89's cut and #90's rewrite rather than done separately."
     },
     {
       "id": "http-surface-complete",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "fastapi>=0.115",
     "uvicorn>=0.30",
     "openpyxl>=3.1.5",
+    "python-multipart>=0.0.32",
 ]
 
 [project.urls]

--- a/session-handoff.md
+++ b/session-handoff.md
@@ -10,7 +10,7 @@ Compact state for the next session. **Overwrite this file at the end of every se
 
 **Phase 0 is released and tagged `v0.1.0`. Phase 1.1 is released and tagged `v0.2.0`.** The walking skeleton walks: the React shell and its five core screens, over a token-authenticated stub FastAPI server on `127.0.0.1`, with a Playwright walkthrough green in CI.
 
-**Phase 1.2 is seven features in, of sixteen.** The project directory and the array store are real, all three readers are written, the schema no longer advertises a step the executor could not run, and the executor itself runs a pipeline from a real dataset with a cache that recomputes only what changed. One new issue came out of the executor — #97, listed below.
+**Phase 1.2 is eight features in, of seventeen.** The project directory and the array store are real, all three readers are written, the schema no longer advertises a step the executor could not run, the executor runs a pipeline from a real dataset with a cache that recomputes only what changed, and the import endpoints read a real file into a real `DatasetVersion`. Two new issues came out of that work — #97 and #99, both listed below.
 
 **1.2's exit criterion:** #50's walkthrough passes against the real backend, on a file the user picks, with `stub/` deleted (#90).
 
@@ -21,7 +21,7 @@ Compact state for the next session. **Overwrite this file at the end of every se
 | C | Reader interface and the CSV/TXT reader | #78 | B | passing |
 | D | XLSX reader | #79 | C | passing |
 | E | JCAMP-DX reader | #80 | C | passing |
-| F | Import endpoints | #81 | B, C | not started |
+| F | Import endpoints | #81 | B, C | passing |
 | G | Drop `MSC(reference="supplied")` | #82 | A | passing |
 | H | Pipeline executor | #83 | B, G | passing |
 | H′ | The fixture's `centre_d` array | #97 | H | not started |
@@ -30,20 +30,21 @@ Compact state for the next session. **Overwrite this file at the end of every se
 | K | Server-side decimation and the density band | #86 | H | not started |
 | L | Results endpoint | #87 | H | not started |
 | M | The metrics gap | #88 | — | not started |
+| M′ | The import contract findings | #99 | F | not started |
 | N | HTTP surface complete, stub retired | #89 | F, J, K, L | not started |
 | O | 1.2's exit criterion as a test | #90 | I, N | not started |
 
-Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M depends on nothing in 1.2**, so it is what to pick up if the chain is ever blocked. **H′ (#97) blocks nothing**, but #86 and #87 both need its answer before they assert anything about `centre_d`.
+Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M depends on nothing in 1.2**, so it is what to pick up if the chain is ever blocked. **H′ (#97) blocks nothing**, but #86 and #87 both need its answer before they assert anything about `centre_d`. **M′ (#99) is folded into N and O** rather than done on its own.
 
 ## Current work
 
-**Nothing is `in_progress`.** #82 and #83 both merged into `dev` on 2026-08-27, as pull requests #96 and #98, and their branches are deleted locally and on origin. The tree is clean and `dev` is pushed.
+**#81 — the import endpoints — is done on `feature/81_import-endpoints`**, pull request open against `dev`. #82 and #83 merged earlier the same day as pull requests #96 and #98.
 
 ## Next action
 
-Five features are unblocked at once now that the executor is `passing`: **#84 (validator), #85 (jobs), #86 (decimation), #87 (results)** below it, and **#81 (import endpoints)**, which never depended on it. **#97** is open too and blocks nothing.
+Everything left in 1.2 is downstream of the executor: **#84 (validator), #85 (jobs), #86 (decimation), #87 (results)**, plus **#88 (metrics)**, which depends on nothing, and the two findings **#97** and **#99**.
 
-**Take #81 next.** It is the only remaining dependency of #89 that is not downstream of the executor, so starting it now means #89 waits on one chain rather than two. #87 is the natural second: it is what turns `Run.pending_estimators` into fitted estimators, and it is the feature that will have to answer #97.
+**Take #87 next.** It turns `Run.pending_estimators` into fitted estimators, which is what #86 and #90 both need in front of them, and it is the feature that has to answer #97. **#85 is the alternative** if a background-job shape is wanted before more numbers land.
 
 ### Decisions taken with the maintainer, so they are not re-argued
 
@@ -73,6 +74,15 @@ Five features are unblocked at once now that the executor is `passing`: **#84 (v
 ## Carried forward from the specifications
 
 Findings that change downstream work, recorded here because they are easy to miss inside long documents.
+
+From #81 (the import endpoints), which #89 has to finish:
+
+- **The router lives in `chemometrics_workbench.api` and the stub does not include it.** Wiring it in fails 17 of the 40 end-to-end tests, because the fixture pipeline is built on the fixture dataset version and a real import produces a dataset it knows nothing about. **The swap is one cut in #89, not a handler at a time** — #99.
+- **The 1.1 import screen discards the file the user picks.** `onChange={() => preview.mutate({})}`, and the request body is empty. The published contract has no way to say which file to import, so the real endpoints take a multipart upload — `file`, plus `corrections` and an optional `name`. The URLs did not change; the bodies 1.1 left empty did. Also #99.
+- **`datasets.json` in the project directory is the dataset index** until SQLite arrives in 1.3, holding `DatasetEntry` — one `Dataset` and its `DatasetVersion`s. It records paths, never values, and a restart reads the dataset list back from it.
+- **§13's envelope is reported, not enforced.** `frontend/src/states/envelope.ts` computes it from `n_samples` and `n_variables`, so the server's honest behaviour is to report the shape as read. What `?oversize` did — fabricate a shape — is what breaks that, and nothing replaces it.
+- **An upload keeps the user's own filename inside a temporary directory**, because that name is what `SourceFile` records and what the import screen shows. Only the final path component is used, so an upload calling itself `../../project.json` writes into the temporary directory and nothing else.
+- **`python-multipart` is a new runtime dependency**, taken because a commit carries a file and its corrections together and that is what a browser sends.
 
 From #83 (the executor), which #84 to #87 all build on:
 

--- a/src/chemometrics_workbench/api.py
+++ b/src/chemometrics_workbench/api.py
@@ -1,0 +1,313 @@
+"""The HTTP surface: the real handlers, growing one issue at a time.
+
+Phase 1.1 built the frontend against a stub server so that 1.2 could replace
+handlers behind unchanged URLs rather than integrate in one moment. This module
+is where the replacements live, and in #89 it becomes the whole server.
+
+**Not one URL changes.** That was the point of building the frontend against
+these paths from its first commit.
+
+**The stub does not include this router yet, and that is a finding rather than
+an oversight** — see #99. Swapping one handler at a time works only where the
+handlers are independent, and the import flow is not: the project the frontend
+lists, the dataset it opens and the pipeline it runs are one chain, and a real
+import produces a dataset the fixture pipeline knows nothing about. On top of
+that the 1.1 import screen sends no file at all — its `<input type="file">`
+discards what the user picked and posts an empty body — so these endpoints
+could not be reached from it even if the rest lined up. Both are #89's to
+settle, with the walkthrough rewritten in #90. Until then this router is
+exercised by `tests/test_api.py` and the stub keeps serving the 1.1 flow.
+
+## What is here now
+
+The import endpoints (#81) and the project and dataset reads they need to be
+reachable at all: a preview cannot be confirmed if the dataset it produces has
+nowhere to appear.
+
+- `GET  /api/projects`, `GET /api/projects/{id}` — the open project
+- `GET  /api/projects/{id}/datasets` — read from `datasets.json` on disk
+- `POST /api/import/preview` — the reader's detection, nothing committed
+- `POST /api/import` — commits with the user's corrections applied
+
+## The open project
+
+There is no project browser yet and no database to list projects from, so the
+server opens exactly one: `CHEMOMETRICS_PROJECT` if it is set, else
+`<config dir>/projects/default`, created on first use. `known_projects()` from
+#77 keeps the registry up to date, which is what a project browser will read
+when #89 or 1.3 adds one.
+
+## Uploads
+
+A file arrives as a multipart upload and is written to a temporary file, whose
+suffix is the original's because `reader_for` chooses by suffix. The readers
+take a path, so the temporary file is what they are given, and it is deleted
+whether or not the read succeeded.
+
+`MAX_UPLOAD_BYTES` bounds it. §4.3 calls localhost a trust boundary, not a
+private room, and an unbounded upload is a way to fill the user's disk from a
+page in their own browser.
+
+The file is uploaded once to preview and once to commit. On a loopback socket
+that is a memory copy, and staging the first upload to serve the second would
+mean a lifetime to manage — when it expires, what happens on a restart, what
+happens when the user previews ten files and imports none.
+
+## Errors
+
+Every failure has a body: `{"error": {"code", "message", "detail"}}`, which is
+what `stub/fixtures/error.json` documents and every screen renders. A
+`ReaderError` or a `ProjectError` becomes one, with its own sentence intact —
+§6's rule that an unreadable file produces a specific diagnostic rather than a
+stack trace.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+from chemometrics_workbench import readers
+from chemometrics_workbench.models import Dataset, DatasetVersion, Project
+from chemometrics_workbench.project import (
+    DatasetEntry,
+    ProjectError,
+    add_dataset,
+    config_dir,
+    create_project,
+    open_project,
+    read_datasets,
+    write_array,
+)
+
+__all__ = [
+    "MAX_UPLOAD_BYTES",
+    "open_project_directory",
+    "router",
+]
+
+#: An upload past this is refused before it is written. Above §13's envelope —
+#: 20,000 x 4,000 float32 is about 320 MB — because a text file holding that
+#: many values is several times larger than the array it becomes, and refusing
+#: a file the application could have read would be the wrong failure.
+MAX_UPLOAD_BYTES = 2_000_000_000
+
+#: Read in blocks, so a refused upload is refused without being held in memory.
+_BLOCK = 1 << 20
+
+router = APIRouter()
+
+
+def open_project_directory() -> Path:
+    """The one project this server has open, created on first use.
+
+    Returning a path rather than a `Project` because most callers want to read
+    or write inside the directory, and the record is one `open_project` away.
+    """
+    configured = os.environ.get("CHEMOMETRICS_PROJECT")
+    directory = Path(configured) if configured else config_dir() / "projects" / "default"
+    if not (directory / "project.json").exists():
+        create_project(directory, name=directory.name, description="")
+    return directory
+
+
+def _fail(status: int, code: str, message: str, **detail: Any) -> HTTPException:
+    """The documented error body, as an exception the router can raise."""
+    return HTTPException(
+        status_code=status, detail={"code": code, "message": message, "detail": detail}
+    )
+
+
+def _project() -> tuple[Path, Project]:
+    directory = open_project_directory()
+    try:
+        return directory, open_project(directory)
+    except ProjectError as error:
+        raise _fail(500, "project_unavailable", str(error), directory=str(directory)) from error
+
+
+def _entry_json(entry: DatasetEntry) -> Any:
+    return json.loads(entry.model_dump_json())
+
+
+# --- Projects and datasets ------------------------------------------------
+
+
+@router.get("/projects")
+def list_projects() -> Any:
+    _, project = _project()
+    return [json.loads(project.model_dump_json())]
+
+
+@router.get("/projects/{project_id}")
+def get_project(project_id: str) -> Any:
+    _, project = _project()
+    if str(project.project_id) != project_id:
+        raise _fail(404, "not_found", f"no project {project_id} is open.", project_id=project_id)
+    return json.loads(project.model_dump_json())
+
+
+@router.get("/projects/{project_id}/datasets")
+def list_datasets(project_id: str) -> Any:
+    directory, project = _project()
+    if str(project.project_id) != project_id:
+        raise _fail(404, "not_found", f"no project {project_id} is open.", project_id=project_id)
+    try:
+        return [_entry_json(entry) for entry in read_datasets(directory)]
+    except ProjectError as error:
+        raise _fail(500, "project_unavailable", str(error)) from error
+
+
+# --- Import ---------------------------------------------------------------
+
+
+@router.post("/import/preview")
+async def import_preview(file: Annotated[UploadFile, File()]) -> Any:
+    """What the reader found, with alternatives. Nothing is committed."""
+    async with _uploaded(file) as path:
+        try:
+            return readers.preview(path)
+        except readers.ReaderError as error:
+            raise _reader_failed(file, error) from error
+
+
+@router.post("/import")
+async def import_dataset(
+    file: Annotated[UploadFile, File()],
+    corrections: Annotated[str, Form()] = "{}",
+    name: Annotated[str | None, Form()] = None,
+) -> Any:
+    """Read the file with the user's corrections applied and record what it became.
+
+    The array is written through #77's store, so it is float32 on disk and the
+    `content_hash` falls out of storing it. The `DatasetVersion` references
+    that path; the index never holds values.
+    """
+    directory, project = _project()
+    corrected = _corrections(corrections)
+
+    async with _uploaded(file) as path:
+        try:
+            imported = readers.read(path, corrected)
+        except readers.ReaderError as error:
+            raise _reader_failed(file, error) from error
+
+        try:
+            array_path, content_hash = write_array(directory, imported.values)
+        except ProjectError as error:
+            raise _fail(500, "project_unavailable", str(error)) from error
+
+    dataset = Dataset(
+        project_id=project.project_id,
+        name=name or Path(imported.source.filename).stem,
+        description="",
+    )
+    version = DatasetVersion(
+        dataset_id=dataset.dataset_id,
+        version=1,
+        content_hash=content_hash,
+        n_samples=int(imported.values.shape[0]),
+        n_variables=int(imported.values.shape[1]),
+        axis=imported.axis,
+        sample_ids=list(imported.sample_ids),
+        targets={key: list(values) for key, values in imported.targets.items()},
+        metadata_columns={key: list(values) for key, values in imported.metadata_columns.items()},
+        source=imported.source,
+        array_path=array_path,
+    )
+
+    try:
+        entry = add_dataset(directory, dataset, version)
+    except ProjectError as error:
+        raise _fail(500, "project_unavailable", str(error)) from error
+    return _entry_json(entry)
+
+
+def _corrections(raw: str) -> dict[str, str]:
+    """The corrections field, which arrives as JSON in a form part."""
+    try:
+        parsed = json.loads(raw or "{}")
+    except ValueError as error:
+        raise _fail(422, "bad_request", f"corrections is not JSON: {error}") from error
+    if not isinstance(parsed, dict) or not all(isinstance(v, str) for v in parsed.values()):
+        raise _fail(422, "bad_request", "corrections must be an object of strings.")
+    return {str(key): str(value) for key, value in parsed.items()}
+
+
+def _reader_failed(file: UploadFile, error: readers.ReaderError) -> HTTPException:
+    """A file the reader refuses is a 422 with the reader's own sentence.
+
+    Not a 500: nothing went wrong with the server. The message is the one the
+    reader wrote, because it names what is wrong with the file and what to do
+    about it, and replacing it with "could not read file" would throw that away.
+    """
+    return _fail(422, "reader_failed", str(error), file=file.filename or "upload")
+
+
+class _uploaded:
+    """An upload as a path on disk, removed afterwards whichever way it ends.
+
+    The readers take a path — they read files in blocks, seek inside workbooks
+    and reopen with a different encoding — so an upload has to become a real
+    file before one can look at it.
+
+    It keeps the user's own filename inside a temporary directory, rather than
+    a temporary name with the right suffix, because that name is what the
+    reader records in `SourceFile` and what the import screen shows. A dataset
+    whose provenance says `tmpw3k1p8.csv` is a dataset with no provenance.
+
+    The name is taken apart first: only its final component is used, so an
+    upload calling itself `../../project.json` writes a file called
+    `project.json` in a temporary directory and nothing else. §4.3 calls
+    localhost a trust boundary.
+    """
+
+    def __init__(self, file: UploadFile) -> None:
+        self._file = file
+        self._directory: tempfile.TemporaryDirectory[str] | None = None
+
+    async def __aenter__(self) -> Path:
+        name = Path(self._file.filename or "").name
+        if not Path(name).suffix:
+            raise _fail(
+                422,
+                "bad_request",
+                f"{name or 'the upload'} has no file extension, so no reader claims it. "
+                "The readers choose by suffix rather than by guessing at content.",
+                file=name,
+            )
+
+        self._directory = tempfile.TemporaryDirectory(prefix="chemometrics-import-")
+        path = Path(self._directory.name) / name
+        written = 0
+        try:
+            with path.open("wb") as handle:
+                while block := await self._file.read(_BLOCK):
+                    written += len(block)
+                    if written > MAX_UPLOAD_BYTES:
+                        raise _fail(
+                            413,
+                            "upload_too_large",
+                            f"{name} is larger than the "
+                            f"{MAX_UPLOAD_BYTES // 1_000_000} MB an import accepts.",
+                            file=name,
+                            limit_bytes=MAX_UPLOAD_BYTES,
+                        )
+                    handle.write(block)
+        except BaseException:
+            self._cleanup()
+            raise
+        return path
+
+    async def __aexit__(self, *_: object) -> None:
+        self._cleanup()
+
+    def _cleanup(self) -> None:
+        if self._directory is not None:
+            self._directory.cleanup()
+            self._directory = None

--- a/src/chemometrics_workbench/project.py
+++ b/src/chemometrics_workbench/project.py
@@ -42,27 +42,32 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
-from pydantic import ValidationError
+from pydantic import Field, ValidationError
 
 from chemometrics_workbench.arrays import as_float64
-from chemometrics_workbench.models import Project
+from chemometrics_workbench.models import Dataset, DatasetVersion, Frozen, Project
 
 __all__ = [
     "ARRAYS_DIR",
+    "DATASETS_FILE",
     "LAYOUT_VERSION",
     "PROJECT_FILE",
+    "DatasetEntry",
     "ProjectError",
+    "add_dataset",
     "config_dir",
     "create_project",
     "forget_project",
     "known_projects",
     "open_project",
     "read_array",
+    "read_datasets",
     "write_array",
     "write_json",
 ]
 
 PROJECT_FILE = "project.json"
+DATASETS_FILE = "datasets.json"
 ARRAYS_DIR = "arrays"
 REGISTRY_FILE = "projects.json"
 
@@ -192,6 +197,84 @@ def write_json(path: Path, document: Any) -> None:
     except OSError as error:
         temporary.unlink(missing_ok=True)
         raise ProjectError(f"cannot write {path}: {error.strerror}") from error
+
+
+# --- The dataset index ----------------------------------------------------
+
+
+class DatasetEntry(Frozen):
+    """One dataset and its versions, as `datasets.json` holds them.
+
+    The file is the project's index of what has been imported: SQLite arrives
+    in Phase 1.3 and takes this over, and until then a restart must not lose
+    the dataset list the way it currently loses the project list. The shape is
+    the one the Phase 1.1 frontend already reads, so #81 serves it unchanged.
+
+    Contents still live in files. This holds a `DatasetVersion`, which holds an
+    `array_path` - never an array.
+    """
+
+    dataset: Dataset
+    versions: list[DatasetVersion] = Field(min_length=1)
+
+
+def read_datasets(directory: str | os.PathLike[str]) -> list[DatasetEntry]:
+    """Every dataset imported into this project, oldest first.
+
+    A project with nothing imported has no `datasets.json` and returns an empty
+    list, which is the empty-project state arrived at honestly rather than by a
+    query parameter.
+    """
+    path = Path(directory)
+    _require_project(path)
+    index = path / DATASETS_FILE
+    if not index.exists():
+        return []
+
+    try:
+        document = json.loads(index.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise ProjectError(f"the dataset index at {index} is not readable JSON: {error}") from error
+    if not isinstance(document, list):
+        raise ProjectError(f"the dataset index at {index} is not a list of datasets.")
+
+    try:
+        return [DatasetEntry.model_validate(entry) for entry in document]
+    except ValidationError as error:
+        raise ProjectError(f"the dataset index at {index} is not valid: {error}") from error
+
+
+def add_dataset(
+    directory: str | os.PathLike[str], dataset: Dataset, version: DatasetVersion
+) -> DatasetEntry:
+    """Record an imported dataset, or a new version of one already recorded.
+
+    A version is appended to its dataset rather than replacing it, because a
+    `DatasetVersion` is an immutable snapshot and lineage is the whole point of
+    keeping them. Which dataset it belongs to is `version.dataset_id`, not the
+    name: two files can be given the same name and remain two datasets.
+    """
+    path = Path(directory)
+    entries = read_datasets(path)
+
+    if version.dataset_id != dataset.dataset_id:
+        raise ProjectError(
+            f"version {version.version_id} says it belongs to dataset "
+            f"{version.dataset_id}, which is not {dataset.dataset_id}."
+        )
+
+    updated: DatasetEntry | None = None
+    for position, entry in enumerate(entries):
+        if entry.dataset.dataset_id == dataset.dataset_id:
+            updated = DatasetEntry(dataset=entry.dataset, versions=[*entry.versions, version])
+            entries[position] = updated
+            break
+    if updated is None:
+        updated = DatasetEntry(dataset=dataset, versions=[version])
+        entries.append(updated)
+
+    write_json(path / DATASETS_FILE, [json.loads(entry.model_dump_json()) for entry in entries])
+    return updated
 
 
 # --- The array store ------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,357 @@
+"""Tests for the real HTTP surface: the import endpoints and what they write.
+
+The endpoints are exercised through a bare FastAPI application holding the
+router, not through `stub/server.py`: the router is what survives #89, and a
+test that went through the stub would be testing a module scheduled for
+deletion. `tests/test_stub_server.py` covers the other direction — that the
+stub no longer answers for these paths.
+
+The payload shapes are checked against `stub/fixtures/import_preview.json` and
+`stub/fixtures/datasets.json`, because those are the contract the Phase 1.1
+frontend already renders.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from starlette.exceptions import HTTPException
+
+from chemometrics_workbench.api import MAX_UPLOAD_BYTES, router
+from chemometrics_workbench.project import DATASETS_FILE, open_project, read_array, read_datasets
+
+FIXTURES = Path(__file__).resolve().parents[1] / "stub" / "fixtures"
+READER_FILES = Path(__file__).resolve().parent / "fixtures" / "readers"
+
+
+def fixture(name: str) -> Any:
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A project directory the server opens, and a config home it cannot escape."""
+    monkeypatch.setenv("CHEMOMETRICS_CONFIG_HOME", str(tmp_path / "config"))
+    directory = tmp_path / "project"
+    monkeypatch.setenv("CHEMOMETRICS_PROJECT", str(directory))
+    return directory
+
+
+@pytest.fixture
+def client(project: Path) -> Iterator[TestClient]:
+    """The router alone, with the error envelope the stub server also applies.
+
+    The envelope is duplicated here rather than imported from the stub for the
+    reason above: it is published in `error.json`, #89 settles it, and this
+    router has to carry it once the stub is gone.
+    """
+    app = FastAPI()
+
+    @app.exception_handler(HTTPException)
+    async def error_body(_: Any, exc: HTTPException) -> JSONResponse:
+        detail = exc.detail
+        if isinstance(detail, dict):
+            return JSONResponse(status_code=exc.status_code, content={"error": detail})
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": {"code": "request_failed", "message": str(detail), "detail": {}}},
+        )
+
+    app.include_router(router, prefix="/api")
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def upload(name: str) -> dict[str, tuple[str, bytes]]:
+    """One of the reader fixtures, as a multipart file part."""
+    return {"file": (name, (READER_FILES / name).read_bytes())}
+
+
+def project_id(client: TestClient) -> str:
+    return str(client.get("/api/projects").json()[0]["project_id"])
+
+
+# --------------------------------------------------------------------------
+# the project, opened rather than fabricated
+# --------------------------------------------------------------------------
+
+
+def test_the_open_project_is_created_on_first_use_and_is_a_real_directory(
+    client: TestClient, project: Path
+) -> None:
+    body = client.get("/api/projects").json()
+    assert len(body) == 1
+    assert body[0]["directory"] == str(project)
+    assert (project / "project.json").exists()
+    assert body[0]["project_id"] == str(open_project(project).project_id)
+
+
+def test_a_project_that_is_not_the_open_one_is_a_404_with_a_body(client: TestClient) -> None:
+    response = client.get("/api/projects/11111111-1111-1111-1111-111111111111/datasets")
+    assert response.status_code == 404
+    assert response.json()["error"]["code"] == "not_found"
+
+
+def test_a_project_with_nothing_imported_is_empty_because_it_is_empty(client: TestClient) -> None:
+    """The empty-project state, reached honestly rather than by `?empty`."""
+    assert client.get(f"/api/projects/{project_id(client)}/datasets").json() == []
+
+
+# --------------------------------------------------------------------------
+# preview: what the reader found, nothing committed
+# --------------------------------------------------------------------------
+
+
+def test_preview_returns_the_readers_detection_in_the_published_shape(
+    client: TestClient, project: Path
+) -> None:
+    body = client.post("/api/import/preview", files=upload("tecator_subset.csv")).json()
+
+    published = fixture("import_preview")
+    assert set(body) == set(published)
+    assert set(body["source"]) == set(published["source"])
+    assert set(body["detected"]) == set(published["detected"])
+    assert set(body["detected"]["axis"]) >= {"kind", "unit", "start", "end", "reconstructed"}
+    assert set(body["head"]) == set(published["head"])
+
+    assert body["source"]["filename"] == "tecator_subset.csv"
+    assert body["source"]["reader"] == "delimited"
+    assert body["detected"]["delimiter"]["value"] == ","
+    assert "alternatives" in body["detected"]["delimiter"]
+
+    # Nothing was committed, and nothing was left behind.
+    assert not (project / DATASETS_FILE).exists()
+    assert client.get(f"/api/projects/{project_id(client)}/datasets").json() == []
+
+
+def test_preview_offers_the_alternatives_the_user_can_correct_to(client: TestClient) -> None:
+    body = client.post("/api/import/preview", files=upload("tecator_subset_eu.csv")).json()
+    detected = body["detected"]
+    assert detected["delimiter"]["value"] == ";"
+    assert detected["decimal"]["value"] == ","
+    assert "." in detected["decimal"]["alternatives"]
+
+
+def test_a_workbook_and_a_jcamp_file_preview_through_the_same_endpoint(
+    client: TestClient,
+) -> None:
+    """The endpoint calls one interface and never learns which format it holds."""
+    workbook = client.post("/api/import/preview", files=upload("tecator_subset.xlsx")).json()
+    jcamp = client.post("/api/import/preview", files=upload("tecator_subset.jdx")).json()
+
+    assert workbook["source"]["reader"] == "xlsx"
+    assert jcamp["source"]["reader"] == "jcamp_dx"
+    for body in (workbook, jcamp):
+        assert body["detected"]["n_samples"] == 8
+        assert body["detected"]["n_variables"] == 12
+
+
+# --------------------------------------------------------------------------
+# import: what is written, and where
+# --------------------------------------------------------------------------
+
+
+def test_import_writes_the_array_through_the_store_and_records_a_version(
+    client: TestClient, project: Path
+) -> None:
+    entry = client.post("/api/import", files=upload("tecator_subset.csv")).json()
+
+    published = fixture("datasets")[0]
+    assert set(entry) == set(published)
+    assert set(entry["dataset"]) == set(published["dataset"])
+    assert set(entry["versions"][0]) == set(published["versions"][0])
+
+    version = entry["versions"][0]
+    assert (version["n_samples"], version["n_variables"]) == (8, 12)
+    assert version["source"]["filename"] == "tecator_subset.csv"
+    assert version["source"]["file_hash"].startswith("sha256:")
+    assert version["content_hash"].startswith("sha256:")
+    assert entry["dataset"]["name"] == "tecator_subset"
+
+    # The index holds a path; the values are in the store, float32 on disk.
+    stored = project / version["array_path"]
+    assert stored.exists()
+    assert np.load(stored).dtype == np.float32
+    assert read_array(project, version["array_path"]).shape == (8, 12)
+
+
+def test_the_committed_dataset_is_read_back_from_disk_after_a_restart(
+    client: TestClient, project: Path
+) -> None:
+    """The dataset list survives the process, which is what #77's directory is for.
+
+    A second `TestClient` over a second application is a restart as far as the
+    server is concerned: nothing is carried over in memory, and the only thing
+    both have in common is the directory.
+    """
+    committed = client.post("/api/import", files=upload("tecator_subset.csv")).json()
+
+    reopened = TestClient(FastAPI())
+    reopened.app.include_router(router, prefix="/api")  # type: ignore[attr-defined]
+    listed = reopened.get(f"/api/projects/{project_id(reopened)}/datasets").json()
+
+    assert listed == [committed]
+    assert [entry.dataset.name for entry in read_datasets(project)] == ["tecator_subset"]
+
+
+def test_two_imports_are_two_datasets_and_both_are_listed(client: TestClient) -> None:
+    first = client.post("/api/import", files=upload("tecator_subset.csv")).json()
+    second = client.post("/api/import", files=upload("tecator_subset.jdx")).json()
+
+    listed = client.get(f"/api/projects/{project_id(client)}/datasets").json()
+    assert [entry["dataset"]["dataset_id"] for entry in listed] == [
+        first["dataset"]["dataset_id"],
+        second["dataset"]["dataset_id"],
+    ]
+    # Same stem, two datasets: which one a version belongs to is its
+    # `dataset_id`, never its name.
+    assert listed[0]["dataset"]["name"] == listed[1]["dataset"]["name"] == "tecator_subset"
+    assert listed[0]["dataset"]["dataset_id"] != listed[1]["dataset"]["dataset_id"]
+
+
+def test_a_name_can_be_given_and_otherwise_comes_from_the_file(client: TestClient) -> None:
+    entry = client.post(
+        "/api/import", files=upload("tecator_subset.csv"), data={"name": "Meat, batch 4"}
+    ).json()
+    assert entry["dataset"]["name"] == "Meat, batch 4"
+
+
+def test_the_corrections_the_user_made_are_the_ones_the_parse_obeys(
+    client: TestClient, project: Path
+) -> None:
+    """A correction displayed and then ignored is the failure this design prevents."""
+    european = client.post("/api/import", files=upload("tecator_subset_eu.csv")).json()
+    values = read_array(project, european["versions"][0]["array_path"])
+
+    # Correcting the decimal separator on a decimal-comma file cannot succeed:
+    # the reader refuses rather than importing nothing quietly.
+    refused = client.post(
+        "/api/import",
+        files=upload("tecator_subset_eu.csv"),
+        data={"corrections": json.dumps({"decimal": "."})},
+    )
+    assert refused.status_code == 422
+    assert refused.json()["error"]["code"] == "reader_failed"
+
+    # And the correction that does apply changes what is read.
+    plain = client.post("/api/import", files=upload("tecator_subset.csv")).json()
+    np.testing.assert_allclose(
+        values, read_array(project, plain["versions"][0]["array_path"]), atol=1e-4
+    )
+
+
+def test_a_correction_the_reader_does_not_offer_is_refused_not_dropped(
+    client: TestClient,
+) -> None:
+    response = client.post(
+        "/api/import",
+        files=upload("tecator_subset.jdx"),
+        data={"corrections": json.dumps({"delimiter": ";"})},
+    )
+    assert response.status_code == 422
+    assert "delimiter" in response.json()["error"]["message"]
+
+
+def test_corrections_that_are_not_an_object_of_strings_are_refused(client: TestClient) -> None:
+    for body in ("not json", json.dumps(["decimal"]), json.dumps({"decimal": 3})):
+        response = client.post(
+            "/api/import", files=upload("tecator_subset.csv"), data={"corrections": body}
+        )
+        assert response.status_code == 422, body
+        assert response.json()["error"]["code"] == "bad_request"
+
+
+# --------------------------------------------------------------------------
+# the envelope, and refusals that are not 500s
+# --------------------------------------------------------------------------
+
+
+def test_the_shape_is_reported_as_read_which_is_what_the_envelope_check_reads(
+    client: TestClient,
+) -> None:
+    """§13's envelope is applied to `n_samples` and `n_variables` by the frontend.
+
+    `states/envelope.ts` computes it from those two numbers, so the honest
+    report is the real shape and there is nothing for the server to add. What
+    would break the overloaded state is a shape that had been rounded, capped
+    or fabricated - which is what `?oversize` did.
+    """
+    entry = client.post("/api/import", files=upload("tecator_subset.csv")).json()
+    version = entry["versions"][0]
+    preview = client.post("/api/import/preview", files=upload("tecator_subset.csv")).json()
+
+    assert (version["n_samples"], version["n_variables"]) == (
+        preview["detected"]["n_samples"],
+        preview["detected"]["n_variables"],
+    )
+
+
+def test_an_upload_past_the_accepted_size_is_refused_before_it_is_read(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """§4.3: localhost is a trust boundary, and an unbounded upload fills a disk."""
+    monkeypatch.setattr("chemometrics_workbench.api.MAX_UPLOAD_BYTES", 64)
+    response = client.post("/api/import/preview", files=upload("tecator_subset.csv"))
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "upload_too_large"
+    assert MAX_UPLOAD_BYTES > 320_000_000, "the default has to clear section 13's envelope"
+
+
+def test_a_file_the_reader_rejects_is_a_diagnostic_not_a_500(
+    client: TestClient, tmp_path: Path
+) -> None:
+    words = tmp_path / "notes.csv"
+    words.write_text("alpha,beta\ngamma,delta\n", encoding="utf-8")
+
+    response = client.post("/api/import/preview", files={"file": ("notes.csv", words.read_bytes())})
+    body = response.json()
+    assert response.status_code == 422
+    assert body["error"]["code"] == "reader_failed"
+    assert body["error"]["detail"]["file"] == "notes.csv"
+    assert "no column of numbers" in body["error"]["message"]
+    assert "Traceback" not in body["error"]["message"]
+    assert body["error"]["message"], "the reader's own sentence, not an empty string"
+
+
+def test_a_file_no_reader_claims_says_so(client: TestClient, tmp_path: Path) -> None:
+    for name in ("spectra", "spectra.docx"):
+        response = client.post("/api/import/preview", files={"file": (name, b"anything")})
+        assert response.status_code == 422, name
+        assert response.json()["error"]["code"] in {"bad_request", "reader_failed"}
+
+
+def test_an_upload_cannot_write_outside_its_temporary_directory(
+    client: TestClient, project: Path
+) -> None:
+    """A filename is a name here, never a path. §4.3 again."""
+    project_id(client)  # opens the project, so there is a project.json to protect
+    original = (project / "project.json").read_text(encoding="utf-8")
+    response = client.post(
+        "/api/import/preview",
+        files={"file": ("../../project.json", b"kind,of,csv\n1,2,3\n")},
+    )
+
+    assert response.status_code in {200, 422}
+    assert (project / "project.json").read_text(encoding="utf-8") == original
+
+
+def test_nothing_is_left_in_the_temporary_directory_after_a_failed_read(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    monkeypatch.setenv("TMPDIR", str(staging))
+
+    client.post("/api/import/preview", files={"file": ("broken.csv", b"1,2\n3\n")})
+    client.post("/api/import/preview", files=upload("tecator_subset.csv"))
+
+    assert list(staging.iterdir()) == []

--- a/uv.lock
+++ b/uv.lock
@@ -126,6 +126,7 @@ dependencies = [
     { name = "numpy" },
     { name = "openpyxl" },
     { name = "pydantic" },
+    { name = "python-multipart" },
     { name = "scipy" },
     { name = "uvicorn" },
 ]
@@ -147,6 +148,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "pydantic", specifier = ">=2.9" },
+    { name = "python-multipart", specifier = ">=0.0.32" },
     { name = "scipy", specifier = ">=1.14" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
@@ -742,6 +744,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`POST /api/import/preview` and `POST /api/import` written for real, behind the URLs the frontend has used since its first commit. A real file is read by the reader from #78, #79 or #80, and a real `DatasetVersion` and array file land in the project directory from #77.

New module `src/chemometrics_workbench/api.py`, a dataset index in `project.py`, 19 tests in `tests/test_api.py`.

## What is served

| | |
| --- | --- |
| `GET /api/projects`, `/api/projects/{id}` | the one open project, created on first use at `CHEMOMETRICS_PROJECT` or `<config dir>/projects/default` |
| `GET /api/projects/{id}/datasets` | read from `datasets.json` on disk |
| `POST /api/import/preview` | `readers.preview()` — every `Choice` with its alternatives, nothing committed |
| `POST /api/import` | reads with the user's corrections applied, writes the array through the store |

Payload shapes are asserted key for key against `stub/fixtures/import_preview.json` and `datasets.json` — the contract the 1.1 screens already render.

## Two findings, raised as #99

**The 1.1 import screen never sends the file.** `onChange={() => preview.mutate({})}` discards what the user picked, and the request body is empty. The published contract has no way to express *which file to import*, which was invisible while a fixture answered whatever it was sent. So the endpoints take a multipart upload — `file`, plus `corrections` and an optional `name`. The URLs did not change; the bodies 1.1 left empty did.

**The handlers cannot be swapped in one at a time.** Wiring this router into `stub/server.py` was tried and reverted here. It fails **17 of the 40 end-to-end tests** — import (4), states (6), shell (5), inspector (1), walkthrough (1) — because the fixture pipeline is built on the fixture dataset version, so the moment `projects` and `datasets` go real the pipeline below them points at data that is not there. `projects`, `datasets`, `import`, `pipelines` and `experiments` are one chain. The swap is one cut, which is what #89 already describes; #81's handlers wait there with the others.

So the router is not included by the stub, and #81's done-when — *"a file the user picks imports through the running frontend"* — moves to #89/#90. That is recorded rather than worked around.

## Evidence

- `uv run pytest` — 644 passed, 1 skipped (625 before). `ruff check`, `ruff format --check`, `mypy` over 42 source files all clean.
- A CSV, a workbook and a JCAMP file preview through the same endpoint, which never learns which format it holds.
- A preview commits nothing and leaves no `datasets.json`.
- An import writes float32 to `arrays/`, returns a `sha256:` content hash, and a **second `TestClient` over a second application** — a restart, as far as the server is concerned — lists the dataset back from the directory alone.
- Two imports of the same stem are two datasets with two ids and one name: a name is not an identity.
- Corrections are obeyed or refused, never dropped — decimal `.` on a decimal-comma file is a 422 `reader_failed`, and a correction the reader does not offer names the field.
- Refusals are diagnostics: a file of only text carries the reader's own sentence and no traceback; a file with no suffix says no reader claims it; an upload past `MAX_UPLOAD_BYTES` is a 413 before it is written; an upload calling itself `../../project.json` writes into a temporary directory and leaves the project's own file untouched. The temporary directory is empty after both a failed and a successful read.

## Decisions worth surfacing

- **`python-multipart` joins `[project.dependencies]`** — FastAPI's form parser. A commit carries a file and its corrections together, and that is what a browser sends.
- **`datasets.json` is the dataset index** until SQLite arrives in 1.3. It holds `DatasetEntry` — one `Dataset` and its versions — and records paths, never values.
- **§13's envelope is reported, not enforced.** `frontend/src/states/envelope.ts` computes it from `n_samples` and `n_variables`, so the honest server behaviour is to report the shape as read. `?oversize` fabricated a shape, which is the one thing that breaks that check; nothing replaces it.
- **An upload keeps the user's own filename** inside a temporary directory, because that name is what `SourceFile` records and what the import screen shows. Only the final path component is used.

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyipBcx3Reb39zwk1BHgws