### PR TITLE
Give the clean-state checklist's third check a command

### DIFF
--- a/clean-state-checklist.md
+++ b/clean-state-checklist.md
@@ -26,7 +26,13 @@ Run the project's full verification suite as documented — lint, formatting, ty
 
 The failure this catches: a feature marked `passing` because the code looked right, with no evidence behind it.
 
-**Pass when** it prints `feature_list.json consistent`, **and** you have read the `evidence` of every feature changed this session and confirmed it records a real command with its real output and a date — not a description of what would happen.
+```bash
+uv run python -m tests.check_feature_list
+```
+
+It checks the mechanical half — statuses, unique ids, dependencies that exist and are finished, `passing` with evidence, `blocked` with a reason, at most one `in_progress` — and prints the problems it finds, one per line.
+
+**Pass when** it prints `feature_list.json consistent`, **and** you have read the `evidence` of every feature changed this session and confirmed it records a real command with its real output and a date — not a description of what would happen. **The command cannot do that second half**, which is the half that catches the failure above: only a person reading the string can tell a recorded run from a description of one.
 
 ## 4. No half-finished work left unrecorded
 

--- a/feature_list.json
+++ b/feature_list.json
@@ -9,6 +9,24 @@
   ],
   "features": [
     {
+      "id": "feature-list-checker",
+      "priority": 0,
+      "area": "process",
+      "issue": 138,
+      "title": "The clean-state checklist's third check has a command behind it",
+      "depends_on": [],
+      "user_visible_behavior": "`uv run python -m tests.check_feature_list` prints `feature_list.json consistent`, or one line per problem and a non-zero exit.",
+      "status": "passing",
+      "verification": [
+        "uv run python -m tests.check_feature_list - prints the sentence and exits 0.",
+        "The same, on each of the four archived lists under docs/phase-*/.",
+        "uv run pytest tests/test_check_feature_list.py - every rule shown failing.",
+        "uv run ruff check && uv run ruff format --check && uv run mypy && uv run pytest"
+      ],
+      "evidence": "2026-09-05. `uv run python -m tests.check_feature_list` printed 'feature_list.json consistent', exit 0, and did the same on all four of docs/phase-0, phase-1-1, phase-1-2, phase-1-3. Run against a deliberately broken copy of the live list it printed three problems and exited 1: \"'row-mapping-said-once' is passing with empty evidence\", \"'canvas-compare-and-duplicate' depends on 'ghost', which is not in this list\", \"2 features are in_progress (pending-estimator-is-announced, range-select-axis-follows-data). At most one may be.\" `uv run pytest` - 775 passed, 1 skipped (758 before, +17 in tests/test_check_feature_list.py). `uv run ruff check`, `uv run ruff format --check` (75 files) and `uv run mypy` (51 source files) all exit 0.",
+      "notes": "clean-state-checklist.md:29 asked check 3 to pass 'when it prints feature_list.json consistent' and nothing in the repository printed it - no script, no test, no scripts/ or tools/ directory. The one check whose purpose is catching a passing with nothing behind it passed by being read, which is #131's second item one level up. The module checks only the mechanical half and the checklist now says so explicitly: whether an evidence string records a real run or a description of one is a person reading it, and a command claiming otherwise would be the same failure again. tests/parity_report.py is the precedent for a runnable module under tests/ that is not a test. Deliberately not wired into CI - that is a separate decision and one line if it is wanted."
+    },
+    {
       "id": "range-select-axis-follows-data",
       "priority": 0,
       "area": "backend",

--- a/tests/check_feature_list.py
+++ b/tests/check_feature_list.py
@@ -1,0 +1,98 @@
+"""Check a feature list against the rules the working protocol states.
+
+    uv run python -m tests.check_feature_list
+    uv run python -m tests.check_feature_list docs/phase-1-3/feature_list.json
+
+`clean-state-checklist.md` check 3 exists to catch a feature marked `passing`
+because the code looked right, with no evidence behind it. It said to pass when
+something printed `feature_list.json consistent`, and nothing printed that —
+the check passed by being read. This is the command it was describing.
+
+**It checks what is mechanical and says so.** Whether an `evidence` string
+records a real command with its real output is a human reading it; this module
+only asserts that the string is not empty. Check 3 keeps both halves and this
+module is the first one. Claiming the second would be the failure the check was
+written to catch, one level up.
+
+Every rule below is in `CLAUDE.md`'s working protocol. Nothing here is a new
+convention.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT = ROOT / "feature_list.json"
+
+
+def problems(document: dict[str, Any]) -> list[str]:
+    """Every rule the document breaks, as sentences naming the feature."""
+    found: list[str] = []
+    features = document["features"]
+    allowed = set(document["status_values"])
+
+    ids: dict[str, int] = {}
+    for feature in features:
+        ids[feature["id"]] = ids.get(feature["id"], 0) + 1
+    found.extend(
+        f"{name!r} appears {count} times; ids are the handle, so they must be unique."
+        for name, count in sorted(ids.items())
+        if count > 1
+    )
+
+    status = {feature["id"]: feature["status"] for feature in features}
+
+    for feature in features:
+        name = feature["id"]
+        if feature["status"] not in allowed:
+            found.append(
+                f"{name!r} has status {feature['status']!r}, which is not one of {sorted(allowed)}."
+            )
+        if feature["status"] == "passing" and not feature["evidence"].strip():
+            found.append(
+                f"{name!r} is passing with empty evidence. A feature becomes passing only "
+                "after its verification steps have actually been run."
+            )
+        if feature["status"] == "blocked" and not feature["notes"].strip():
+            found.append(
+                f"{name!r} is blocked with empty notes. Record what is blocking it and what "
+                "would unblock it."
+            )
+        for dependency in feature["depends_on"]:
+            if dependency not in status:
+                found.append(f"{name!r} depends on {dependency!r}, which is not in this list.")
+            elif feature["status"] == "passing" and status[dependency] != "passing":
+                found.append(
+                    f"{name!r} is passing but depends on {dependency!r}, which is "
+                    f"{status[dependency]}."
+                )
+
+    in_progress = [f["id"] for f in features if f["status"] == "in_progress"]
+    if len(in_progress) > 1:
+        found.append(
+            f"{len(in_progress)} features are in_progress ({', '.join(sorted(in_progress))}). "
+            "At most one may be."
+        )
+    return found
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = sys.argv[1:] if argv is None else argv
+    path = Path(arguments[0]) if arguments else DEFAULT
+    document = json.loads(path.read_text(encoding="utf-8"))
+
+    found = problems(document)
+    if found:
+        for problem in found:
+            print(problem)
+        return 1
+    print(f"{path.name} consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_feature_list.py
+++ b/tests/test_check_feature_list.py
@@ -1,0 +1,128 @@
+"""The checker is shown catching each rule, not just passing on the real file.
+
+A checker that cannot fail is worse than no checker: it makes the checklist
+step look done. That is #131's second item — a test asserting a file that could
+no longer exist either way — one level up, and the reason this file exists.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.check_feature_list import DEFAULT, ROOT, main, problems
+
+LISTS = [DEFAULT, *sorted(ROOT.glob("docs/phase-*/feature_list.json"))]
+
+
+def feature(**overrides: Any) -> dict[str, Any]:
+    base = {
+        "id": "a",
+        "priority": 0,
+        "area": "backend",
+        "issue": 1,
+        "title": "A thing happens",
+        "depends_on": [],
+        "user_visible_behavior": "The thing happens.",
+        "status": "passing",
+        "verification": ["uv run pytest"],
+        "evidence": "2026-09-05. uv run pytest - 758 passed.",
+        "notes": "",
+    }
+    return base | overrides
+
+
+def document(*features: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "phase": "Phase N",
+        "exit_criterion": "Something demonstrable.",
+        "status_values": ["not_started", "in_progress", "blocked", "passing"],
+        "features": list(features),
+    }
+
+
+def test_a_list_breaking_nothing_is_consistent() -> None:
+    assert problems(document(feature())) == []
+
+
+def test_passing_with_no_evidence_is_caught() -> None:
+    (found,) = problems(document(feature(evidence="   ")))
+    assert "passing with empty evidence" in found
+
+
+def test_blocked_with_no_notes_is_caught() -> None:
+    (found,) = problems(document(feature(status="blocked", evidence="", notes="")))
+    assert "blocked with empty notes" in found
+
+
+def test_an_unknown_status_is_caught() -> None:
+    (found,) = problems(document(feature(status="nearly", evidence="")))
+    assert "not one of" in found
+
+
+def test_a_duplicate_id_is_caught() -> None:
+    found = problems(document(feature(), feature()))
+    assert any("appears 2 times" in problem for problem in found)
+
+
+def test_a_dependency_on_nothing_is_caught() -> None:
+    (found,) = problems(document(feature(depends_on=["ghost"])))
+    assert "'ghost', which is not in this list" in found
+
+
+def test_passing_on_an_unfinished_dependency_is_caught() -> None:
+    found = problems(
+        document(
+            feature(id="a", status="not_started", evidence=""),
+            feature(id="b", depends_on=["a"]),
+        )
+    )
+    assert found == ["'b' is passing but depends on 'a', which is not_started."]
+
+
+def test_an_unfinished_feature_may_depend_on_an_unfinished_one() -> None:
+    assert (
+        problems(
+            document(
+                feature(id="a", status="not_started", evidence=""),
+                feature(id="b", status="not_started", evidence="", depends_on=["a"]),
+            )
+        )
+        == []
+    )
+
+
+def test_two_features_in_progress_are_caught() -> None:
+    found = problems(
+        document(
+            feature(id="a", status="in_progress", evidence=""),
+            feature(id="b", status="in_progress", evidence=""),
+        )
+    )
+    assert any("At most one may be." in problem for problem in found)
+
+
+def test_one_feature_in_progress_is_fine() -> None:
+    assert problems(document(feature(status="in_progress", evidence=""))) == []
+
+
+@pytest.mark.parametrize("path", LISTS, ids=lambda p: p.parent.name)
+def test_every_list_in_the_repository_is_consistent(path: Path) -> None:
+    assert problems(json.loads(path.read_text(encoding="utf-8"))) == []
+
+
+def test_main_prints_the_sentence_the_checklist_names(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main([str(DEFAULT)]) == 0
+    assert capsys.readouterr().out == "feature_list.json consistent\n"
+
+
+def test_main_exits_non_zero_and_says_why(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    broken = tmp_path / "feature_list.json"
+    broken.write_text(json.dumps(document(feature(evidence=""))), encoding="utf-8")
+    assert main([str(broken)]) == 1
+    assert "empty evidence" in capsys.readouterr().out


### PR DESCRIPTION
`clean-state-checklist.md:29` asked check 3 to pass "when it prints `feature_list.json consistent`". Nothing in the repository printed that — no script, no pytest test, no `scripts/`, `tools/` or `bin/` directory for one to live in. The one check whose stated purpose is catching a `passing` with nothing behind it passed by being read, which is #131's second item one level up.

## What is here

`tests/check_feature_list.py`, run as:

```bash
uv run python -m tests.check_feature_list                          # the live list
uv run python -m tests.check_feature_list docs/phase-1-3/feature_list.json
```

`tests/parity_report.py` is the precedent for a runnable module under `tests/` that is not a test.

Every rule it applies is already in `CLAUDE.md`'s working protocol, none is new: known statuses, unique ids, dependencies that exist, a dependency finished before its dependent is `passing`, `passing` with non-empty `evidence`, `blocked` with a reason, at most one `in_progress`.

## It checks the mechanical half, and says so

The checklist text now states the limit in the same breath as the command. Whether an `evidence` string records a real command with its real output, or a description of what would happen, is a person reading it. A command that claimed to settle that would be the same failure the check exists to catch, one level further up.

## The test asserts it can fail

`tests/test_check_feature_list.py` feeds it a list breaking each rule and asserts it says so, rather than only running it against the current file. A checker that always passes makes the checklist step look done, which is the whole complaint.

Two cases are there to pin the boundaries rather than the failures: an unfinished feature may depend on an unfinished one, and one `in_progress` is fine.

## Verification

```
$ uv run python -m tests.check_feature_list
feature_list.json consistent                       # exit 0
```

Exit 0 on all four archived lists under `docs/phase-*/` as well. Against a deliberately broken copy of the live list:

```
'row-mapping-said-once' is passing with empty evidence. A feature becomes passing only after its verification steps have actually been run.
'canvas-compare-and-duplicate' depends on 'ghost', which is not in this list.
2 features are in_progress (pending-estimator-is-announced, range-select-axis-follows-data). At most one may be.
                                                   # exit 1
```

`uv run pytest` — **775 passed, 1 skipped** (758 before; +17 in the new file). `ruff check`, `ruff format --check` (75 files) and `mypy` (51 source files) all exit 0.

## Not in scope

CI. This is a session-end tool and wiring it into the workflow is a separate decision — one line if it is wanted. No list's contents change.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)