### PR TITLE
Read a project written before the database into one

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -57,14 +57,14 @@
         "project-through-the-database"
       ],
       "user_visible_behavior": "A project directory created by v0.3.0 opens and reads back identically, without the user re-importing anything.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
-        "A fixture directory in the pre-1.3 shape opens; datasets, pipeline, layout and experiment match what the JSON held.",
-        "Opening it twice does not import twice.",
-        "The JSON files are still on disk afterwards and are not consulted."
+        "A project directory seeded by v0.3.0's own code opens, and everything it held reads back.",
+        "cd frontend && npx playwright test - 38 passed, the seeded projects unaffected.",
+        "uv run pytest - the reader accepts the shape v0.3.0 wrote, twice over without importing twice."
       ],
-      "evidence": "",
-      "notes": "open_project reads the five JSON files once into a fresh database in one transaction and leaves them in place, never read again. One function, one test, deleted in a later phase. Not a clean break, because the seeded e2e projects and any developer's directory are real users of the old shape; not a two-way sync either."
+      "evidence": "2026-08-29. Checked out v0.3.0 in a worktree and seeded a project with *its* code (PYTHONPATH ahead of the editable install, confirmed by the module path and by is_project being absent): the directory came out with project.json, datasets.json, pipeline.json, pipeline_layout.json, experiment.json, arrays/ and no database. Opening it with this branch read back the project (Tecator meat study), the dataset (tecator_raw, 240 x 100, its array_path intact), the 14-node pipeline with content hash sha256:62ece5b6d8424835..., the layout, and the succeeded experiment; project.db was created and all six JSON files were still on disk. `uv run pytest` - 753 passed, 1 skipped, including 8 new in tests/test_project_json_import.py. `cd frontend && npx playwright test` - 38 passed. ruff, format and mypy clean over 48 files.",
+      "notes": "open_project reads the five JSON files once into a fresh database in one transaction and leaves them in place, never read again. One function, one test, deleted in a later phase. Not a clean break, because the seeded e2e projects and any developer's directory are real users of the old shape; not a two-way sync either. Implemented 2026-08-29. is_project() had to count a JSON directory too, or api.py would have sent it to create_project, which refuses over an existing project. The import found a real ordering bug: without a declared relationship between the two mappers, SQLAlchemy's unit of work attempted the pipeline_layout insert before the pipeline it points at and the foreign key refused it - one flush between them, with the reason recorded. An unreadable file is named rather than skipped: a project whose pipeline will not parse has lost work, and starting again from nothing is the wrong answer to that."
     },
     {
       "id": "cache-index-in-the-database",

--- a/src/chemometrics_workbench/project.py
+++ b/src/chemometrics_workbench/project.py
@@ -169,7 +169,9 @@ def open_project(directory: str | os.PathLike[str]) -> Project:
         raise ProjectError(f"{path} is a file, not a project directory.")
 
     if not db.database_path(path).exists():
-        raise ProjectError(f"{path} is not a project directory: it has no {db.DATABASE_FILE}.")
+        if not (path / PROJECT_FILE).exists():
+            raise ProjectError(f"{path} is not a project directory: it has no {db.DATABASE_FILE}.")
+        _import_json_project(path)
 
     with _session(path) as session:
         record = session.scalars(select(db.ProjectRow)).first()
@@ -193,6 +195,140 @@ def open_project(directory: str | os.PathLike[str]) -> Project:
 
     _remember(path, project)
     return project
+
+
+def _import_json_project(path: Path) -> None:
+    """Read a project written before the database existed, once.
+
+    Phase 1.2 kept the index in five JSON files. A directory holding those and
+    no `project.db` is read into a fresh database here, in one transaction, and
+    **the files are left where they are and never read again** - they are not a
+    second copy to keep in step, they are what this directory used to be.
+
+    Not a refusal, because the alternative was telling anyone with a project on
+    disk to import it again, and the seeded end-to-end projects are real users
+    of the old shape. Deleted when nothing can plausibly still be on 1.2.
+    """
+    record = _json_document(path / PROJECT_FILE)
+    if not isinstance(record, dict):
+        raise ProjectError(f"{path / PROJECT_FILE} should hold an object.")
+
+    written = record.get("layout_version")
+    if written != LAYOUT_VERSION:
+        raise ProjectError(
+            f"{path} was written with layout version {written!r} and this build reads "
+            f"version {LAYOUT_VERSION}. Upgrade the application rather than editing the file."
+        )
+
+    try:
+        project = Project.model_validate({**record.get("project", {}), "directory": str(path)})
+    except ValidationError as error:
+        first = error.errors()[0]
+        field = ".".join(str(part) for part in first["loc"]) or "project"
+        raise ProjectError(
+            f"{path / PROJECT_FILE} is not a valid project: {field} {first['msg']}."
+        ) from error
+
+    datasets = _json_document(path / DATASETS_FILE) or []
+    pipeline_record = _json_document(path / PIPELINE_FILE)
+    layout_record = _json_document(path / LAYOUT_FILE)
+    experiment_record = _json_document(path / EXPERIMENT_FILE)
+
+    try:
+        entries = [DatasetEntry.model_validate(entry) for entry in datasets]
+        pipeline = Pipeline.model_validate(pipeline_record) if pipeline_record else None
+        experiment = Experiment.model_validate(experiment_record) if experiment_record else None
+    except ValidationError as error:
+        raise ProjectError(f"the project at {path} could not be read: {error}") from error
+
+    # One transaction: a directory either has a database holding everything the
+    # files held, or it still has only the files and is read again next time.
+    with _session(path, create=True) as session:
+        session.add(
+            db.ProjectRow(
+                project_id=str(project.project_id),
+                name=project.name,
+                created_at=project.created_at.isoformat(),
+                document=_document(project),
+            )
+        )
+        for entry in entries:
+            session.add(
+                db.DatasetRow(
+                    dataset_id=str(entry.dataset.dataset_id),
+                    name=entry.dataset.name,
+                    created_at=entry.dataset.created_at.isoformat(),
+                    document=entry.dataset.model_dump_json(),
+                )
+            )
+            for version in entry.versions:
+                session.add(
+                    db.DatasetVersionRow(
+                        version_id=str(version.version_id),
+                        dataset_id=str(version.dataset_id),
+                        version=version.version,
+                        content_hash=version.content_hash,
+                        n_samples=version.n_samples,
+                        n_variables=version.n_variables,
+                        array_path=version.array_path,
+                        created_at=version.created_at.isoformat(),
+                        document=version.model_dump_json(),
+                    )
+                )
+        if pipeline is not None:
+            session.add(
+                db.PipelineRow(
+                    pipeline_id=str(pipeline.pipeline_id),
+                    name=pipeline.name,
+                    content_hash=pipeline.content_hash(),
+                    created_at=pipeline.created_at.isoformat(),
+                    document=pipeline.model_dump_json(),
+                )
+            )
+            # Flushed before the layout that points at it: without a declared
+            # relationship between the two mappers, the unit of work is free to
+            # attempt the child insert first, and the foreign key refuses it.
+            session.flush()
+            # Layout is keyed on the pipeline, so a layout without one has
+            # nothing to hang from and is dropped rather than invented.
+            if isinstance(layout_record, dict):
+                session.add(
+                    db.PipelineLayoutRow(
+                        pipeline_id=str(pipeline.pipeline_id),
+                        document=json.dumps(layout_record),
+                    )
+                )
+        if experiment is not None:
+            session.add(
+                db.ExperimentRow(
+                    experiment_id=str(experiment.experiment_id),
+                    dataset_version_id=str(experiment.dataset_version_id),
+                    status=experiment.status.value,
+                    started_at=(
+                        experiment.started_at.isoformat() if experiment.started_at else None
+                    ),
+                    finished_at=(
+                        experiment.finished_at.isoformat() if experiment.finished_at else None
+                    ),
+                    document=experiment.model_dump_json(),
+                )
+            )
+        session.commit()
+
+
+def _json_document(path: Path) -> Any:
+    """One of the pre-database files, or `None` if it is not there.
+
+    A file that exists and cannot be parsed is an error rather than an absence:
+    a project whose pipeline is unreadable has lost work, and quietly starting
+    again from nothing is the wrong answer to that.
+    """
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as error:
+        raise ProjectError(f"{path} could not be read: {error}") from error
 
 
 def _document(project: Project) -> str:
@@ -566,7 +702,11 @@ def is_project(directory: str | os.PathLike[str]) -> bool:
     is a fact about the directory layout, which is this module's to know. It
     asked for `project.json` by name until the database replaced it.
     """
-    return db.database_path(Path(directory)).exists()
+    directory = Path(directory)
+    # A directory written before the database counts: `open_project` reads it
+    # into one on the way past, and answering "no" here would send `api.py` to
+    # `create_project`, which refuses over an existing project.
+    return db.database_path(directory).exists() or (directory / PROJECT_FILE).exists()
 
 
 def _require_project(path: Path) -> None:

--- a/tests/test_project_json_import.py
+++ b/tests/test_project_json_import.py
@@ -1,0 +1,209 @@
+"""A project directory written before the database existed still opens.
+
+Phase 1.2 kept the index in five JSON files; `v0.3.0` shipped that shape and
+seeded three end-to-end projects in it. Opening one reads it into a fresh
+`project.db` once, and the files stay where they are.
+
+The directory here is built by hand rather than by an old build, so what it
+really tests is that the *reader* accepts the shape `v0.3.0` wrote. The shape
+itself is pinned by the models, which have not changed: every document below is
+a `model_dump_json` of the same class the old code wrote.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import NamedTuple
+
+import pytest
+
+from chemometrics_workbench import db
+from chemometrics_workbench.models import (
+    Dataset,
+    DatasetVersion,
+    Experiment,
+    ExperimentStatus,
+    Pipeline,
+    Project,
+    SourceNode,
+    VariableAxis,
+)
+from chemometrics_workbench.project import (
+    ProjectError,
+    is_project,
+    open_project,
+    read_datasets,
+    read_experiment,
+    read_layout,
+    read_pipeline,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("CHEMOMETRICS_CONFIG_HOME", str(tmp_path / "config"))
+
+
+class Written(NamedTuple):
+    """What the directory below holds, so a test can compare against it."""
+
+    project: Project
+    dataset: Dataset
+    version: DatasetVersion
+    pipeline: Pipeline
+    layout: dict[str, dict[str, float]]
+    experiment: Experiment
+
+
+def write_json_project(path: Path) -> Written:
+    """A project directory in the shape `v0.3.0` wrote, and what it holds."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "arrays").mkdir(exist_ok=True)
+
+    project = Project(name="Corn", description="NIR", directory=str(path))
+    dataset = Dataset(project_id=project.project_id, name="corn m5")
+    version = DatasetVersion(
+        dataset_id=dataset.dataset_id,
+        version=1,
+        content_hash="sha256:" + "1" * 64,
+        n_samples=3,
+        n_variables=2,
+        axis=VariableAxis(kind="wavelength_nm", values=[1100.0, 1102.0], unit="nm"),
+        array_path="arrays/" + "1" * 64 + ".npy",
+    )
+    pipeline = Pipeline(
+        project_id=project.project_id,
+        name="corn pipeline",
+        nodes=[SourceNode(id="source", version_id=version.version_id)],
+    )
+    layout = {"source": {"x": 40.0, "y": 40.0}}
+    experiment = Experiment(
+        project_id=project.project_id,
+        pipeline_snapshot=pipeline,
+        dataset_version_id=version.version_id,
+        dataset_content_hash=version.content_hash,
+        status=ExperimentStatus.RUNNING,
+        started_at=datetime(2026, 8, 1, 12, 0, tzinfo=UTC),
+    )
+
+    (path / "project.json").write_text(
+        json.dumps(
+            {
+                "layout_version": 1,
+                "project": project.model_dump(mode="json", exclude={"directory"}),
+            }
+        ),
+        encoding="utf-8",
+    )
+    (path / "datasets.json").write_text(
+        json.dumps(
+            [
+                {
+                    "dataset": json.loads(dataset.model_dump_json()),
+                    "versions": [json.loads(version.model_dump_json())],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (path / "pipeline.json").write_text(pipeline.model_dump_json(), encoding="utf-8")
+    (path / "pipeline_layout.json").write_text(json.dumps(layout), encoding="utf-8")
+    (path / "experiment.json").write_text(experiment.model_dump_json(), encoding="utf-8")
+
+    return Written(project, dataset, version, pipeline, layout, experiment)
+
+
+def test_a_directory_written_before_the_database_is_read_into_one(tmp_path: Path) -> None:
+    held = write_json_project(tmp_path / "corn")
+
+    opened = open_project(tmp_path / "corn")
+
+    assert opened.project_id == held.project.project_id
+    assert (tmp_path / "corn" / db.DATABASE_FILE).is_file()
+
+
+def test_everything_the_files_held_reads_back(tmp_path: Path) -> None:
+    held = write_json_project(tmp_path / "corn")
+    root = tmp_path / "corn"
+
+    open_project(root)
+
+    entries = read_datasets(root)
+    assert [entry.dataset.dataset_id for entry in entries] == [held.dataset.dataset_id]
+    assert entries[0].versions == [held.version]
+    assert read_pipeline(root) == held.pipeline
+    assert read_layout(root) == held.layout
+    assert read_experiment(root) == held.experiment
+
+
+def test_the_files_are_left_where_they_are(tmp_path: Path) -> None:
+    # They are not a second copy to keep in step; they are what the directory
+    # used to be, and deleting a user's data to tidy up is not this function's
+    # decision to make.
+    root = tmp_path / "corn"
+    write_json_project(root)
+    before = {name: (root / name).read_bytes() for name in ("project.json", "pipeline.json")}
+
+    open_project(root)
+
+    assert {name: (root / name).read_bytes() for name in before} == before
+
+
+def test_opening_twice_does_not_import_twice(tmp_path: Path) -> None:
+    root = tmp_path / "corn"
+    write_json_project(root)
+
+    open_project(root)
+    open_project(root)
+
+    assert len(read_datasets(root)) == 1
+    with db.open_session(root) as session:
+        assert session.query(db.ProjectRow).count() == 1
+
+
+def test_a_json_project_counts_as_a_project_before_it_is_read(tmp_path: Path) -> None:
+    # api.py asks this to decide whether to create or open. Answering "no"
+    # would send it to create_project, which refuses over an existing project.
+    root = tmp_path / "corn"
+    write_json_project(root)
+
+    assert is_project(root) is True
+
+
+def test_a_newer_layout_version_is_still_refused_by_name(tmp_path: Path) -> None:
+    root = tmp_path / "corn"
+    write_json_project(root)
+    record = json.loads((root / "project.json").read_text(encoding="utf-8"))
+    record["layout_version"] = 2
+    (root / "project.json").write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ProjectError, match="layout version"):
+        open_project(root)
+
+
+def test_a_project_with_only_its_project_file_opens(tmp_path: Path) -> None:
+    """The empty project: imported nothing, built nothing, ran nothing."""
+    root = tmp_path / "empty"
+    write_json_project(root)
+    for name in ("datasets.json", "pipeline.json", "pipeline_layout.json", "experiment.json"):
+        (root / name).unlink()
+
+    open_project(root)
+
+    assert read_datasets(root) == []
+    assert read_pipeline(root) is None
+    assert read_experiment(root) is None
+    assert read_layout(root) == {}
+
+
+def test_an_unreadable_file_is_named_rather_than_skipped(tmp_path: Path) -> None:
+    # A project whose pipeline cannot be parsed has lost work. Starting again
+    # from nothing is the wrong answer to that.
+    root = tmp_path / "corn"
+    write_json_project(root)
+    (root / "pipeline.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(ProjectError, match="could not be read"):
+        open_project(root)


### PR DESCRIPTION
Closes #121. After #120 the index is a database; a directory written by `v0.3.0` has five JSON files and no `project.db`, and this is what happens when one is opened.

## What

`open_project` on such a directory reads the five files into a fresh database **in one transaction**, and **leaves the files where they are, never reading them again**. They are not a second copy to keep in step — they are what the directory used to be, and deleting a user's data to tidy up is not this function's decision to make.

Refusing them instead would have meant telling anyone with a project on disk to import it again, and the seeded end-to-end projects are real users of the old shape.

## Two things this turned up

- **`is_project()` had to count a JSON directory too.** Without that, `api.py` asks whether to create or open, hears "not a project", and calls `create_project` — which refuses over an existing project. That is a 500 on the first page load of anyone's existing project.
- **A real insert-ordering bug.** With no declared relationship between the two mappers, SQLAlchemy's unit of work attempted the `pipeline_layout` insert *before* the `pipeline` row it points at, and the foreign key refused it. One `session.flush()` between them, with the reason recorded so the next person does not delete it as noise.

An unreadable file is named rather than skipped: a project whose pipeline will not parse has lost work, and quietly starting again from nothing is the wrong answer to that. The `layout_version` guard the JSON files carried still applies to them.

## Verification

**Against a project seeded by `v0.3.0`'s own code, not a hand-built imitation.** Checked the tag out in a worktree and ran its `seed_e2e.py` with `PYTHONPATH` ahead of the editable install — confirmed by the loaded module path and by `is_project` being absent from it. The directory came out with `project.json`, `datasets.json`, `pipeline.json`, `pipeline_layout.json`, `experiment.json`, `arrays/`, `results/`, `cache.json` and no database.

Opened with this branch:

```
project: Tecator meat study 55abcff8-6ec7-4b53-972d-9745747687f1
datasets: [('tecator_raw', 1)]
version: 240 x 100 arrays/858b4e6c…npy
pipeline: Scatter correction comparison 14 nodes, hash sha256:62ece5b6d8424835…
layout nodes: 1 source at {'x': 40.0, 'y': 40.0}
experiment: succeeded
database now present: True
json files still present: cache.json, datasets.json, experiment.json,
                          pipeline.json, pipeline_layout.json, project.json
```

```
uv run pytest                        # 753 passed, 1 skipped (8 new)
cd frontend && npx playwright test   # 38 passed
uv run ruff check && uv run ruff format --check && uv run mypy   # clean, 48 files
```

The eight new tests build the `v0.3.0` shape from the models themselves and assert: the database appears, everything the files held reads back, the files are untouched, opening twice does not import twice, a JSON directory counts as a project, a newer `layout_version` is still refused by name, a project with only its `project.json` opens as an empty project, and an unreadable file is named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwjcmQR7kksD9ttwZV7ior