### PR TITLE
Phase 1.2 · Pipeline validator: the two warnings nothing emits

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -208,7 +208,7 @@
         "pipeline-executor"
       ],
       "user_visible_behavior": "A pipeline that will produce an optimistic RMSECV, or a PLS with no centring upstream, warns the user and points at the node - without blocking the run.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "A MeanCentre or Autoscale upstream of a split emits the leakage warning, naming the node.",
         "A PLS node with no centring upstream emits its warning, naming the node.",
@@ -217,8 +217,27 @@
         "The validate response is computed - the unconditional valid: true is gone.",
         "Each warning states the consequence, not only the rule."
       ],
+      "evidence": "2026-08-27. On feature/84_pipeline-validator. New module src/chemometrics_workbench/checks.py (check_pipeline, PipelineWarning, two codes), validation_payload in api.py, the stub's validate handler replaced by a call to it, and 21 tests in tests/test_checks.py. uv run pytest is 679 passed, 1 skipped (658 before); ruff check, ruff format --check and mypy over 44 source files all clean; pnpm e2e is 40 passed with the frontend untouched. Warning one, the leak: a MeanCentre or an Autoscale with a split anywhere below it names both nodes and says RMSECV comes out optimistic and that moving the node below the split fits it per fold - the consequence and the remedy, not the rule. Found through intervening nodes, and both splits named when one centring feeds two. Silent when the centring is below the split, when it is on a branch that never reaches one (the fixture's shape - centre_a and split_d are in one pipeline and have nothing to do with each other), and for SNV, Normalise, Savitzky-Golay and the baselines above a split, which estimate nothing across samples. Autoscale counts as centring for both rules because it subtracts the column means before it divides. Warning two: a PLS or PLS-DA node with no MeanCentre or Autoscale anywhere above it says the first component spends itself on the offset and the model carries no intercept to absorb it. Silenced by either kind of centring at any distance above. A PCA with no centring is deliberately not warned about - only pls-regression.md section 3 says 'almost always wrong', and extending it to PCA would be a preference with no document behind it. A PLS fed by a leaky centring is warned about once, not twice: the centring is there, and where it sits is the other warning's subject. Both fire at once on a pipeline that earns both, and neither hides the other. Envelope: the GUESS shape is kept exactly - valid and problems, which the canvas renders by joining the sentences - and warnings is added alongside carrying code, node_id, related and severity, so a canvas can point at the node without parsing a sentence. valid is false whenever there is anything to say, because the 1.1 screen shows the problems only then and reporting valid while holding a warning would drop it. Nothing blocks: check_pipeline is advisory, and a test executes a leaky pipeline to completion after asserting it warns. The stub's handler is computed rather than constant - it parses stub/fixtures/pipeline.json and calls validation_payload - and the fixture pipeline earns neither warning, so the response is byte-identical to the constant it replaced, now for a reason. A third case, MSC above a split, is #103 rather than a widened branch.",
+      "notes": "Both are specified in metrics-and-validation.md section 9 and pls-regression.md section 3 and have never been emitted. The 1.1 handler returns valid: true unconditionally. The envelope keeps valid and problems and adds warnings alongside, so the frontend is unchanged. MSC above a split leaks by the same rule and is raised as #103."
+    },
+    {
+      "id": "msc-above-a-split",
+      "priority": 16,
+      "area": "backend",
+      "issue": 103,
+      "title": "MSC above a split leaks too, and nothing warns about it",
+      "depends_on": [
+        "pipeline-validator"
+      ],
+      "user_visible_behavior": "A pipeline whose MSC reference is estimated from the held-out spectra as well as the training ones says so, as centring above a split already does.",
+      "status": "not_started",
+      "verification": [
+        "MSC above a split emits the leakage warning, naming the node and the split.",
+        "Its message is in MSC's own terms - the reference spectrum, not the mean.",
+        "metrics-and-validation.md section 9's legitimate list says why MSC is not on it."
+      ],
       "evidence": "",
-      "notes": "Both are specified in metrics-and-validation.md section 9 and pls-regression.md section 3 and have never been emitted. The 1.1 handler returns valid: true unconditionally."
+      "notes": "Raised from #84 under its own convention: a third warning becomes an issue rather than a widened branch. MSC estimates a reference from the fit set, so a sample's output depends on which other samples were present - the property that makes centring a leak. SNV, Normalise, Savitzky-Golay, the baselines and RangeSelect were checked and are legitimate above a split; MSC is the only step in the schema that leaks and is not warned about. Open question in the issue: one warning code for all three steps, or a second code, since the sentence differs."
     },
     {
       "id": "real-jobs",

--- a/session-handoff.md
+++ b/session-handoff.md
@@ -10,7 +10,7 @@ Compact state for the next session. **Overwrite this file at the end of every se
 
 **Phase 0 is released and tagged `v0.1.0`. Phase 1.1 is released and tagged `v0.2.0`.** The walking skeleton walks: the React shell and its five core screens, over a token-authenticated stub FastAPI server on `127.0.0.1`, with a Playwright walkthrough green in CI.
 
-**Phase 1.2 is nine features in, of eighteen.** The project directory and the array store are real, all three readers are written, the schema no longer advertises a step the executor could not run, the executor runs a pipeline from a real dataset and now fits its PCA nodes too, and the import endpoints read a real file into a real `DatasetVersion`. Three new issues came out of that work — #97, #99 and #101, all listed below.
+**Phase 1.2 is ten features in, of nineteen.** The project directory and the array store are real, all three readers are written, the schema no longer advertises a step the executor could not run, the executor runs a pipeline from a real dataset and now fits its PCA nodes too, the import endpoints read a real file into a real `DatasetVersion`, and the validator emits the two warnings nothing has ever emitted. Four new issues came out of that work — #97, #99, #101 and #103, all listed below.
 
 **Two features have landed with their HTTP half deferred.** #81's handlers and #87's results payload are written and tested; neither is served, because the swap from the stub is one cut rather than a handler at a time. That is #99, and it lands in #89.
 
@@ -27,7 +27,8 @@ Compact state for the next session. **Overwrite this file at the end of every se
 | G | Drop `MSC(reference="supplied")` | #82 | A | passing |
 | H | Pipeline executor | #83 | B, G | passing |
 | H′ | The fixture's `centre_d` array | #97 | H | not started |
-| I | Pipeline validator | #84 | H | not started |
+| I | Pipeline validator | #84 | H | passing |
+| I′ | MSC above a split | #103 | I | not started |
 | J | Real jobs | #85 | H | not started |
 | K | Server-side decimation and the density band | #86 | H | not started |
 | L | Results endpoint | #87 | H | passing |
@@ -37,17 +38,17 @@ Compact state for the next session. **Overwrite this file at the end of every se
 | N | HTTP surface complete, stub retired | #89 | F, J, K, L | not started |
 | O | 1.2's exit criterion as a test | #90 | I, N | not started |
 
-Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M depends on nothing in 1.2**, so it is what to pick up if the chain is ever blocked. **H′ (#97) blocks nothing**, but #86 and #87 both need its answer before they assert anything about `centre_d`. **M′ (#99) is folded into N and O** rather than done on its own, and now covers #87's endpoint as well as #81's. **M″ (#101) blocks nothing** and is a specification decision, like #71.
+Chain: `A → B → C → {D, E, F} → H → {I, J, K, L} → N → O`. **M depends on nothing in 1.2**, so it is what to pick up if the chain is ever blocked. **H′ (#97) blocks nothing**, but #86 and #87 both need its answer before they assert anything about `centre_d`. **M′ (#99) is folded into N and O** rather than done on its own, and now covers #87's endpoint as well as #81's. **M″ (#101) blocks nothing** and is a specification decision, like #71. **I′ (#103) blocks nothing** — it is #84's own convention working: a third warning becomes an issue rather than a widened branch.
 
 ## Current work
 
-**Nothing is `in_progress`.** #81, #82, #83 and #87 all merged into `dev` on 2026-08-27, as pull requests #100, #96, #98 and #102, and their branches are deleted locally and on origin. The tree is clean and `dev` is pushed.
+**#84 — the pipeline validator — is done on `feature/84_pipeline-validator`**, pull request open against `dev`. #81, #82, #83 and #87 merged earlier the same day as pull requests #100, #96, #98 and #102.
 
 ## Next action
 
-Three features are left in 1.2 before the cut: **#84 (validator), #85 (jobs), #86 (decimation)**, plus **#88 (metrics)**, which depends on nothing, and three findings — **#97**, **#99** and **#101**.
+Two features are left in 1.2 before the cut: **#85 (jobs)** and **#86 (decimation)**, plus **#88 (metrics)**, which depends on nothing, and four findings — **#97**, **#99**, **#101** and **#103**.
 
-**Take #84 next.** It is the only one whose whole subject is logic rather than transport: a function over a `Pipeline` emitting the two warnings nothing emits, with no HTTP half to defer. #86 is the natural second — it needs a dataset big enough to exercise x-axis decimation, which Tecator at 100 variables is not. **#85 is the alternative** if a background-job shape is wanted first.
+**Take #88 next.** Like #84 it is all logic and no transport, so it finishes rather than deferring a half to #89: SEC, SEP, Q² and `coefficients_original_units` are specified in `metrics-and-validation.md` §5–§6, were never implemented, and nothing verified them in #12. **#85 is the alternative** — its job envelope is marked GUESS and may change, which makes it the item most likely to move the frontend, and doing that before #89 rather than after is cheaper.
 
 ### Decisions taken with the maintainer, so they are not re-argued
 
@@ -77,6 +78,14 @@ Three features are left in 1.2 before the cut: **#84 (validator), #85 (jobs), #8
 ## Carried forward from the specifications
 
 Findings that change downstream work, recorded here because they are easy to miss inside long documents.
+
+From #84 (the validator), which #89 and #103 build on:
+
+- **The validation envelope keeps `valid` and `problems` and adds `warnings` beside them.** The GUESS shape is untouched, so the canvas renders unchanged; the structured list carries `code`, `node_id`, `related` and `severity` for a screen that wants to point at the node instead of parsing a sentence.
+- **`valid` means "there is nothing to tell you", not "this will run".** Everything runs — `checks.py` is advisory and a test executes a leaky pipeline to completion. Reporting `valid: true` while holding a warning would mean the 1.1 screen said "valid" and dropped the sentence.
+- **`Autoscale` counts as centring for both rules**, because it subtracts the column means before it divides.
+- **A PCA with no centring is deliberately not warned about.** Only `pls-regression.md` §3 says "almost always wrong", and extending that to PCA would be a preference with no document behind it.
+- **`MSC` above a split leaks by the same rule and is #103.** `SNV`, `Normalise`, Savitzky-Golay, the baselines and `RangeSelect` were all checked and are legitimate above a split — none estimates anything across samples — so MSC is the only step in the schema that leaks and is not warned about.
 
 From #87 (the estimators), which #86 and #90 draw on:
 

--- a/src/chemometrics_workbench/api.py
+++ b/src/chemometrics_workbench/api.py
@@ -29,9 +29,12 @@ nowhere to appear.
 - `POST /api/import/preview` — the reader's detection, nothing committed
 - `POST /api/import` — commits with the user's corrections applied
 
-`results_payload` (#87) renders an estimator result for `results/{node_id}`.
-The endpoint itself waits for the pipeline store, because a result is a node in
-a pipeline and there is nowhere yet to keep one — #89 again.
+`results_payload` (#87) renders an estimator result for `results/{node_id}`,
+and `validation_payload` (#84) renders `pipelines/{id}/validate`. Neither
+endpoint is served here yet: both take a pipeline, and there is nowhere to keep
+one until #89's pipeline store — the same cut #99 describes. The stub calls
+`validation_payload` for the one pipeline it has, so that response is computed
+rather than constant.
 
 ## The open project
 
@@ -77,8 +80,9 @@ from typing import Annotated, Any
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
 from chemometrics_workbench import readers
+from chemometrics_workbench.checks import check_pipeline
 from chemometrics_workbench.executor import EstimatorResult
-from chemometrics_workbench.models import Dataset, DatasetVersion, Project
+from chemometrics_workbench.models import Dataset, DatasetVersion, Pipeline, Project
 from chemometrics_workbench.project import (
     DatasetEntry,
     ProjectError,
@@ -95,6 +99,7 @@ __all__ = [
     "open_project_directory",
     "results_payload",
     "router",
+    "validation_payload",
 ]
 
 #: An upload past this is refused before it is written. Above §13's envelope —
@@ -380,3 +385,38 @@ def _samples(rows: list[int], version: DatasetVersion) -> list[dict[str, Any]]:
     return [
         {"index": row, "sample_id": ids[row] if row < len(ids) else f"row {row}"} for row in rows
     ]
+
+
+# --- Validation -----------------------------------------------------------
+
+
+def validation_payload(pipeline: Pipeline) -> dict[str, Any]:
+    """What `pipelines/{id}/validate` answers, computed rather than constant.
+
+    The Phase 1.1 envelope was published as a GUESS — `{"valid", "problems"}`,
+    with `problems` a list of sentences — and the screen renders `problems`
+    joined together when `valid` is false. Both are kept exactly, so no screen
+    changes, and the structured form is added alongside under `warnings`, where
+    a canvas that wants to point at the node can find its id.
+
+    `valid` therefore means "there is nothing to tell you" rather than "this
+    will run". Everything here runs: `checks.py` warns and never blocks, and
+    reporting `valid: true` while holding a warning would mean the screen said
+    "valid" and dropped the sentence.
+    """
+    warnings = check_pipeline(pipeline)
+    return {
+        "pipeline_id": str(pipeline.pipeline_id),
+        "valid": not warnings,
+        "problems": [warning.message for warning in warnings],
+        "warnings": [
+            {
+                "code": warning.code,
+                "node_id": warning.node_id,
+                "related": list(warning.related),
+                "severity": warning.severity,
+                "message": warning.message,
+            }
+            for warning in warnings
+        ],
+    }

--- a/src/chemometrics_workbench/checks.py
+++ b/src/chemometrics_workbench/checks.py
@@ -1,0 +1,185 @@
+"""What is wrong with a pipeline that will nonetheless run.
+
+Everything `models.py` can refuse, it refuses: an odd Savitzky-Golay window, a
+`start` above its `end`, a cycle in the graph. What it cannot refuse is a
+recipe that is well formed, executes without complaint, and produces a number
+that is quietly wrong. Those are here.
+
+**Both warnings in this module catch mistakes whose symptom is a plausible
+result.** A leaked mean does not raise; it lowers RMSECV. A PLS model on
+uncentred data does not raise; it spends its first component on the offset.
+Neither is discoverable by looking at the output, which is why they are stated
+before the run rather than diagnosed after it.
+
+## They warn, they do not block
+
+The pipeline is the record of what was done. Refusing to run it would make the
+application the author of the analysis, and silently relocating a node — moving
+a `MeanCentre` below the split "for" the user — would make the recipe a lie.
+`metrics-and-validation.md` §9 is explicit: the validator warns and names the
+node, and the warning travels into the experiment record so the number is never
+read without it.
+
+## Adding a third
+
+Every warning here has a document behind it saying what the consequence is. A
+rule that seems obviously right but is written down nowhere is a preference,
+and preferences do not belong in something that annotates a scientist's work.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from chemometrics_workbench.models import (
+    Autoscale,
+    MeanCentre,
+    NodeId,
+    Pipeline,
+    PipelineNode,
+    PLSDASpec,
+    PLSRegressionSpec,
+)
+
+__all__ = [
+    "LEAK_BEFORE_SPLIT",
+    "PLS_WITHOUT_CENTRING",
+    "PipelineWarning",
+    "check_pipeline",
+]
+
+#: Codes rather than message matching, so a screen can style or filter a
+#: warning without parsing the sentence a person reads.
+LEAK_BEFORE_SPLIT = "centring_upstream_of_split"
+PLS_WITHOUT_CENTRING = "pls_without_centring"
+
+#: The steps that estimate a parameter from the data *and* centre it. Both are
+#: what `pls-regression.md` §3 means by centring, because `Autoscale` subtracts
+#: the column means before it divides.
+_CENTRING = (MeanCentre, Autoscale)
+
+
+@dataclass(frozen=True)
+class PipelineWarning:
+    """One thing worth saying about a pipeline before it is run.
+
+    `node_id` is what the canvas points at. `related` names the other node that
+    makes it a problem — the split that is being leaked into — because a
+    warning about `centre_a` alone leaves the user hunting for which split it
+    means in a graph with four branches.
+    """
+
+    code: str
+    node_id: NodeId
+    message: str
+    related: tuple[NodeId, ...] = ()
+    severity: str = "warning"
+
+
+def check_pipeline(pipeline: Pipeline) -> list[PipelineWarning]:
+    """Everything worth saying about `pipeline`, in the order its nodes appear.
+
+    An empty list means there is nothing to tell the user, not that the recipe
+    is good: this checks two named mistakes, and says so.
+    """
+    by_id = {node.id: node for node in pipeline.nodes}
+    found: list[PipelineWarning] = []
+
+    for node in pipeline.nodes:
+        found.extend(_leak_before_split(node, by_id))
+        found.extend(_pls_without_centring(node, by_id))
+    return found
+
+
+def _leak_before_split(
+    node: PipelineNode, by_id: dict[NodeId, PipelineNode]
+) -> list[PipelineWarning]:
+    """`metrics-and-validation.md` §9: fitted before the split is fitted on everything.
+
+    Savitzky-Golay, derivatives, SNV, range selection and unit conversion are
+    legitimate above a split — they estimate nothing from the set of samples,
+    so a sample's output does not depend on which other samples were present.
+    Centring and autoscaling do, and the validation rows contribute to the
+    statistics the training rows are then judged against.
+    """
+    if node.type != "preprocess" or not isinstance(node.step, _CENTRING):
+        return []
+
+    splits = sorted(other for other in _descendants(node.id, by_id) if by_id[other].type == "split")
+    if not splits:
+        return []
+
+    named = ", ".join(repr(split) for split in splits)
+    return [
+        PipelineWarning(
+            code=LEAK_BEFORE_SPLIT,
+            node_id=node.id,
+            related=tuple(splits),
+            message=(
+                f"{node.step.kind!r} at {node.id!r} is fitted above the split at {named}, so "
+                "it is fitted once on every sample. The held-out samples contribute to the "
+                "mean the training samples are centred by, and RMSECV comes out optimistic. "
+                "Moving the node below the split fits it on each training fold instead."
+            ),
+        )
+    ]
+
+
+def _pls_without_centring(
+    node: PipelineNode, by_id: dict[NodeId, PipelineNode]
+) -> list[PipelineWarning]:
+    """`pls-regression.md` §3: legal here, and almost always wrong.
+
+    PLS fits the matrices it is given and centres nothing of its own, so
+    centring is a node in the recipe or it has not happened.
+    """
+    if node.type != "estimator" or not isinstance(node.spec, PLSRegressionSpec | PLSDASpec):
+        return []
+
+    upstream = (by_id[other] for other in _ancestors(node.id, by_id))
+    if any(other.type == "preprocess" and isinstance(other.step, _CENTRING) for other in upstream):
+        return []
+
+    return [
+        PipelineWarning(
+            code=PLS_WITHOUT_CENTRING,
+            node_id=node.id,
+            message=(
+                f"{node.spec.kind!r} at {node.id!r} has no centring step above it. PLS fits "
+                "the matrix it is given and centres nothing of its own, so the first "
+                "component spends itself on the offset and the model carries no intercept to "
+                "absorb it. Add a mean centre or an autoscale above this node."
+            ),
+        )
+    ]
+
+
+def _descendants(node_id: NodeId, by_id: dict[NodeId, PipelineNode]) -> set[NodeId]:
+    """Every node that consumes this one's output, directly or through others."""
+    children: dict[NodeId, list[NodeId]] = {nid: [] for nid in by_id}
+    for node in by_id.values():
+        for parent in node.inputs:
+            children[parent].append(node.id)
+
+    seen: set[NodeId] = set()
+    stack = list(children[node_id])
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(children[current])
+    return seen
+
+
+def _ancestors(node_id: NodeId, by_id: dict[NodeId, PipelineNode]) -> set[NodeId]:
+    """Every node this one's output is computed from."""
+    seen: set[NodeId] = set()
+    stack = list(by_id[node_id].inputs)
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(by_id[current].inputs)
+    return seen

--- a/stub/server.py
+++ b/stub/server.py
@@ -46,7 +46,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pydantic import TypeAdapter, ValidationError
 
-from chemometrics_workbench.models import PreprocessStep
+from chemometrics_workbench.api import validation_payload
+from chemometrics_workbench.models import Pipeline, PreprocessStep
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures"
 # Production mode serves the built frontend from here. STUB_BUNDLE overrides it,
@@ -221,9 +222,20 @@ def get_pipeline_state(pipeline_id: str) -> Any:
 
 @api.post("/pipelines/{pipeline_id}/validate")
 def validate_pipeline(pipeline_id: str) -> Any:
-    # GUESS, like the envelope shapes in generate_fixtures.py: models.py does
-    # not cover a validation response, so 1.2 is free to change this.
-    return {"pipeline_id": fixture("pipeline")["pipeline_id"], "valid": True, "problems": []}
+    """The real validator (#84), over the one pipeline this server has.
+
+    Computed rather than constant: `checks.check_pipeline` decides, and the
+    fixture pipeline happens to have nothing wrong with it - its centring sits
+    below the split, and its estimators are PCA rather than PLS - so the answer
+    is the same `valid: true` the constant used to return, for a reason now.
+
+    The envelope keeps `valid` and `problems`, which were published as a GUESS
+    and which the canvas renders, and gains `warnings` alongside them. Which
+    pipeline is being validated is still the fixture's, because there is
+    nowhere to keep a second one until #89.
+    """
+    published = Pipeline.model_validate(fixture("pipeline"))
+    return validation_payload(published)
 
 
 # --- Results -------------------------------------------------------------

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,366 @@
+"""Tests for the two warnings nothing used to emit.
+
+Both catch a mistake whose symptom is a plausible number, so what is asserted
+is not only that they fire but that they fire on the right node and say what
+the consequence is. A warning reading "centring before split" would pass a
+weaker test and teach the user nothing.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from chemometrics_workbench.api import validation_payload
+from chemometrics_workbench.checks import (
+    LEAK_BEFORE_SPLIT,
+    PLS_WITHOUT_CENTRING,
+    check_pipeline,
+)
+from chemometrics_workbench.models import (
+    SNV,
+    Autoscale,
+    EstimatorNode,
+    KFoldSplit,
+    MeanCentre,
+    Normalise,
+    PCASpec,
+    Pipeline,
+    PLSDASpec,
+    PLSRegressionSpec,
+    PreprocessNode,
+    SavitzkyGolay,
+    SourceNode,
+    SplitNode,
+)
+
+FIXTURES = Path(__file__).resolve().parents[1] / "stub" / "fixtures"
+
+
+def pipeline(*nodes: Any) -> Pipeline:
+    return Pipeline(
+        project_id=uuid4(),
+        name="test",
+        nodes=[SourceNode(id="source", version_id=uuid4()), *nodes],
+    )
+
+
+# --------------------------------------------------------------------------
+# centring above a split
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("step", [MeanCentre(), Autoscale(), Autoscale(ddof=0)])
+def test_centring_above_a_split_warns_and_names_both_nodes(step: Any) -> None:
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="centre", inputs=("source",), step=step),
+            SplitNode(id="cv", inputs=("centre",), spec=KFoldSplit(n_splits=10)),
+            EstimatorNode(id="pca", inputs=("cv",), spec=PCASpec(n_components=3)),
+        )
+    )
+
+    assert [warning.code for warning in found] == [LEAK_BEFORE_SPLIT]
+    assert found[0].node_id == "centre"
+    assert found[0].related == ("cv",)
+
+
+def test_the_warning_states_the_consequence_not_only_the_rule() -> None:
+    """ "RMSECV will be optimistic" is the part a user can act on."""
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+            SplitNode(id="cv", inputs=("centre",), spec=KFoldSplit(n_splits=5)),
+        )
+    )
+    message = found[0].message
+
+    assert "optimistic" in message
+    assert "'centre'" in message and "'cv'" in message
+    assert "below the split" in message, "and what to do about it"
+
+
+def test_the_leak_is_found_through_intervening_nodes() -> None:
+    """Fitted before the split is fitted on everything, however far before."""
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+            PreprocessNode(
+                id="savgol",
+                inputs=("centre",),
+                step=SavitzkyGolay(window_length=11, polyorder=2, deriv=1),
+            ),
+            PreprocessNode(id="snv", inputs=("savgol",), step=SNV()),
+            SplitNode(id="cv", inputs=("snv",), spec=KFoldSplit(n_splits=5)),
+        )
+    )
+    assert [(w.code, w.node_id) for w in found] == [(LEAK_BEFORE_SPLIT, "centre")]
+
+
+def test_centring_below_the_split_is_the_correct_arrangement_and_is_silent() -> None:
+    found = check_pipeline(
+        pipeline(
+            SplitNode(id="cv", inputs=("source",), spec=KFoldSplit(n_splits=10)),
+            PreprocessNode(id="centre", inputs=("cv",), step=MeanCentre()),
+            EstimatorNode(id="pca", inputs=("centre",), spec=PCASpec(n_components=3)),
+        )
+    )
+    assert found == []
+
+
+def test_centring_on_a_branch_that_never_reaches_a_split_is_silent() -> None:
+    """A split somewhere in the graph is not a split above this node.
+
+    This is the fixture pipeline's shape: `centre_a` and `split_d` are in the
+    same pipeline and have nothing to do with each other.
+    """
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="centre_a", inputs=("source",), step=MeanCentre()),
+            EstimatorNode(id="pca_a", inputs=("centre_a",), spec=PCASpec(n_components=3)),
+            SplitNode(id="cv", inputs=("source",), spec=KFoldSplit(n_splits=10)),
+            PreprocessNode(id="centre_d", inputs=("cv",), step=MeanCentre()),
+        )
+    )
+    assert found == []
+
+
+def test_a_step_that_estimates_nothing_may_sit_above_a_split() -> None:
+    """§9 names them: Savitzky-Golay, derivatives, SNV, range selection.
+
+    None depends on which other samples were present, so fitting once on
+    everything gives each row what it would have had on its own.
+    """
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="snv", inputs=("source",), step=SNV()),
+            PreprocessNode(
+                id="savgol",
+                inputs=("snv",),
+                step=SavitzkyGolay(window_length=11, polyorder=2, deriv=1),
+            ),
+            PreprocessNode(id="norm", inputs=("savgol",), step=Normalise()),
+            SplitNode(id="cv", inputs=("norm",), spec=KFoldSplit(n_splits=10)),
+        )
+    )
+    assert found == []
+
+
+def test_two_splits_below_one_centring_are_both_named() -> None:
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+            SplitNode(id="cv_a", inputs=("centre",), spec=KFoldSplit(n_splits=5)),
+            SplitNode(id="cv_b", inputs=("centre",), spec=KFoldSplit(n_splits=10)),
+        )
+    )
+    assert found[0].related == ("cv_a", "cv_b")
+    assert "'cv_a', 'cv_b'" in found[0].message
+
+
+# --------------------------------------------------------------------------
+# PLS without centring
+# --------------------------------------------------------------------------
+
+
+def test_a_pls_node_with_no_centring_above_it_warns() -> None:
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="snv", inputs=("source",), step=SNV()),
+            EstimatorNode(
+                id="pls",
+                inputs=("snv",),
+                spec=PLSRegressionSpec(n_components=6, target="fat"),
+            ),
+        )
+    )
+
+    assert [warning.code for warning in found] == [PLS_WITHOUT_CENTRING]
+    assert found[0].node_id == "pls"
+    assert "first component" in found[0].message
+    assert "intercept" in found[0].message
+
+
+def test_pls_da_is_the_same_model_and_gets_the_same_warning() -> None:
+    found = check_pipeline(
+        pipeline(
+            EstimatorNode(
+                id="plsda", inputs=("source",), spec=PLSDASpec(n_components=4, class_column="grade")
+            ),
+        )
+    )
+    assert [(w.code, w.node_id) for w in found] == [(PLS_WITHOUT_CENTRING, "plsda")]
+
+
+@pytest.mark.parametrize("step", [MeanCentre(), Autoscale()])
+def test_either_kind_of_centring_above_a_pls_node_silences_it(step: Any) -> None:
+    """`Autoscale` subtracts the column means before it divides, so it centres."""
+    found = check_pipeline(
+        pipeline(
+            SplitNode(id="cv", inputs=("source",), spec=KFoldSplit(n_splits=10)),
+            PreprocessNode(id="centre", inputs=("cv",), step=step),
+            EstimatorNode(
+                id="pls",
+                inputs=("centre",),
+                spec=PLSRegressionSpec(n_components=6, target="fat"),
+            ),
+        )
+    )
+    assert found == []
+
+
+def test_the_centring_may_be_any_distance_above_the_pls_node() -> None:
+    found = check_pipeline(
+        pipeline(
+            SplitNode(id="cv", inputs=("source",), spec=KFoldSplit(n_splits=10)),
+            PreprocessNode(id="centre", inputs=("cv",), step=MeanCentre()),
+            PreprocessNode(id="snv", inputs=("centre",), step=SNV()),
+            EstimatorNode(
+                id="pls", inputs=("snv",), spec=PLSRegressionSpec(n_components=6, target="fat")
+            ),
+        )
+    )
+    assert found == []
+
+
+def test_a_pca_node_with_no_centring_is_not_warned_about() -> None:
+    """Uncentred PCA is a choice with a literature behind it; uncentred PLS is not.
+
+    Only `pls-regression.md` §3 says "almost always wrong", so only PLS is
+    warned about. Extending this to PCA would be a preference with no document
+    behind it.
+    """
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="snv", inputs=("source",), step=SNV()),
+            EstimatorNode(id="pca", inputs=("snv",), spec=PCASpec(n_components=5)),
+        )
+    )
+    assert found == []
+
+
+# --------------------------------------------------------------------------
+# both at once, and the pipeline that deserves neither
+# --------------------------------------------------------------------------
+
+
+def test_a_pipeline_can_earn_both_warnings_and_gets_both() -> None:
+    found = check_pipeline(
+        pipeline(
+            # One branch centres above its split; the other never centres at all.
+            PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+            SplitNode(id="cv", inputs=("centre",), spec=KFoldSplit(n_splits=10)),
+            EstimatorNode(id="pca", inputs=("cv",), spec=PCASpec(n_components=3)),
+            PreprocessNode(id="snv", inputs=("source",), step=SNV()),
+            EstimatorNode(
+                id="pls", inputs=("snv",), spec=PLSRegressionSpec(n_components=6, target="fat")
+            ),
+        )
+    )
+    assert {(w.code, w.node_id) for w in found} == {
+        (LEAK_BEFORE_SPLIT, "centre"),
+        (PLS_WITHOUT_CENTRING, "pls"),
+    }
+
+
+def test_a_pls_fed_by_a_leaky_centring_is_warned_about_once_not_twice() -> None:
+    """The centring is there, so the PLS has what it needs; where it sits is
+    the other warning's subject, and it already names the node."""
+    found = check_pipeline(
+        pipeline(
+            PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+            SplitNode(id="cv", inputs=("centre",), spec=KFoldSplit(n_splits=10)),
+            EstimatorNode(
+                id="pls", inputs=("cv",), spec=PLSRegressionSpec(n_components=6, target="fat")
+            ),
+        )
+    )
+    assert [(w.code, w.node_id) for w in found] == [(LEAK_BEFORE_SPLIT, "centre")]
+
+
+def test_the_fixture_pipeline_earns_neither_warning() -> None:
+    """The recipe the artboards draw is arranged correctly, and stays a check on these rules."""
+    published = Pipeline.model_validate(
+        json.loads((FIXTURES / "pipeline.json").read_text(encoding="utf-8"))
+    )
+    assert check_pipeline(published) == []
+
+
+# --------------------------------------------------------------------------
+# the envelope
+# --------------------------------------------------------------------------
+
+
+def test_the_response_keeps_the_published_shape_and_adds_to_it() -> None:
+    """The GUESS envelope is kept exactly, so no screen changes to read it."""
+    leaky = pipeline(
+        PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+        SplitNode(id="cv", inputs=("centre",), spec=KFoldSplit(n_splits=10)),
+    )
+    payload = validation_payload(leaky)
+
+    assert set(payload) == {"pipeline_id", "valid", "problems", "warnings"}
+    assert payload["pipeline_id"] == str(leaky.pipeline_id)
+    assert payload["valid"] is False
+    assert payload["problems"] == [warning.message for warning in check_pipeline(leaky)]
+
+    # The structured form carries what a sentence cannot: the node to point at.
+    assert payload["warnings"][0]["node_id"] == "centre"
+    assert payload["warnings"][0]["related"] == ["cv"]
+    assert payload["warnings"][0]["severity"] == "warning"
+    assert payload["warnings"][0]["code"] == LEAK_BEFORE_SPLIT
+
+
+def test_a_pipeline_with_nothing_to_say_about_it_is_valid_and_empty() -> None:
+    clean = pipeline(
+        SplitNode(id="cv", inputs=("source",), spec=KFoldSplit(n_splits=10)),
+        PreprocessNode(id="centre", inputs=("cv",), step=MeanCentre()),
+    )
+    assert validation_payload(clean) == {
+        "pipeline_id": str(clean.pipeline_id),
+        "valid": True,
+        "problems": [],
+        "warnings": [],
+    }
+
+
+def test_a_warning_does_not_stop_the_pipeline_running(tmp_path: Path) -> None:
+    """The user is told, not stopped. The recipe is the record of what was done."""
+    from chemometrics_workbench.datasets import load_tecator
+    from chemometrics_workbench.executor import execute
+    from chemometrics_workbench.models import DatasetVersion
+    from chemometrics_workbench.project import create_project, write_array
+
+    tecator = load_tecator()
+    directory = tmp_path / "project"
+    create_project(directory, "warnings do not block")
+    array_path, _ = write_array(directory, tecator.spectra)
+    version = DatasetVersion(
+        dataset_id=uuid4(),
+        version=1,
+        content_hash=tecator.source.file_hash,
+        n_samples=tecator.n_samples,
+        n_variables=tecator.n_variables,
+        axis=tecator.axis,
+        sample_ids=list(tecator.sample_ids),
+        array_path=array_path,
+    )
+
+    leaky = Pipeline(
+        project_id=uuid4(),
+        name="leaky",
+        nodes=[
+            SourceNode(id="source", version_id=version.version_id),
+            PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+            SplitNode(id="cv", inputs=("centre",), spec=KFoldSplit(n_splits=10, seed=42)),
+            EstimatorNode(id="pca", inputs=("cv",), spec=PCASpec(n_components=3)),
+        ],
+    )
+
+    assert [warning.code for warning in check_pipeline(leaky)] == [LEAK_BEFORE_SPLIT]
+    run = execute(directory, leaky, version)
+    assert run.results["pca"].n_components == 3


### PR DESCRIPTION
New module `src/chemometrics_workbench/checks.py`, `validation_payload` in `api.py`, the stub's validate handler replaced by a call to it, and 21 tests in `tests/test_checks.py`.

Both warnings catch a mistake whose symptom is a *believable* number. A mean leaked across a split does not raise — it lowers RMSECV. A PLS model on uncentred data does not raise — it spends its first component on the offset. Neither is visible in the output, which is why they are stated before the run rather than diagnosed after it.

## Warning one — centring above a split

`metrics-and-validation.md` §9. A `MeanCentre` or `Autoscale` with a split anywhere below it names both nodes and says what follows: RMSECV comes out optimistic, and moving the node below the split fits it on each training fold instead. Consequence and remedy, not the rule.

- Found through intervening nodes — fitted before the split is fitted on everything, however far before.
- Both splits named when one centring feeds two.
- Silent when the centring is below the split; when it is on a branch that never reaches one (the fixture's own shape — `centre_a` and `split_d` are in one pipeline and have nothing to do with each other); and for `SNV`, `Normalise`, Savitzky-Golay and the baselines above a split, none of which estimates anything across samples.

## Warning two — PLS without centring

`pls-regression.md` §3: legal here, and almost always wrong. A `PLSRegressionSpec` or `PLSDASpec` node with no centring above it says the first component spends itself on the offset and the model carries no intercept to absorb it. Silenced by either kind of centring at any distance above.

**A PCA with no centring is deliberately not warned about.** Only §3 says "almost always wrong"; extending that to PCA would be a preference with no document behind it.

**A PLS fed by a leaky centring is warned about once, not twice.** The centring is there, so the PLS has what it needs; where it sits is the other warning's subject, and that warning already names the node.

## The envelope, and the frontend

`valid` and `problems` are kept exactly as published — the canvas renders `problems` joined together — and `warnings` is added beside them with `code`, `node_id`, `related` and `severity`, so a screen can point at a node instead of parsing a sentence.

`valid` therefore means **"there is nothing to tell you"**, not "this will run". Everything runs. Reporting `valid: true` while holding a warning would mean the 1.1 screen said "valid · 14 steps" and dropped the sentence.

`pnpm e2e` is 40 passed with the frontend untouched.

## The stub handler is computed now

It parses `stub/fixtures/pipeline.json` and calls `validation_payload`. The fixture pipeline earns neither warning, so the response is byte-identical to the constant it replaced — for a reason rather than by construction. That is also a standing check on the rules: the recipe the artboards draw is arranged correctly, and a test asserts it stays that way.

## A third case, raised as #103

`MSC` estimates its reference spectrum from the fit set, so a sample's output depends on which other samples were present — the property that makes centring a leak. §9 lists it in neither its legitimate set nor its leaking set. Under #84's own convention that becomes an issue rather than a widened branch.

`SNV`, `Normalise`, Savitzky-Golay, the baselines and `RangeSelect` were all checked and are legitimate above a split, which leaves MSC as the only step in the schema that leaks and is not warned about.

## Evidence

- `uv run pytest` — 679 passed, 1 skipped (658 before). `ruff check`, `ruff format --check`, `mypy` over 44 source files clean.
- `pnpm e2e` — 40 passed, frontend unchanged.
- Warnings do not block: a test executes a leaky pipeline to completion after asserting it warns.
- Both warnings fire at once on a pipeline that earns both, and neither hides the other.

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UyipBcx3Reb39zwk1BHgws