### PR TITLE
Cover the beyond-the-envelope screen, and record what is deliberately not covered

### DIFF
--- a/docs/decisions/0005-overloaded-state-coverage.md
+++ b/docs/decisions/0005-overloaded-state-coverage.md
@@ -1,0 +1,63 @@
+# 0005 — The beyond-the-envelope screen is covered as a component, and the end-to-end gap is recorded rather than closed
+
+**Date:** 2026-08-29
+**Status:** accepted
+**Issue:** [#109](https://github.com/millermuttu/Chemometrics-Workbench/issues/109)
+**Decides:** what replaces the stub's `?oversize` affordance, retired in #89.
+
+---
+
+## Decision
+
+`frontend/src/__tests__/overloaded.test.tsx` renders `Overloaded.tsx` and the guard in
+`SpectraView.tsx` through `react-dom/server`, and asserts the notice a user reads: which bounds
+were crossed, what the dataset costs, what the limit is, the two ways back inside it, that it is
+announced with `role="alert"`, and that the plot view is never entered.
+
+Option A from the issue — importing a dataset that really is past the envelope — is **not**
+implemented, and no substitute for it is either. The gap is recorded here: **nothing in the suite
+proves that a real oversize import reaches the notice.**
+
+## Why the state cannot be reached from a small input
+
+PROPOSAL.md §13's envelope is **reported, not enforced** — #81. `frontend/src/states/envelope.ts`
+computes it from the `n_samples` and `n_variables` a `DatasetVersion` records, and the server's
+honest behaviour is to report the shape it read. So the only genuine way into this state is a
+dataset of about 42,000 × 6,200: a gigabyte as float32, and several times that as the CSV that
+becomes it. There is no small honest input, because the state is a function of size alone.
+
+The stub had one because it was allowed to lie. `?oversize` fabricated the shape, which is exactly
+the behaviour #89 removed — a server reporting a shape it did not read.
+
+## Why not seed a `DatasetVersion` past the envelope
+
+Option B — a record whose shape exceeds the envelope and whose `array_path` points at nothing —
+would render the notice with no gigabyte anywhere. It is rejected because the application can
+never produce such a record: every version the importer writes has an array behind it. A test that
+seeds one proves the screen renders for a project state that cannot exist, which is the fixture
+wearing a real project's clothes that #89 spent its length removing.
+
+## Why `react-dom/server` and not jsdom
+
+This state draws nothing and runs no effects — that is its entire purpose. Its output *is* static
+markup, so `renderToStaticMarkup` sees all of it. `react-dom` is already a dependency; jsdom and a
+testing library would be two new ones for a string the test already has.
+
+The one stub is `plotly.js-gl2d-dist-min`, which reads `self` when it loads. `SpectraView.tsx`
+imports it at module scope and, past the envelope, never calls it — the guard returns first. The
+stub is what lets that be asserted outside a browser; it replaces a browser global, not a project
+state.
+
+## What is claimed, and what is not
+
+| claim | where it lives |
+| --- | --- |
+| The thresholds and the megabyte arithmetic | `envelope.test.ts` |
+| The notice's wording, its bounds and its `role="alert"` | `overloaded.test.tsx` |
+| The plot screen routes to the notice instead of mounting the plot | `overloaded.test.tsx` |
+| A real gigabyte import reaches the notice | **nothing — deliberately** |
+
+The last row is the cost of the decision, stated so the next person does not read the absence of
+an end-to-end test as an oversight. If a machine-sized import fixture ever becomes cheap — a
+memory-mapped array written in place, say, rather than a CSV parsed — option A becomes worth
+revisiting.

--- a/feature_list.json
+++ b/feature_list.json
@@ -428,12 +428,13 @@
         "http-surface-complete"
       ],
       "user_visible_behavior": "The beyond-the-envelope notice is proven to appear on a dataset that is really past PROPOSAL.md section 13's envelope.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
-        "The overloaded notice is exercised against a real dataset shape, or the decision not to is recorded with its reason."
+        "cd frontend && pnpm test - overloaded.test.tsx renders the notice and the guard that reaches it.",
+        "The decision not to prove it end to end is recorded in docs/decisions/0005-overloaded-state-coverage.md."
       ],
