### PR TITLE
Make two instances over one project directory a defined thing

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -95,14 +95,14 @@
         "project-through-the-database"
       ],
       "user_visible_behavior": "A second application instance on the same project directory reads without blocking and writes without corrupting; a write that cannot get the lock says which project it was waiting for.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "Two engines on one directory, both writing, both sets of rows present afterwards.",
         "A write held past busy_timeout produces the named error, not a bare 'database is locked'.",
         "tests/test_server.py - concurrent reads never fail, still passes."
       ],
-      "evidence": "",
-      "notes": "api.py:186-191 defers exactly this to 1.3, and docs/phase-1-2/feature_list.json:50 records it as undefined until a database can arbitrate. WAL plus busy_timeout is the answer. The in-process _CREATE_LOCK at api.py:168 stays: it guards a check-then-create inside one process, which is a different problem."
+      "evidence": "2026-08-29. `uv run pytest` - 758 passed, 1 skipped, including 4 new in tests/test_two_processes.py: two writers on one directory both land; a reader is not blocked by an open write (asserted while another connection holds BEGIN IMMEDIATE); a writer that cannot get its turn raises ProjectError naming the project directory and saying it is busy, with 'database is locked' absent from the message (busy_timeout monkeypatched to 100 ms so the test waits as briefly as the claim allows); and a genuinely separate process writes a dataset this one then reads. tests/test_server.py's concurrent reads test still passes. `cd frontend && npx playwright test` - 38 passed. ruff, format and mypy clean over 49 files.",
+      "notes": "api.py:186-191 defers exactly this to 1.3, and docs/phase-1-2/feature_list.json:50 records it as undefined until a database can arbitrate. WAL plus busy_timeout is the answer. The in-process _CREATE_LOCK at api.py:168 stays: it guards a check-then-create inside one process, which is a different problem. Implemented 2026-08-29. The pragmas were already set in #119; what was missing was the error path. _session only converted failures at open, so a commit that timed out escaped as a raw OperationalError - a stack trace at the HTTP layer, which section 6 forbids. It is a context manager now and converts on the way out too, telling the user which project is busy and for how long it waited rather than 'database is locked'. api.py's deferral comment was replaced by what the database actually does."
     },
     {
       "id": "phase-1-3-closes",

--- a/src/chemometrics_workbench/api.py
+++ b/src/chemometrics_workbench/api.py
@@ -188,8 +188,10 @@ def open_project_directory() -> Path:
     # apart - a winner halfway through and a directory that really is not a
     # project - look identical from outside, and only waiting distinguishes
     # them. This lock is about *this process*: it stops six requests on one
-    # page load racing each other. Two processes over one directory is the
-    # database's to arbitrate, which is #123.
+    # page load racing each other. Two *processes* over one directory is the
+    # database's to arbitrate and it does - WAL lets a reader read while a
+    # write is in flight, writers take turns, and one that cannot get its turn
+    # inside the busy timeout is told which project is busy (#123).
     with _CREATE_LOCK:
         if not is_project(directory):
             create_project(directory, name=directory.name, description="")

--- a/src/chemometrics_workbench/project.py
+++ b/src/chemometrics_workbench/project.py
@@ -37,6 +37,7 @@ import hashlib
 import io
 import json
 import os
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -45,7 +46,7 @@ import numpy as np
 from numpy.typing import NDArray
 from pydantic import Field, ValidationError
 from sqlalchemy import select
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from chemometrics_workbench import db
@@ -360,22 +361,46 @@ def _document(project: Project) -> str:
     return project.model_copy(update={"directory": ""}).model_dump_json()
 
 
-def _session(path: Path, *, create: bool = False) -> Session:
+@contextlib.contextmanager
+def _session(path: Path, *, create: bool = False) -> Iterator[Session]:
     """A session on this project's database, with database errors named.
 
-    Every failure below arrives at the HTTP layer as `ProjectError`, which §6
-    turns into a diagnostic rather than a stack trace. `db.DatabaseError` and
+    Every failure arrives at the HTTP layer as `ProjectError`, which §6 turns
+    into a diagnostic rather than a stack trace. `db.DatabaseError` and
     SQLAlchemy's own exceptions mean the same thing to a caller - this
-    directory cannot be read as a project - so they are one type here.
+    directory cannot be read or written as a project - so they are one type
+    here.
+
+    Opening is not the only place that fails. A second application instance
+    holding the write lock makes the *commit* fail, and `database is locked` on
+    its own names neither the project nor the reason, so it is caught on the
+    way out as well.
     """
     if not create and not db.database_path(path).exists():
         raise ProjectError(f"{path} is not a project directory: it has no {db.DATABASE_FILE}.")
     try:
-        return db.open_session(path, create=create)
+        session = db.open_session(path, create=create)
     except db.DatabaseError as error:
         raise ProjectError(str(error)) from error
     except SQLAlchemyError as error:
         raise ProjectError(f"cannot open the database at {db.database_path(path)}: {error}") from (
+            error
+        )
+
+    try:
+        with session:
+            yield session
+    except OperationalError as error:
+        if "locked" in str(error.orig).lower() or "busy" in str(error.orig).lower():
+            raise ProjectError(
+                f"the project at {path} is busy: another instance held the write lock for longer "
+                f"than {db.BUSY_TIMEOUT_MS} ms. Close the other window and try again."
+            ) from error
+        raise ProjectError(f"cannot use the database at {db.database_path(path)}: {error}") from (
+            error
+        )
+    except SQLAlchemyError as error:
+        raise ProjectError(f"cannot use the database at {db.database_path(path)}: {error}") from (
             error
         )
 

--- a/tests/test_two_processes.py
+++ b/tests/test_two_processes.py
@@ -1,0 +1,160 @@
+"""Two application instances over one project directory.
+
+Until the database there was no answer to this. `api.py` held one in-process
+lock and said so: "two processes over one directory is a database question, not
+this one". These are the answers.
+
+WAL is what makes them defined. A reader sees the last committed state while a
+writer is mid-transaction, writers take turns, and a writer that cannot get its
+turn inside `busy_timeout` fails with a sentence naming the project rather than
+`database is locked`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+import textwrap
+from collections.abc import Iterator
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from chemometrics_workbench import db
+from chemometrics_workbench.models import Dataset, DatasetVersion, VariableAxis
+from chemometrics_workbench.project import (
+    ProjectError,
+    add_dataset,
+    create_project,
+    open_project,
+    read_datasets,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("CHEMOMETRICS_CONFIG_HOME", str(tmp_path / "config"))
+    yield
+    db.dispose_all()
+
+
+def a_dataset(project_id: str, name: str) -> tuple[Dataset, DatasetVersion]:
+    dataset = Dataset(project_id=project_id, name=name)
+    version = DatasetVersion(
+        dataset_id=dataset.dataset_id,
+        version=1,
+        content_hash="sha256:" + f"{abs(hash(name)):064x}"[:64],
+        n_samples=2,
+        n_variables=2,
+        axis=VariableAxis(kind="index", values=[1.0, 2.0]),
+        array_path=f"arrays/{uuid4().hex}.npy",
+    )
+    return dataset, version
+
+
+def test_two_writers_on_one_directory_both_land(tmp_path: Path) -> None:
+    """Writers take turns rather than overwriting each other."""
+    project = create_project(tmp_path / "corn", name="Corn")
+    root = tmp_path / "corn"
+
+    for name in ("first", "second"):
+        # Disposing between writes makes each one a fresh connection, which is
+        # what a second instance of the application is.
+        dataset, version = a_dataset(str(project.project_id), name)
+        add_dataset(root, dataset, version)
+        db.dispose_all()
+
+    assert sorted(entry.dataset.name for entry in read_datasets(root)) == ["first", "second"]
+
+
+def test_a_reader_is_not_blocked_by_an_open_write(tmp_path: Path) -> None:
+    """The whole reason for WAL: a page load during a write still renders."""
+    project = create_project(tmp_path / "corn", name="Corn")
+    root = tmp_path / "corn"
+    dataset, version = a_dataset(str(project.project_id), "already here")
+    add_dataset(root, dataset, version)
+    db.dispose_all()
+
+    holder = sqlite3.connect(root / db.DATABASE_FILE, timeout=1)
+    try:
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("INSERT INTO cache_entry (key, document) VALUES ('held', '[]')")
+
+        # Uncommitted, so it is not visible - but the read itself succeeds,
+        # which is the claim.
+        assert [entry.dataset.name for entry in read_datasets(root)] == ["already here"]
+        assert open_project(root).project_id == project.project_id
+    finally:
+        holder.rollback()
+        holder.close()
+
+
+def test_a_writer_that_cannot_get_its_turn_says_which_project_is_busy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`database is locked` names neither the project nor the reason."""
+    project = create_project(tmp_path / "corn", name="Corn")
+    root = tmp_path / "corn"
+    db.dispose_all()
+    # A tenth of a second rather than five, so the test waits as briefly as the
+    # claim allows. The pragma is set per connection, hence the dispose above.
+    monkeypatch.setattr(db, "BUSY_TIMEOUT_MS", 100)
+
+    holder = sqlite3.connect(root / db.DATABASE_FILE, timeout=1)
+    try:
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("INSERT INTO cache_entry (key, document) VALUES ('held', '[]')")
+
+        dataset, version = a_dataset(str(project.project_id), "blocked")
+        with pytest.raises(ProjectError) as refusal:
+            add_dataset(root, dataset, version)
+    finally:
+        holder.rollback()
+        holder.close()
+
+    assert "is busy" in str(refusal.value)
+    assert str(root) in str(refusal.value)
+    assert "database is locked" not in str(refusal.value)
+
+
+def test_a_second_process_writes_and_this_one_sees_it(tmp_path: Path) -> None:
+    """Not two connections in one process: two processes, which is the case
+    `api.py` said it could not answer."""
+    project = create_project(tmp_path / "corn", name="Corn")
+    root = tmp_path / "corn"
+    db.dispose_all()
+
+    written = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                f"""
+                from uuid import uuid4
+                from chemometrics_workbench.models import Dataset, DatasetVersion, VariableAxis
+                from chemometrics_workbench.project import add_dataset
+
+                dataset = Dataset(project_id="{project.project_id}", name="from another process")
+                version = DatasetVersion(
+                    dataset_id=dataset.dataset_id,
+                    version=1,
+                    content_hash="sha256:" + "7" * 64,
+                    n_samples=2,
+                    n_variables=2,
+                    axis=VariableAxis(kind="index", values=[1.0, 2.0]),
+                    array_path="arrays/" + uuid4().hex + ".npy",
+                )
+                add_dataset(r"{root}", dataset, version)
+                print("written")
+                """
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert "written" in written.stdout
+    assert [entry.dataset.name for entry in read_datasets(root)] == ["from another process"]


### PR DESCRIPTION
Closes #123. `api.py` has carried a comment since #77 saying that one server owns one project directory and that *"two processes over one directory is a database question, not this one, and it arrives with SQLite in Phase 1.3."* It has arrived.

## What the answer is

- **A reader is never blocked.** WAL lets a page load render off the last committed state while a write is in flight.
- **Writers take turns**, and both land.
- **A writer that cannot get its turn** inside `busy_timeout` is told *which project* is busy and how long it waited.

## What was actually missing

The pragmas were already set in #119. The gap was the error path: `_session` converted failures **at open only**, so a commit that timed out escaped as a raw `OperationalError` — a stack trace at the HTTP layer, which §6 forbids. It is a context manager now and converts on the way out as well.

`database is locked` names neither the project nor the reason. The message now does both:

> the project at /home/…/corn is busy: another instance held the write lock for longer than 5000 ms. Close the other window and try again.

`api.py`'s deferral comment is replaced by what the database does. The in-process `_CREATE_LOCK` stays — it stops six requests on one page load racing each other, which is a different problem.

## Verification

```
uv run pytest                        # 758 passed, 1 skipped (4 new)
cd frontend && npx playwright test   # 38 passed
uv run ruff check && uv run ruff format --check && uv run mypy   # clean, 49 files
```

The four: two writers on one directory both land; a reader succeeds while another connection holds `BEGIN IMMEDIATE`; a blocked writer raises `ProjectError` naming the directory with `database is locked` **absent** from the message (`busy_timeout` monkeypatched to 100 ms so the test waits as briefly as the claim allows); and a **genuinely separate process** — not two connections in one — writes a dataset this one then reads.

`tests/test_server.py`'s concurrent-reads test, the regression test for the old registry-rewrite race, still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwjcmQR7kksD9ttwZV7ior