### PR TITLE
Say each model-to-row mapping once

### DIFF
--- a/src/chemometrics_workbench/project.py
+++ b/src/chemometrics_workbench/project.py
@@ -147,14 +147,7 @@ def create_project(directory: str | os.PathLike[str], name: str, description: st
 
     project = Project(name=name, description=description, directory=str(path.resolve()))
     with _session(path, create=True) as session:
-        session.add(
-            db.ProjectRow(
-                project_id=str(project.project_id),
-                name=project.name,
-                created_at=project.created_at.isoformat(),
-                document=_document(project),
-            )
-        )
+        session.add(_project_row(project))
         session.commit()
     _remember(path, project)
     return project
@@ -250,47 +243,13 @@ def _import_json_project(path: Path) -> None:
     # One transaction: a directory either has a database holding everything the
     # files held, or it still has only the files and is read again next time.
     with _session(path, create=True) as session:
-        session.add(
-            db.ProjectRow(
-                project_id=str(project.project_id),
-                name=project.name,
-                created_at=project.created_at.isoformat(),
-                document=_document(project),
-            )
-        )
+        session.add(_project_row(project))
         for entry in entries:
-            session.add(
-                db.DatasetRow(
-                    dataset_id=str(entry.dataset.dataset_id),
-                    name=entry.dataset.name,
-                    created_at=entry.dataset.created_at.isoformat(),
-                    document=entry.dataset.model_dump_json(),
-                )
-            )
+            session.add(_dataset_row(entry.dataset))
             for version in entry.versions:
-                session.add(
-                    db.DatasetVersionRow(
-                        version_id=str(version.version_id),
-                        dataset_id=str(version.dataset_id),
-                        version=version.version,
-                        content_hash=version.content_hash,
-                        n_samples=version.n_samples,
-                        n_variables=version.n_variables,
-                        array_path=version.array_path,
-                        created_at=version.created_at.isoformat(),
-                        document=version.model_dump_json(),
-                    )
-                )
+                session.add(_version_row(version))
         if pipeline is not None:
-            session.add(
-                db.PipelineRow(
-                    pipeline_id=str(pipeline.pipeline_id),
-                    name=pipeline.name,
-                    content_hash=pipeline.content_hash(),
-                    created_at=pipeline.created_at.isoformat(),
-                    document=pipeline.model_dump_json(),
-                )
-            )
+            session.add(_pipeline_row(pipeline))
             # Flushed before the layout that points at it: without a declared
             # relationship between the two mappers, the unit of work is free to
             # attempt the child insert first, and the foreign key refuses it.
@@ -298,12 +257,7 @@ def _import_json_project(path: Path) -> None:
             # Layout is keyed on the pipeline, so a layout without one has
             # nothing to hang from and is dropped rather than invented.
             if isinstance(layout_record, dict):
-                session.add(
-                    db.PipelineLayoutRow(
-                        pipeline_id=str(pipeline.pipeline_id),
-                        document=json.dumps(layout_record),
-                    )
-                )
+                session.add(_layout_row(pipeline.pipeline_id, layout_record))
         # The executor's index comes too. Without it every node in a migrated
         # project would recompute on the next run - correct, because the arrays
         # are content-addressed and would be rewritten identically, but a
@@ -311,26 +265,9 @@ def _import_json_project(path: Path) -> None:
         if isinstance(cache_record, dict):
             for key, stored in cache_record.items():
                 if isinstance(key, str) and isinstance(stored, list):
-                    session.add(
-                        db.CacheEntryRow(
-                            key=key, document=json.dumps([str(entry) for entry in stored])
-                        )
-                    )
+                    session.add(_cache_row(key, [str(entry) for entry in stored]))
         if experiment is not None:
-            session.add(
-                db.ExperimentRow(
-                    experiment_id=str(experiment.experiment_id),
-                    dataset_version_id=str(experiment.dataset_version_id),
-                    status=experiment.status.value,
-                    started_at=(
-                        experiment.started_at.isoformat() if experiment.started_at else None
-                    ),
-                    finished_at=(
-                        experiment.finished_at.isoformat() if experiment.finished_at else None
-                    ),
-                    document=experiment.model_dump_json(),
-                )
-            )
+            session.add(_experiment_row(experiment))
         session.commit()
 
 
@@ -347,6 +284,74 @@ def _json_document(path: Path) -> Any:
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError) as error:
         raise ProjectError(f"{path} could not be read: {error}") from error
