### PR TITLE
Put the last JSON index in the project into the database

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -76,14 +76,14 @@
         "project-through-the-database"
       ],
       "user_visible_behavior": "Re-running an unchanged pipeline still recomputes nothing, and editing one node still recomputes only that node and its descendants - with no JSON index left in the project.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "tests/test_executor.py - a second run recomputes nothing; an edit recomputes the node and its descendants only; an edit below a split leaves the branch above.",
         "tests/test_executor.py - a pruned .npy is recomputed rather than refused; use_cache=False neither reads nor writes the index.",
         "A cache entry naming a missing array costs a recomputation, which is what the corrupt-cache.json test becomes."
       ],
-      "evidence": "",
-      "notes": "cache.json is a map from a node's cache key to the array paths it produced - pure references, which is what the database is for. The ponytail note at executor.py:908-910 (the index only grows, no mark-and-sweep) stays true and stays marked. One transaction per run rather than per node only if a measurement says the per-node cost matters."
+      "evidence": "2026-08-29. `uv run pytest` - 754 passed, 1 skipped. The executor's cache claims pass in table form: a second run recomputes nothing, an edit recomputes the node and its descendants only, an edit below a split leaves the branch above, a pruned .npy is recomputed rather than refused, and use_cache=False leaves read_cache_index empty. The corrupt-cache.json test became 'an index entry naming a missing array costs a recomputation', which is the failure that can still happen now the index is rows. Measured on a project seeded by v0.3.0's own code: its cache.json held 10 entries, the table held the identical 10 after opening, and a run on the migrated project reused all 10 and recomputed 0. `cd frontend && npx playwright test` - 38 passed. ruff, format and mypy clean over 48 files.",
+      "notes": "cache.json is a map from a node's cache key to the array paths it produced - pure references, which is what the database is for. The ponytail note at executor.py:908-910 (the index only grows, no mark-and-sweep) stays true and stays marked. One transaction per run rather than per node only if a measurement says the per-node cost matters. Implemented 2026-08-29. The accessors live in project.py as read_cache_index and write_cache_index, beside the other store functions, rather than in executor.py reaching into the database itself - the executor has always gone through project.py for storage. cache.json is also read across by #121's import: without it every node in a migrated project would recompute, which is correct but a pipeline's worth of work to arrive back where the project already was."
     },
     {
       "id": "two-processes-one-directory",

--- a/src/chemometrics_workbench/executor.py
+++ b/src/chemometrics_workbench/executor.py
@@ -41,12 +41,13 @@ nothing else's — which is the staleness rule stated as arithmetic rather than
 maintained as a separate flag.
 
 The key is derived from the same node JSON `Pipeline.content_hash` uses, and
-canvas coordinates live in `pipeline_state.json` outside the model entirely.
+canvas coordinates live outside the model entirely, in their own table.
 A node cannot be moved into a cache miss.
 
-The index from key to stored path is `cache.json` in the project directory.
-The arrays themselves are content-addressed by the store, so two nodes that
-compute the same values share one file.
+The index from key to stored path is a table in the project's database - it is
+a map of references, and `PROPOSAL.md` §11 puts those there. The arrays
+themselves are content-addressed files, so two nodes that compute the same
+values share one.
 
 ## Estimators
 
@@ -105,12 +106,18 @@ from chemometrics_workbench.models import (
     PipelineNode,
     ResolvedSplit,
 )
-from chemometrics_workbench.project import ProjectError, read_array, write_array, write_json
+from chemometrics_workbench.project import (
+    ProjectError,
+    read_array,
+    read_cache_index,
+    write_array,
+    write_cache_index,
+    write_json,
+)
 from chemometrics_workbench.validation import Fold, k_fold, leave_one_out, validate_partition
 
 __all__ = [
     "ALPHA",
-    "CACHE_FILE",
     "RESULTS_DIR",
     "EstimatorResult",
     "ExecutorError",
@@ -129,7 +136,6 @@ __all__ = [
     "stored_result",
 ]
 
-CACHE_FILE = "cache.json"
 RESULTS_DIR = "results"
 
 #: The confidence level every limit is quoted at. One number, in one place: a
@@ -335,7 +341,7 @@ def execute(
     path = Path(directory)
     axis = np.asarray(version.axis.values, dtype=np.float64)
     keys = node_keys(pipeline, version)
-    index = _load_index(path) if use_cache else {}
+    index = read_cache_index(path) if use_cache else {}
 
     states: dict[NodeId, _State] = {}
     outputs: dict[NodeId, NodeOutput] = {}
@@ -356,7 +362,7 @@ def execute(
     def check_cancelled() -> None:
         if is_cancelled is not None and is_cancelled():
             if index_changed:
-                _save_index(path, index)
+                write_cache_index(path, index)
             raise RunCancelled(f"the run was cancelled before node {node.id!r}")
 
     for node in ordered:
@@ -415,7 +421,7 @@ def execute(
         announce(node)
 
     if index_changed:
-        _save_index(path, index)
+        write_cache_index(path, index)
 
     return Run(
         pipeline_id=str(pipeline.pipeline_id),
@@ -792,7 +798,7 @@ def stored(directory: str | Path, pipeline: Pipeline, version: DatasetVersion) -
     """
     path = Path(directory)
     keys = node_keys(pipeline, version)
-    index = _load_index(path)
+    index = read_cache_index(path)
     by_id = {node.id: node for node in pipeline.nodes}
 
     present: dict[NodeId, str] = {}
@@ -817,7 +823,7 @@ def stored_display(
     keys = node_keys(pipeline, version)
     if node_id not in keys:
         return None
-    paths = _load_index(path).get(keys[node_id])
+    paths = read_cache_index(path).get(keys[node_id])
     if not paths:
         return None
 
@@ -883,29 +889,3 @@ def _from_cache(
     except ProjectError:
         return None
     return _State(arrays=arrays, folds=folds)
-
-
-def _load_index(directory: Path) -> dict[str, list[str]]:
-    """The key-to-paths index, or an empty one if it is absent or unreadable.
-
-    A corrupt index costs a recomputation, which is the cheapest possible
-    failure here and the reason it is not an error.
-    """
-    try:
-        document = json.loads((directory / CACHE_FILE).read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return {}
-    if not isinstance(document, dict):
-        return {}
-    return {
-        key: [str(path) for path in value]
-        for key, value in document.items()
-        if isinstance(key, str) and isinstance(value, list)
-    }
-
-
-def _save_index(directory: Path, index: dict[str, list[str]]) -> None:
-    # ponytail: the index only grows - an edited-away node's entry stays, and
-    # so does its array. Pruning wants a mark-and-sweep against the pipelines
-    # in the project, which is #89's business once there is a list of them.
-    write_json(directory / CACHE_FILE, index)

--- a/src/chemometrics_workbench/project.py
+++ b/src/chemometrics_workbench/project.py
@@ -62,6 +62,7 @@ from chemometrics_workbench.models import (
 
 __all__ = [
     "ARRAYS_DIR",
+    "CACHE_FILE",
     "DATASETS_FILE",
     "EXPERIMENT_FILE",
     "LAYOUT_FILE",
@@ -78,11 +79,13 @@ __all__ = [
     "known_projects",
     "open_project",
     "read_array",
+    "read_cache_index",
     "read_datasets",
     "read_experiment",
     "read_layout",
     "read_pipeline",
     "write_array",
+    "write_cache_index",
     "write_experiment",
     "write_json",
     "write_layout",
@@ -96,6 +99,7 @@ DATASETS_FILE = "datasets.json"
 PIPELINE_FILE = "pipeline.json"
 LAYOUT_FILE = "pipeline_layout.json"
 EXPERIMENT_FILE = "experiment.json"
+CACHE_FILE = "cache.json"
 
 ARRAYS_DIR = "arrays"
 REGISTRY_FILE = "projects.json"
@@ -230,6 +234,7 @@ def _import_json_project(path: Path) -> None:
         ) from error
 
     datasets = _json_document(path / DATASETS_FILE) or []
+    cache_record = _json_document(path / CACHE_FILE)
     pipeline_record = _json_document(path / PIPELINE_FILE)
     layout_record = _json_document(path / LAYOUT_FILE)
     experiment_record = _json_document(path / EXPERIMENT_FILE)
@@ -298,6 +303,18 @@ def _import_json_project(path: Path) -> None:
                         document=json.dumps(layout_record),
                     )
                 )
+        # The executor's index comes too. Without it every node in a migrated
+        # project would recompute on the next run - correct, because the arrays
+        # are content-addressed and would be rewritten identically, but a
+        # pipeline's worth of work to arrive back where it started.
+        if isinstance(cache_record, dict):
+            for key, stored in cache_record.items():
+                if isinstance(key, str) and isinstance(stored, list):
+                    session.add(
+                        db.CacheEntryRow(
+                            key=key, document=json.dumps([str(entry) for entry in stored])
+                        )
+                    )
         if experiment is not None:
             session.add(
                 db.ExperimentRow(
@@ -579,6 +596,42 @@ def write_layout(directory: str | os.PathLike[str], layout: dict[NodeId, dict[st
                 document=json.dumps(layout),
             )
         )
+        session.commit()
+
+
+# --- The executor's cache index -------------------------------------------
+
+
+def read_cache_index(directory: str | os.PathLike[str]) -> dict[str, list[str]]:
+    """Every cache key this project holds, against the arrays it produced.
+
+    References, which is why it is in the database rather than beside the
+    arrays it names: `PROPOSAL.md` §11 keeps contents in files and everything
+    that points at them here. One list per key, one entry per fold below a
+    split.
+    """
+    path = Path(directory)
+    with _session(path) as session:
+        rows = session.scalars(select(db.CacheEntryRow)).all()
+    index: dict[str, list[str]] = {}
+    for row in rows:
+        stored = json.loads(row.document)
+        if isinstance(stored, list):
+            index[row.key] = [str(entry) for entry in stored]
+    return index
+
+
+def write_cache_index(directory: str | os.PathLike[str], index: dict[str, list[str]]) -> None:
+    """Record every entry in `index`, replacing any it already holds.
+
+    ponytail: the index only grows - an edited-away node's entry stays, and so
+    does its array. Pruning wants a mark-and-sweep against the pipelines in the
+    project, which needs a list of them to sweep against.
+    """
+    path = Path(directory)
+    with _session(path) as session:
+        for key, stored in index.items():
+            session.merge(db.CacheEntryRow(key=key, document=json.dumps(stored)))
         session.commit()
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -24,7 +24,6 @@ from chemometrics_workbench import preprocessing, validation
 from chemometrics_workbench.datasets import load_tecator
 from chemometrics_workbench.decomposition import PCA
 from chemometrics_workbench.executor import (
-    CACHE_FILE,
     ExecutorError,
     execute,
     node_keys,
@@ -49,7 +48,12 @@ from chemometrics_workbench.models import (
     SplitNode,
     TrainTestSplit,
 )
-from chemometrics_workbench.project import create_project, write_array
+from chemometrics_workbench.project import (
+    create_project,
+    read_cache_index,
+    write_array,
+    write_cache_index,
+)
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "contract"
 
@@ -398,14 +402,21 @@ def test_a_pruned_array_is_recomputed_rather_than_refused(
     np.testing.assert_allclose(run.displays["centre_a"], first.displays["centre_a"])
 
 
-def test_a_corrupt_index_costs_a_recomputation_and_nothing_more(
+def test_an_index_entry_naming_a_missing_array_costs_a_recomputation(
     project: tuple[Path, DatasetVersion],
 ) -> None:
+    """What a corrupt `cache.json` used to cost, in the form the table has.
+
+    The index cannot be malformed any more - it is rows, and a row that does
+    not parse as a list is skipped - so the failure worth testing is the one
+    that can still happen: an entry that points at an array nobody can read.
+    """
     directory, version = project
     pipeline = fixture_pipeline(version.version_id)
     first = execute(directory, pipeline, version)
 
-    (directory / CACHE_FILE).write_text("{ not json", encoding="utf-8")
+    index = read_cache_index(directory)
+    write_cache_index(directory, {key: ["arrays/gone.npy"] for key in index})
     run = execute(directory, pipeline, version)
 
     assert run.reused == []
@@ -419,7 +430,7 @@ def test_use_cache_false_neither_reads_nor_writes_the_index(
     run = execute(directory, fixture_pipeline(version.version_id), version, use_cache=False)
 
     assert run.reused == []
-    assert not (directory / CACHE_FILE).exists()
+    assert read_cache_index(directory) == {}
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_project_json_import.py
+++ b/tests/test_project_json_import.py
@@ -34,6 +34,7 @@ from chemometrics_workbench.project import (
     ProjectError,
     is_project,
     open_project,
+    read_cache_index,
     read_datasets,
     read_experiment,
     read_layout,
@@ -111,6 +112,9 @@ def write_json_project(path: Path) -> Written:
     (path / "pipeline.json").write_text(pipeline.model_dump_json(), encoding="utf-8")
     (path / "pipeline_layout.json").write_text(json.dumps(layout), encoding="utf-8")
     (path / "experiment.json").write_text(experiment.model_dump_json(), encoding="utf-8")
+    (path / "cache.json").write_text(
+        json.dumps({"sha256:" + "9" * 64: ["arrays/" + "1" * 64 + ".npy"]}), encoding="utf-8"
+    )
 
     return Written(project, dataset, version, pipeline, layout, experiment)
 
@@ -136,6 +140,18 @@ def test_everything_the_files_held_reads_back(tmp_path: Path) -> None:
     assert read_pipeline(root) == held.pipeline
     assert read_layout(root) == held.layout
     assert read_experiment(root) == held.experiment
+
+
+def test_the_executors_cache_comes_across_so_nothing_recomputes(tmp_path: Path) -> None:
+    # Recomputing would be correct - the arrays are content-addressed and
+    # would be rewritten identically - but it is a pipeline's worth of work to
+    # arrive back where the project already was.
+    root = tmp_path / "corn"
+    write_json_project(root)
+
+    open_project(root)
+
+    assert read_cache_index(root) == {"sha256:" + "9" * 64: ["arrays/" + "1" * 64 + ".npy"]}
 
 
 def test_the_files_are_left_where_they_are(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #122. `cache.json` mapped a node's cache key to the array paths it produced — a map of **references**, which is what `PROPOSAL.md` §11 puts in the database, and the last JSON index left in a project directory.

## What

`read_cache_index` and `write_cache_index` live in `project.py`, beside the other store functions, rather than the executor reaching into the database itself: the executor has always gone through `project.py` for storage and there is no reason for the cache to be the exception. `executor.py` loses `CACHE_FILE`, `_load_index` and `_save_index`, and its call sites are otherwise unchanged.

The `ponytail:` note travels with the function: the index only grows — an edited-away node's entry stays, and so does its array. Pruning wants a mark-and-sweep against the pipelines in the project, which needs a list of them to sweep against.

## The gap between #121 and #122, closed here

A project migrated by #121 kept its `cache.json` on disk but had no cache rows, so **every node would have recomputed on the next run**. Correct — arrays are content-addressed and would be rewritten identically — but a pipeline's worth of work to arrive back where the project already was. The import reads it across.

Measured against a project seeded by `v0.3.0`'s own code in a worktree:

```
cache entries in v0.3.0's cache.json: 10
cache entries in the table after opening: 10
identical: True
nodes reused from cache: 10 recomputed: 0
```

## The test that had to change meaning

"A corrupt `cache.json` costs a recomputation" became **"an index entry naming a missing array costs a recomputation"**. The index cannot be malformed any more — it is rows, and a row that does not parse as a list is skipped — so the failure worth testing is the one that can still happen. Every other cache claim is asserted unchanged: a second run recomputes nothing, an edit recomputes the node and its descendants only, an edit below a split leaves the branch above alone, a pruned `.npy` is recomputed rather than refused, and `use_cache=False` neither reads nor writes the index.

## Verification

```
uv run pytest                        # 754 passed, 1 skipped
cd frontend && npx playwright test   # 38 passed
uv run ruff check && uv run ruff format --check && uv run mypy   # clean, 48 files
```

**A project directory now holds no JSON index at all** — `project.db`, `arrays/`, and `results/` for the estimator results, which are contents rather than references and stay files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwjcmQR7kksD9ttwZV7ior