-      "evidence": "",
-      "notes": "Opened 2026-08-28 from #89. ?oversize fabricated a 42,000 x 6,200 shape and died with the other three affordances; nothing replaces it, because #81 established that section 13's envelope is reported and not enforced. The arithmetic is covered by frontend/src/__tests__/envelope.test.ts; the screen is not. The issue lists four options and suggests covering Overloaded.tsx as a component test and recording the decision for the remainder - no option honestly proves a real 1 GB import reaches the notice, and a hollow DatasetVersion would be a fixture wearing a real project's clothes."
+      "evidence": "2026-08-29. `cd frontend && npx vitest run` - 9 files, 63 tests passed, including src/__tests__/overloaded.test.tsx (6 tests). `npx tsc -b --noEmit` and `npx eslint .` both exit 0. The test renders Overloaded.tsx and SpectraView.tsx's guard through react-dom/server and asserts the crossed bounds (\"BEYOND THE V1 ENVELOPE - spectra - variables - memory\"), the sentence (\"42,000 x 6,200 is about 1,042 MB as float32\", \"20,000 x 4,000, about 320 MB\"), role=\"alert\", that children render beside the notice, and that the plot view is never entered. Option A - a real oversize import - is deliberately not implemented; docs/decisions/0005-overloaded-state-coverage.md records why and states the remaining gap.",
+      "notes": "Opened 2026-08-28 from #89. Closed 2026-08-29 with option C plus D: a component test for the screen, and the end-to-end gap recorded rather than closed. The envelope is reported and not enforced (#81), so the only honest input to this state is about a gigabyte - there is no small one, because the state is a function of size alone. A seeded DatasetVersion with no array (option B) was rejected: the application cannot produce that record. Rendered with react-dom/server rather than jsdom plus a testing library, because the state draws nothing and runs no effects, so static markup is its whole output; react-dom is already a dependency. plotly.js-gl2d-dist-min is stubbed because it reads `self` at load - it replaces a browser global, not a project state. vitest.config.ts now includes src/**/*.test.tsx."
     },
     {
       "id": "e2e-real-backend",

--- a/frontend/src/__tests__/overloaded.test.tsx
+++ b/frontend/src/__tests__/overloaded.test.tsx
@@ -1,0 +1,75 @@
+/** The screen that says a dataset is past PROPOSAL.md section 13's envelope.
+ *
+ * `envelope.test.ts` proves the arithmetic; this proves the notice a user
+ * actually reads, and that the screen guarding the plot reaches it.
+ *
+ * It is a component test rather than an end-to-end one, and that is a
+ * decision with a reason: `docs/decisions/0005-overloaded-state-coverage.md`.
+ * The state is entered by importing a dataset of about a gigabyte, which does
+ * not belong in CI, and the envelope is reported rather than enforced - so
+ * there is no smaller honest input that produces it. What is claimed here is
+ * the component and the guard; what is not claimed is that a real oversize
+ * import reaches them.
+ *
+ * Rendered through `react-dom/server` rather than a DOM: this state draws no
+ * plot and runs no effects - that is its whole point - so static markup is
+ * the entire output, and jsdom plus a testing library would be two
+ * dependencies for a string this test already has.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { Overloaded } from "@/states/Overloaded";
+
+// Plotly is a browser bundle and reads `self` when it loads. SpectraView
+// imports it at module scope, and past the envelope it is never called - the
+// guard returns before the plot exists. Stubbing the import is what lets that
+// be asserted outside a browser.
+vi.mock("plotly.js-gl2d-dist-min", () => ({ default: { react: vi.fn(), purge: vi.fn() } }));
+
+describe("the beyond-the-envelope notice", () => {
+  const html = renderToStaticMarkup(
+    <Overloaded samples={42_000} variables={6_200} what="The spectra plot" />,
+  );
+
+  it("names every bound that was crossed, not just 'too big'", () => {
+    expect(html).toContain("BEYOND THE V1 ENVELOPE · spectra · variables · memory");
+  });
+
+  it("says what is not drawn, what this dataset costs and what the limit is", () => {
+    expect(html).toContain("The spectra plot is not drawn for this dataset.");
+    expect(html).toContain("42,000 × 6,200 is about 1,042 MB as float32");
+    expect(html).toContain("20,000 × 4,000, about 320 MB");
+  });
+
+  it("tells the user the two ways back inside the envelope", () => {
+    expect(html).toContain("Select a range of variables or a subset of samples");
+  });
+
+  it("is announced rather than drawn silently", () => {
+    expect(html).toContain('role="alert"');
+  });
+
+  it("keeps what is cheap available beside the notice", () => {
+    const withMetadata = renderToStaticMarkup(
+      <Overloaded samples={42_000} variables={6_200} what="The spectra plot">
+        <p>240 samples · Tecator</p>
+      </Overloaded>,
+    );
+    expect(withMetadata).toContain("240 samples · Tecator");
+  });
+});
+
+describe("the screen that guards the plot", () => {
+  it("renders the notice instead of mounting the plot, past the envelope", async () => {
+    const { SpectraView } = await import("@/screens/SpectraView");
+    const html = renderToStaticMarkup(
+      <SpectraView nodeId="source" title="Raw spectra" samples={42_000} variables={6_200} />,
+    );
+    expect(html).toContain('data-testid="overloaded"');
+    // The plot view was never entered: it would have asked for spectra and
+    // rendered its loading pane. Past the envelope there is nothing to
+    // prepare, which is the freeze this state exists to avoid.
+    expect(html).not.toContain("Loading spectra");
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,5 +4,5 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: { alias: { "@": path.resolve(import.meta.dirname, "src") } },
-  test: { environment: "node", include: ["src/**/*.test.ts"] },
+  test: { environment: "node", include: ["src/**/*.test.ts", "src/**/*.test.tsx"] },
 });