+
+
+def _project_row(project: Project) -> db.ProjectRow:
+    """One place per row where a model becomes columns.
+
+    Each of these is used twice: once on the normal path, and once by
+    `_import_json_project` reading a directory written before the database.
+    Written out twice, a column added to `db.py` would reach the path with a
+    user and not the path with one test, and the two would disagree quietly.
+    """
+    return db.ProjectRow(
+        project_id=str(project.project_id),
+        name=project.name,
+        created_at=project.created_at.isoformat(),
+        document=_document(project),
+    )
+
+
+def _dataset_row(dataset: Dataset) -> db.DatasetRow:
+    return db.DatasetRow(
+        dataset_id=str(dataset.dataset_id),
+        name=dataset.name,
+        created_at=dataset.created_at.isoformat(),
+        document=dataset.model_dump_json(),
+    )
+
+
+def _version_row(version: DatasetVersion) -> db.DatasetVersionRow:
+    return db.DatasetVersionRow(
+        version_id=str(version.version_id),
+        dataset_id=str(version.dataset_id),
+        version=version.version,
+        content_hash=version.content_hash,
+        n_samples=version.n_samples,
+        n_variables=version.n_variables,
+        array_path=version.array_path,
+        created_at=version.created_at.isoformat(),
+        document=version.model_dump_json(),
+    )
+
+
+def _pipeline_row(pipeline: Pipeline) -> db.PipelineRow:
+    return db.PipelineRow(
+        pipeline_id=str(pipeline.pipeline_id),
+        name=pipeline.name,
+        content_hash=pipeline.content_hash(),
+        created_at=pipeline.created_at.isoformat(),
+        document=pipeline.model_dump_json(),
+    )
+
+
+def _layout_row(pipeline_id: object, layout: object) -> db.PipelineLayoutRow:
+    return db.PipelineLayoutRow(pipeline_id=str(pipeline_id), document=json.dumps(layout))
+
+
+def _experiment_row(experiment: Experiment) -> db.ExperimentRow:
+    return db.ExperimentRow(
+        experiment_id=str(experiment.experiment_id),
+        dataset_version_id=str(experiment.dataset_version_id),
+        status=experiment.status.value,
+        started_at=experiment.started_at.isoformat() if experiment.started_at else None,
+        finished_at=experiment.finished_at.isoformat() if experiment.finished_at else None,
+        document=experiment.model_dump_json(),
+    )
+
+
+def _cache_row(key: str, stored: list[str]) -> db.CacheEntryRow:
+    return db.CacheEntryRow(key=key, document=json.dumps(stored))
 
 
 def _document(project: Project) -> str:
