### PR TITLE
Phase 1.2 · Record which side of the centre_d disagreement moves

### DIFF
--- a/docs/decisions/0003-fixture-centre-d.md
+++ b/docs/decisions/0003-fixture-centre-d.md
@@ -1,0 +1,72 @@
+# 0003 — The Phase 1.1 fixture's `centre_d` stands; §9 is what the executor follows
+
+**Date:** 2026-08-29
+**Status:** accepted
+**Issue:** [#97](https://github.com/millermuttu/Chemometrics-Workbench/issues/97)
+**Decides:** the exception to "the fixtures are the contract and the numbers may not change",
+stated in `tests/fixtures/contract/README.md`.
+
+---
+
+## Decision
+
+**The fixture keeps the array it published, and the executor keeps disagreeing with it.**
+
+`tests/fixtures/contract/spectra.json` serves `centre_d` — the `MeanCentre` node *below*
+`split_d` — as a mean centring fitted on all 240 samples. `metrics-and-validation.md` §9 says
+every node downstream of a split is refitted on the training fold alone, and the array such a
+node displays is assembled out of fold, each sample taking the row from the fold that held it
+out. The executor does that. The two differ, and they will keep differing.
+
+`pca_d` is fitted on `centre_d` and diverges for the same reason. It is the second casualty and
+is covered by this record.
+
+## Why this way round
+
+The fixture is the **Phase 1.1 record** — what the frontend was built against — and §9 is the
+**specification**. Where they disagree, the specification is what the application follows and the
+record stays a record. Regenerating the fixture would make a historical artefact agree with a rule
+it predates, which is tidier and less true.
+
+Two practical facts settled it as much as the principle:
+
+- **The generator is gone.** `stub/generate_fixtures.py` was deleted with the rest of `stub/` in
+  [#89](https://github.com/millermuttu/Chemometrics-Workbench/issues/89), and the fixtures became
+  frozen regression inputs at that moment. Regenerating now means rebuilding a generator first.
+- **The executor is not in doubt.** Every other array in the fixture pipeline — `source`, `snv`,
+  `centre_a`, `msc`, `centre_b`, `savgol`, `autoscale_c`, `snv_savgol`, `split_d` — is reproduced
+  to the fixture's own 6-decimal rounding. This is the one array where the rule bites, not a
+  symptom of a shaky implementation.
+
+## The measurement, which is the point
+
+For sample 0 of `centre_d`, against the fixture's published row:
+
+| computed as | max abs difference from the fixture |
+| --- | --- |
+| `MeanCentre` fitted on all 240 samples | 4.9e-07 — the fixture's own 6-decimal rounding |
+| out-of-fold, §9 | 1.2e-03 |
+
+Both are computed in
+`tests/test_executor.py::test_a_node_below_a_split_is_refitted_per_fold_which_the_fixture_is_not`,
+which asserts the fixture holds the fit-on-everything number *and* that the executor differs from
+it by more than 1e-4, then reproduces the executor's own value from fold arithmetic done by hand.
+`test_pca_d_diverges_from_the_fixture_for_the_reason_centre_d_does` does the same for `pca_d`.
+
+The divergence is therefore a **measured fact that a test would notice changing**, not a
+remembered one. That is what makes leaving it safe: nothing can drift quietly toward the fixture
+or away from §9 without a test saying so.
+
+## What this does not license
+
+It is not a general permission for the executor to disagree with the fixtures. Every other
+published number is reproduced, and a new disagreement is a finding to investigate, not a
+precedent to cite. The exception is this node, for this reason, with this measurement.
+
+## Rejected
+
+**Regenerate `spectra.json` so `centre_d` carries the out-of-fold array.** It would keep "the
+fixture is the contract" literally true, and it was the cheaper option when #97 was filed — before
+#89 deleted the generator. It also means regenerating `pca.json`, since `pca_d` is fitted on this
+array. Taken today it is more work than the thing it buys, and what it buys is a record that no
+longer records what happened.

--- a/feature_list.json
+++ b/feature_list.json
@@ -190,13 +190,15 @@
         "pipeline-executor"
       ],
       "user_visible_behavior": "The spectra view of a node below a split shows what actually happened to each sample - the fold that held it out - rather than a mean taken over the samples it is being validated against.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
-        "The decision is recorded: either spectra.json is regenerated with the out-of-fold array, or the exception is written where the fixture rule is stated.",
-        "#87 asserts whichever was chosen, and does not assert the other."
+        "The exception is recorded where the fixture rule is stated.",
+        "The decision is in docs/decisions/, so it is not re-argued from preference.",
+        "#87 does not assert the fixture's centre_d or pca_d numbers.",
+        "A test computes both values, so the divergence cannot drift unnoticed."
       ],