### PR DESCRIPTION
Closes #109. The last feature of Phase 1.2.

## What went missing

`?oversize` made the 1.1 stub fabricate a dataset shape of 42,000 × 6,200 so the beyond-the-envelope notice could be rendered, and `states.spec.ts` asserted the notice against it. It died with the other three 1.1-only affordances in #89 and nothing replaced it. `envelope.test.ts` still covers the arithmetic; the **screen** was uncovered.

## What this does

`frontend/src/__tests__/overloaded.test.tsx` — six tests, rendering `Overloaded.tsx` and the guard in `SpectraView.tsx` through `react-dom/server`:

- every crossed bound is named, not just "too big" — `BEYOND THE V1 ENVELOPE · spectra · variables · memory`
- what is not drawn, what this dataset costs (`42,000 × 6,200 is about 1,042 MB as float32`) and what the limit is (`20,000 × 4,000, about 320 MB`)
- the two ways back inside the envelope
- `role="alert"` — announced, not drawn silently
- children render beside the notice, because what is cheap stays available
- past the envelope `SpectraView` renders the notice and never enters the plot view

## What it deliberately does not do

The issue's **option A** — importing a dataset that really is past the envelope — is not implemented, and nothing stands in for it. §13's envelope is *reported, not enforced* (#81), so the state is a function of size alone: there is no small honest input, only a gigabyte. **Option B** — a `DatasetVersion` whose shape exceeds the envelope with no array behind it — is rejected because the application can never produce that record; seeding one proves the screen renders for a project state that cannot exist.

That gap is written down in `docs/decisions/0005-overloaded-state-coverage.md`, with a table of what is claimed and what is not, so the absence of an end-to-end test is not read later as an oversight.

## Choices worth a second's attention

- **`react-dom/server`, not jsdom.** This state draws nothing and runs no effects — that is its purpose — so static markup is its entire output. `react-dom` is already a dependency; jsdom plus a testing library would be two new ones for a string the test already has.
- **`plotly.js-gl2d-dist-min` is stubbed** because it reads `self` when it loads and `SpectraView` imports it at module scope. Past the envelope it is never called. The stub replaces a browser global, not a project state.
- `vitest.config.ts` now includes `src/**/*.test.tsx` alongside `.test.ts`.

## Verification

```
cd frontend
npx vitest run     # 9 files, 63 tests passed (overloaded.test.tsx: 6)
npx tsc -b --noEmit   # exit 0
npx eslint .          # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwjcmQR7kksD9ttwZV7ior