@@ -503,27 +508,8 @@ def add_dataset(
     with _session(path) as session:
         existing = session.get(db.DatasetRow, str(dataset.dataset_id))
         if existing is None:
-            session.add(
-                db.DatasetRow(
-                    dataset_id=str(dataset.dataset_id),
-                    name=dataset.name,
-                    created_at=dataset.created_at.isoformat(),
-                    document=dataset.model_dump_json(),
-                )
-            )
-        session.add(
-            db.DatasetVersionRow(
-                version_id=str(version.version_id),
-                dataset_id=str(version.dataset_id),
-                version=version.version,
-                content_hash=version.content_hash,
-                n_samples=version.n_samples,
-                n_variables=version.n_variables,
-                array_path=version.array_path,
-                created_at=version.created_at.isoformat(),
-                document=version.model_dump_json(),
-            )
-        )
+            session.add(_dataset_row(dataset))
+        session.add(_version_row(version))
         session.commit()
 
     for entry in read_datasets(path):
@@ -568,15 +554,7 @@ def read_pipeline(directory: str | os.PathLike[str]) -> Pipeline | None:
 def write_pipeline(directory: str | os.PathLike[str], pipeline: Pipeline) -> None:
     path = Path(directory)
     with _session(path) as session:
-        session.merge(
-            db.PipelineRow(
-                pipeline_id=str(pipeline.pipeline_id),
-                name=pipeline.name,
-                content_hash=pipeline.content_hash(),
-                created_at=pipeline.created_at.isoformat(),
-                document=pipeline.model_dump_json(),
-            )
-        )
+        session.merge(_pipeline_row(pipeline))
         session.commit()
 
 
@@ -615,12 +593,7 @@ def write_layout(directory: str | os.PathLike[str], layout: dict[NodeId, dict[st
     if pipeline is None:
         raise ProjectError(f"{path} has no pipeline for a layout to belong to.")
     with _session(path) as session:
-        session.merge(
-            db.PipelineLayoutRow(
-                pipeline_id=str(pipeline.pipeline_id),
-                document=json.dumps(layout),
-            )
-        )
+        session.merge(_layout_row(pipeline.pipeline_id, layout))
         session.commit()
 
 
@@ -656,7 +629,7 @@ def write_cache_index(directory: str | os.PathLike[str], index: dict[str, list[s
     path = Path(directory)
     with _session(path) as session:
         for key, stored in index.items():
-            session.merge(db.CacheEntryRow(key=key, document=json.dumps(stored)))
+            session.merge(_cache_row(key, stored))
         session.commit()
 
 
@@ -687,18 +660,7 @@ def read_experiment(directory: str | os.PathLike[str]) -> Experiment | None:
 def write_experiment(directory: str | os.PathLike[str], experiment: Experiment) -> None:
     path = Path(directory)
     with _session(path) as session:
-        session.merge(
-            db.ExperimentRow(
-                experiment_id=str(experiment.experiment_id),
-                dataset_version_id=str(experiment.dataset_version_id),
-                status=experiment.status.value,
-                started_at=(experiment.started_at.isoformat() if experiment.started_at else None),
-                finished_at=(
-                    experiment.finished_at.isoformat() if experiment.finished_at else None
-                ),
-                document=experiment.model_dump_json(),
-            )
-        )
+        session.merge(_experiment_row(experiment))
         session.commit()
 
 

--- a/src/chemometrics_workbench/server.py
+++ b/src/chemometrics_workbench/server.py
@@ -51,6 +51,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 
 from chemometrics_workbench.api import JOBS, router
+from chemometrics_workbench.db import dispose_all
 
 __all__ = ["BUNDLE", "TOKEN", "app", "main"]
 
@@ -77,9 +78,16 @@ def require_token(authorization: Annotated[str | None, Header()] = None) -> None
 
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
-    """Ask every unfinished run to stop before the process goes."""
+    """Ask every unfinished run to stop before the process goes, and let go of
+    the database.
+
+    Disposing matters least on the way out of a process and most on Windows,
+    where an undisposed handle is what keeps a file locked after the program
+    that held it has gone.
+    """
     yield
     JOBS.shutdown(wait=False)
+    dispose_all()
 
 
 app = FastAPI(title="Chemometrics Workbench", lifespan=lifespan)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,6 @@ from chemometrics_workbench.datasets import load_tecator
 from chemometrics_workbench.executor import Run, execute
 from chemometrics_workbench.models import AxisKind, DatasetVersion, VariableAxis
 from chemometrics_workbench.project import (
-    DATASETS_FILE,
     create_project,
     open_project,
     read_array,
@@ -146,8 +145,8 @@ def test_preview_returns_the_readers_detection_in_the_published_shape(
     assert body["detected"]["delimiter"]["value"] == ","
     assert "alternatives" in body["detected"]["delimiter"]
 
-    # Nothing was committed, and nothing was left behind.
-    assert not (project / DATASETS_FILE).exists()
+    # Nothing was committed. Asserted against the dataset list rather than
+    # against a file that is no longer written either way.
     assert client.get(f"/api/projects/{project_id(client)}/datasets").json() == []
 
 


### PR DESCRIPTION
Closes #131. Cleanup at the Phase 1.3 checkpoint. **No behaviour changes** — 124 lines out, 93 in.

## The one that mattered

The swap left every row type built in two places: once on the normal path (`create_project`, `add_dataset`, `write_pipeline`, `write_layout`, `write_experiment`, `write_cache_index`) and once in `_import_json_project`, which reads a directory written before the database.

Six mappings from a Pydantic model to its columns, each stated twice. **Adding a column means remembering both**, and the copy that gets forgotten is the import path — one test, and no user until someone opens an old project. That is a failure that would be found long after it was introduced.

One builder per row now, used by both paths. `project.py` is 38 lines shorter and the seven remaining `db.*Row(` constructions are exactly the seven builders.

## Two smaller things found at the same time

- **A test that could not fail.** `tests/test_api.py` asserted `datasets.json` does not exist after a preview. That file is never written now, so the assertion held whatever the code did. The line after it makes the real claim — the dataset list is empty — so the dead one is gone rather than rewritten into a second way of saying the same thing.
- **Engines were never disposed when the server stopped.** The lifespan stopped the jobs and left every SQLite engine holding its file. It costs nothing on the way out of a process and is exactly what keeps a file locked on Windows; `db.dispose_all()` already existed for it.

## What was deliberately not touched

An audit for exported-but-unused names flagged `executor.NodeOutput`, `checks.PipelineWarning`, `project.PROJECT_FILE` and nine others. Each is used inside its own module or is the type a caller receives, so deleting them would be churn dressed as cleanup. The frontend's exports were checked the same way and are all live.

## Verification

```
uv run pytest                        # 758 passed, 1 skipped — unchanged
cd frontend && npx playwright test   # 38 passed
uv run ruff check && uv run ruff format --check && uv run mypy   # clean, 49 files
```

The import path's eight tests are the net under the riskiest half of this: they assert that a `v0.3.0` directory still reads back identically, which is what would break if a builder and its caller disagreed.

## Note on ordering

Branched from `dev` at `86b9fa4`, so it does not include #130 (the phase close, still open). No overlap — #130 touches documents and list files, this touches `project.py`, `server.py` and one test. The `feature_list.json` entry for this fix lands after #130 settles which list is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MwjcmQR7kksD9ttwZV7ior