-      "evidence": "",
-      "notes": "Found in #83 and measured there: fit-on-everything agrees with the fixture to 4.9e-07, out of fold differs by 1.2e-03. metrics-and-validation.md §9 requires the fold fit; the fixture's run_preprocessing says in its own docstring that it does no fold handling. Blocks nothing - #86 and #87 both need to know which array centre_d holds."
+      "evidence": "2026-08-29. On feature/97_fixture-centre-d-exception. Decided with the maintainer: **the fixture keeps the array it published and the executor keeps following §9.** Recorded in docs/decisions/0003-fixture-centre-d.md and as the one stated exception in tests/fixtures/contract/README.md, beside the rule it excepts.\n\nThe fixture is the Phase 1.1 record; §9 is the specification; where they disagree the application follows the specification and the record stays a record. Regenerating would make a historical artefact agree with a rule it predates - and #89 deleted stub/generate_fixtures.py with the rest of stub/, so it would mean rebuilding a generator first, then regenerating pca.json too because pca_d is fitted on centre_d.\n\nNo code changed, and none needed to. The executor already implements §9 and #87 already measures the divergence rather than asserting the fixture's numbers: test_a_node_below_a_split_is_refitted_per_fold_which_the_fixture_is_not asserts the fixture holds the fit-on-everything value (4.9e-07, its own 6-decimal rounding) and that the executor differs by more than 1e-4 (1.2e-03), then reproduces the executor's value from fold arithmetic done by hand; test_pca_d_diverges_from_the_fixture_for_the_reason_centre_d_does does the same for pca_d. The divergence is a measured fact a test would notice changing, which is what makes leaving it safe.\n\nThe record says what it does not license: every other published array is reproduced to the fixture's rounding, so a new disagreement is a finding to investigate rather than a precedent to cite. uv run pytest 731 passed, 1 skipped; ruff and mypy clean.",
+      "notes": "Found in #83 and measured there: fit-on-everything agrees with the fixture to 4.9e-07, out of fold differs by 1.2e-03. metrics-and-validation.md §9 requires the fold fit; the fixture's run_preprocessing says in its own docstring that it does no fold handling. Blocks nothing - #86 and #87 both need to know which array centre_d holds. Decided 2026-08-29, recorded in docs/decisions/0003-fixture-centre-d.md."
     },
     {
       "id": "pipeline-validator",

--- a/tests/fixtures/contract/README.md
+++ b/tests/fixtures/contract/README.md
@@ -21,5 +21,21 @@ Two things they are not:
   file here to match. Every envelope marked GUESS in Phase 1.1 may change; the
   numbers may not, because they came from the kernels.
 
+## The one number the application deliberately does not reproduce
+
+`spectra.json` publishes `centre_d` as a mean centring fitted on all 240
+samples. `metrics-and-validation.md` §9 requires a node below a split to be
+refitted on the training fold alone, and the executor does that, so the two
+differ - by 1.2e-03, measured. `pca.json`'s `pca_d` is fitted on that array and
+diverges with it.
+
+**This is the exception to the rule above, and the only one.** The fixture is
+the Phase 1.1 record; §9 is the specification; where they disagree the
+application follows the specification and the record stays a record.
+`docs/decisions/0003-fixture-centre-d.md` is why, and
+`tests/test_executor.py` computes both numbers so the divergence cannot drift
+without a test noticing. Every other array here is reproduced to the fixture's
+own rounding - a new disagreement is a finding, not a precedent.
+
 `tests/seed_e2e.py` rebuilds the same four-branch pipeline these were generated
 from, so the end-to-end suite exercises the same graph against real arrays.


### PR DESCRIPTION
Closes #97.

The Phase 1.1 fixture publishes `centre_d` as a mean centring fitted on all 240 samples. `metrics-and-validation.md` §9 requires a node below a split to be refitted on the training fold alone, and the executor does that — so the two differ by 1.2e-03.

**Decided with the maintainer: the fixture keeps what it published, and the executor keeps following §9.**

## Why this way round

The fixture is the **Phase 1.1 record**; §9 is the **specification**. Where they disagree the application follows the specification and the record stays a record. Regenerating would make a historical artefact agree with a rule it predates — tidier, and less true.

Two practical facts pointed the same way:

- **The generator is gone.** #89 deleted `stub/generate_fixtures.py` with the rest of `stub/`, and the fixtures became frozen regression inputs at that moment. Regenerating now means rebuilding a generator first — and then `pca.json` too, because `pca_d` is fitted on this array.
- **The executor is not in doubt.** Every other array in the fixture pipeline is reproduced to the fixture's own 6-decimal rounding. This is the one array where the rule bites, not a symptom of a shaky implementation.

## No code changed, and none needed to

The executor already implements §9, and the tests already measure the divergence rather than asserting the fixture's numbers:

- `test_a_node_below_a_split_is_refitted_per_fold_which_the_fixture_is_not` asserts the fixture holds the fit-on-everything value (4.9e-07 — its own rounding) **and** that the executor differs by more than 1e-4 (1.2e-03), then reproduces the executor's value from fold arithmetic done by hand.
- `test_pca_d_diverges_from_the_fixture_for_the_reason_centre_d_does` does the same for `pca_d`.

The divergence is a **measured fact a test would notice changing**, which is what makes leaving it safe. Nothing can drift quietly toward the fixture or away from §9.

What was missing was the exception being written where the rule is stated, so the next person meets it there rather than rediscovering it.

## What it does not license

`docs/decisions/0003-fixture-centre-d.md` says so explicitly: every other published array is reproduced to the fixture's rounding, so **a new disagreement is a finding to investigate, not a precedent to cite**. The exception is this node, for this reason, with this measurement.

## Verification

`uv run pytest` 731 passed, 1 skipped; ruff, format and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qZq9dRS4MUXBVRmjx7j5V