### PR TITLE
Stop citing a closed issue as the reason PLS is not fitted

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -1,6 +1,6 @@
 {
   "phase": "Phase 2 - comparison and direct manipulation",
-  "exit_criterion": "PROPOSAL.md section 16: \"A complete calibration workflow on a real NIR dataset matches reference software within stated tolerance.\" Concretely, and demonstrated rather than reasoned: a real NIR dataset is imported, preprocessed, split, fitted with PLS, cross-validated and read back - the metrics, the predicted-versus-actual plot and the residuals - without leaving the application, and the numbers agree with the parity programme's reference within the tolerances docs/parity-report.md publishes. The phase ends when that run is recorded with its evidence, not when every entry below is passing. Section 16 also names PLS regression and PLS-DA, the full validation suite, Hotelling T2, SPE, VIP and contribution plots, predicted-versus-actual and residual plots, a train/test splitting UI, and the Bruker OPUS reader. Of those only PLS has a kernel (#88 is the executor half); the rest have no entry on this list yet, and the list is not complete until they do.",
+  "exit_criterion": "PROPOSAL.md section 16: \"A complete calibration workflow on a real NIR dataset matches reference software within stated tolerance.\" Concretely, and demonstrated rather than reasoned: a real NIR dataset is imported, preprocessed, split, fitted with PLS, cross-validated and read back - the metrics, the predicted-versus-actual plot and the residuals - without leaving the application, and the numbers agree with the parity programme's reference within the tolerances docs/parity-report.md publishes. The phase ends when that run is recorded with its evidence, not when every entry below is passing. Section 16 also names PLS regression and PLS-DA, the full validation suite, Hotelling T2, SPE, VIP and contribution plots, predicted-versus-actual and residual plots, a train/test splitting UI, and the Bruker OPUS reader. Of those PLS has a kernel and is parity-covered, but the executor does not fit it - that is #142, the critical path to this criterion and untracked until 2026-09-05. The rest have no entry on this list yet, and the list is not complete until they do.",
   "status_values": [
     "not_started",
     "in_progress",
@@ -91,7 +91,7 @@
         "uv run pytest"
       ],
       "evidence": "2026-09-05. Against the live mango pipeline, which holds a PLS node on a mean-centred branch: POST /api/pipelines/current/validate returned valid: false with one warning - code 'estimator_not_fitted', node_id 'pls_dm', severity 'info', and the sentence \"'pls' at 'pls_dm' has no kernel in this build and will not be fitted. The run will report success and this node will stay unrun; every other node is unaffected.\" It returned valid: true, problems: [], warnings: [] before. Node states are unchanged: 11 of 12 complete, pls_dm not_run. uv run pytest - 793 passed, 1 skipped (787 before, +6 in tests/test_not_fitted_warning.py). uv run ruff check, ruff format --check (77 files) and mypy (53 source files) exit 0. Frontend npx tsc -b --noEmit and npx vitest run - 10 files, 77 tests passed, unchanged.",
-      "notes": "Not #88, which is the kernel. This is the silence around it, found end to end: validate returned valid: true with no warnings, the job reported succeeded and 'Done', and the PLS node was left 'not_run' - the same state a node has before it has ever been run, so a screen cannot tell 'not yet' from 'never will be'. Run.pending_estimators (executor.py:279, populated at :432) already names the declined nodes and the string 'pending_estimators' appears nowhere in api.py. The warnings list is already in the validate payload and already rendered. This should become redundant when #88 lands. Built in api.py's validation_payload rather than in checks.py, deliberately: that module's docstring states its contract - every warning there catches a mistake whose symptom is a plausible result, with a document behind it - and this is neither. Nothing is wrong with the recipe; the build is short a kernel. Filing it under 'what is wrong with your pipeline' would blame the user for #88. Two sources, one list, told apart by code and severity ('info' rather than 'warning'). executor.has_kernel(spec) is now the one place that knows what can be fitted, asked by the executor's routing and by the warning, so #88 adds to one tuple rather than editing two files. The state half of the issue - pipelines/{id}/state telling 'not yet' from 'never will be' - was left: frontend NodeState is a closed union in canvas/graph.ts:12, so it needs a type change, a NodeCard switch case and a visual treatment with no artboard behind it, and #88 makes it moot. PipelineCanvas.tsx:190 already renders problems.join(' . ') when valid is false, so the sentence reaches the canvas with no frontend change and nothing blocks the run."
+      "notes": "Not the kernel, which exists and is parity-covered; #142 is the executor half. This is the silence around it, found end to end: validate returned valid: true with no warnings, the job reported succeeded and 'Done', and the PLS node was left 'not_run' - the same state a node has before it has ever been run, so a screen cannot tell 'not yet' from 'never will be'. Run.pending_estimators (executor.py:279, populated at :432) already names the declined nodes and the string 'pending_estimators' appears nowhere in api.py. The warnings list is already in the validate payload and already rendered. This should become redundant when #142 lands. Built in api.py's validation_payload rather than in checks.py, deliberately: that module's docstring states its contract - every warning there catches a mistake whose symptom is a plausible result, with a document behind it - and this is neither. Nothing is wrong with the recipe; the build is short a kernel. Filing it under 'what is wrong with your pipeline' would blame the user for #142. Two sources, one list, told apart by code and severity ('info' rather than 'warning'). executor.has_kernel(spec) is now the one place that knows what can be fitted, asked by the executor's routing and by the warning, so #142 adds to one tuple rather than editing two files. The state half of the issue - pipelines/{id}/state telling 'not yet' from 'never will be' - was left: frontend NodeState is a closed union in canvas/graph.ts:12, so it needs a type change, a NodeCard switch case and a visual treatment with no artboard behind it, and #142 makes it moot. PipelineCanvas.tsx:190 already renders problems.join(' . ') when valid is false, so the sentence reaches the canvas with no frontend change and nothing blocks the run."
     },
     {
       "id": "canvas-compare-and-duplicate",
@@ -100,7 +100,8 @@
       "issue": 51,
       "title": "Duplicate a subgraph, and compare two terminal nodes in one tab",
       "depends_on": [
-        "canvas-direct-editing"
+        "canvas-direct-editing",
+        "pls-in-the-executor"
       ],
       "user_visible_behavior": "A subgraph can be duplicated so a variant is built from an existing path rather than from scratch, and selecting two terminal nodes opens a tab comparing their results.",
       "status": "not_started",
@@ -109,7 +110,27 @@
         "Two terminal nodes open one comparison tab showing both models' metrics."
       ],
       "evidence": "",
-      "notes": "Items 2 and 3 of #51, deliberately left for a second pass. The comparison tab is a screen with no artboard behind it and no metrics to compare until PLS has a kernel in the executor (#88's subject), which is what makes 'compare two models' worth looking at. DESIGN_BRIEF.md section 5 is the reference."
+      "notes": "Items 2 and 3 of #51, deliberately left for a second pass. The comparison tab is a screen with no artboard behind it and no metrics to compare until the executor fits PLS (#142), which is what makes 'compare two models' worth looking at. DESIGN_BRIEF.md section 5 is the reference."
+    },
+    {
+      "id": "pls-in-the-executor",
+      "priority": 2,
+      "area": "backend",
+      "issue": 142,
+      "title": "The executor fits PLS, and a PLS result has a defined shape",
+      "depends_on": [],
+      "user_visible_behavior": "A PLS node in a pipeline is fitted like a PCA node is, and its result is readable: the RMSECV curve, the metrics, predicted versus actual, and coefficients on the original axis where the chain allows it.",
+      "status": "not_started",
+      "verification": [
+        "A pipeline with a PLS node under a split runs and Run.pending_estimators is empty.",
+        "The result's metrics match regression.py and validation.py called directly on the same arrays - the executor orchestrates and computes nothing of its own.",
+        "GET /api/results/{node} serves it, on node_axis's axis (#134).",
+        "The mango calibration reproduces the recorded numbers: RMSECV 0.9193 at A=30 over 10 folds, R2cv 0.8638.",
+        "validate stops warning estimator_not_fitted for a PLS node, and still warns for PLS-DA.",
+        "uv run ruff check && uv run ruff format --check && uv run mypy && uv run pytest"
+      ],
+      "evidence": "",
+      "notes": "The critical path to this list's exit criterion, and untracked until 2026-09-05. Everything cited it as blocked on #88 - executor.py's docstring, session-handoff.md, this file - and #88 closed on 2026-08-27 as #105. SEC, SEP, Q2 and coefficients_original_units all exist, the PLS kernel exists and is parity-covered, and 10-fold CV over 7413 mango spectra ran on 2026-09-05 scoring 0.9198 RMSE against the paper's published 0.8281. The sentence outlived its reason by nine days because no issue tracked what it deferred to. What is actually left is not a kernel but a decision: EstimatorResult is shaped for a decomposition - scores, loadings, eigenvalues, T2, SPE - and a regression's result is a different set. PLS-DA is deliberately out of scope, needing a class column and a confusion matrix. The screen that renders it is a follow-up not yet filed, because an issue written before the payload shape is decided would be guessing; DESIGN_BRIEF.md section 5 is the reference and there is no artboard for a regression result."
     },
     {
       "id": "import-column-roles-and-sample-ids",

--- a/session-handoff.md
+++ b/session-handoff.md
@@ -56,14 +56,19 @@ things to remove.
 
 ## Next action
 
-**The rest of #51** (priority 2): duplicating a subgraph, and a comparison tab for two terminal
-nodes. The comparison tab still has no artboard and little to compare until PLS has a kernel in the
-executor (#88). That ordering is still worth deciding before the branch is cut, and the end-to-end
-run sharpened it: **#88 now blocks the phase's own exit criterion**, not just one screen.
+**#142 — the executor fits PLS.** It is the critical path to this list's own exit criterion, it
+unblocks #51's second half, and it makes #136 redundant as that issue predicted. It is not a kernel
+problem: the kernel exists and is parity-covered. It is a decision about what a regression's
+`EstimatorResult` holds, because that dataclass is shaped for a decomposition — scores, loadings,
+eigenvalues, T², SPE — and a regression carries a different set. PLS-DA is deliberately out of its
+scope. Read the issue before cutting the branch; the shape is the work.
+
+**Then the rest of #51** (priority 2): duplicating a subgraph, and a comparison tab for two terminal
+nodes. The tab still has no artboard, and after #142 it finally has something to compare.
 
 **#135** (priority 3) is waiting on a rule decision, below. **#137** (priority 4) is a documentation
-correction and can go any time. Either is a reasonable thing to take instead of #51 if the PLS
-ordering is not settled yet.
+correction and can go any time. Either is a reasonable thing to take first if #142's shape needs
+thinking about.
 
 **Everything the end-to-end run found is now closed** — #134 as #140 and #136 as #141 — except
 those two.
@@ -123,15 +128,24 @@ same mismatch quietly.
 `checks.py`: that module's docstring draws its own line — every warning there catches a mistake
 whose symptom is a plausible result, with a document behind it — and a node the build cannot fit is
 neither. The recipe is right and the application is short a kernel, so filing it there would blame
-the user for #88. It is built in `validation_payload` instead: two sources, one list, told apart by
+the user for #142. It is built in `validation_payload` instead: two sources, one list, told apart by
 `code` and by `severity` (`info` rather than `warning`). **`executor.has_kernel(spec)` is now the
 one place that knows what can be fitted**, asked by the executor's routing and by the warning, so
-#88 adds to one tuple rather than to two files that have to be remembered together.
+#142 adds to one tuple rather than to two files that have to be remembered together.
 
 The issue's better half was left, deliberately: `pipelines/{id}/state` telling *not yet* from *never
 will be* needs `NodeState` in `frontend/src/canvas/graph.ts:12` widened, a `NodeCard` case and a
-visual treatment with no artboard behind it — and #88 makes it moot. `PipelineCanvas.tsx:190`
+visual treatment with no artboard behind it — and #142 makes it moot. `PipelineCanvas.tsx:190`
 already renders `problems` when `valid` is false, so the sentence reaches the canvas for free.
+
+**A stale issue reference outlived its reason by nine days, and nothing noticed.** `executor.py`
+said PLS was not fitted "because what a PLS result carries … is #88's subject". #88 closed on
+2026-08-27 as #105 — it *was* the metrics gap, and SEC, SEP, Q² and `coefficients_original_units`
+have existed ever since. `session-handoff.md` and `feature_list.json` both inherited the claim, and
+it was repeated into two pull request bodies on 2026-09-05 before being caught. **The reason it
+survived is that no issue tracked the work it deferred to** — a pointer to a closed issue is not a
+plan, and nothing was watching the pointer. That work is #142 now. When a comment defers to an
+issue, the deferral needs its own issue, or the comment becomes the only record and rots quietly.
 
 **Worth not rediscovering:** the executor holds no per-node axis, deliberately and for a good reason
 (`executor.py:5-8` — a second thing beside the arrays would have to stay consistent with them).
@@ -351,7 +365,7 @@ From #87 (the estimators), which #86 and #90 draw on:
 - **`validation` is an additive payload key**, so every array the 1.1 screen reads keeps the length the fixture has. A screen that ignores it renders exactly what it rendered before.
 - **`pca_d` is the second casualty of #97** — 3.8e-05 on explained variance, 1.8e-01 on T². Regenerating the fixtures means regenerating `spectra.json` **and** `pca.json`.
 - **The reported rank was one too high for any centred matrix** — #101, now fixed. A centred array read back as float32 has columns that no longer sum to zero, and the SVD finds a hundredth singular value. Only the displayed integer moved; the limits move in the ninth decimal.
-- **PLS and PLS-DA have no kernel in the executor** and are reported in `Run.pending_estimators`. What a PLS result carries is #88's subject.
+- **PLS and PLS-DA are not fitted by the executor** and are reported in `Run.pending_estimators`. This said "what a PLS result carries is #88's subject" until 2026-09-05, and #88 had closed on 2026-08-27. **The kernel and its metrics exist**; what is missing is the executor branch and the result shape, which is #142.
 
 From #81 (the import endpoints), which #89 finished:
 

--- a/src/chemometrics_workbench/api.py
+++ b/src/chemometrics_workbench/api.py
@@ -526,7 +526,7 @@ def _not_fitted(pipeline: Pipeline) -> list[PipelineWarning]:
     plausible result, and has a document behind it saying what the consequence
     is. This is neither. Nothing is wrong with the recipe; the build has no
     kernel for part of it, which is a fact about the application. Filing it
-    under "what is wrong with your pipeline" would blame the user for #88.
+    under "what is wrong with your pipeline" would blame the user for #142.
 
     What made this worth saying at all: a PLS node validated clean, the run
     reported `succeeded` and `"Done"`, and the node was left `not_run` — which

--- a/src/chemometrics_workbench/executor.py
+++ b/src/chemometrics_workbench/executor.py
@@ -66,9 +66,16 @@ beside the calibration ones, because §9's rule is that they are pushed through
 the training fold's parameters rather than left out of the picture.
 
 `PLSRegressionSpec` and `PLSDASpec` have no result here. They are reported in
-`Run.pending_estimators` rather than fitted, because what a PLS result carries
-— RMSECV over a fold assignment, SEC, SEP, `coefficients_original_units` — is
-#88's subject and is not in the 1.1 fixture to be checked against.
+`Run.pending_estimators` rather than fitted, and #142 is where that changes.
+
+This used to say the quantities a PLS result carries — RMSECV over a fold
+assignment, SEC, SEP, `coefficients_original_units` — were #88's subject.
+**They stopped being, on 2026-08-27**: #88 merged as #105 and all four are in
+`validation.py` and `regression.py` now, with PLS parity-covered in
+`docs/parity-report.md`. The sentence outlived its reason by nine days because
+no issue tracked the work it deferred to. What is actually left is a decision
+about what a regression's `EstimatorResult` holds — this dataclass is shaped
+for a decomposition — and that is #142's subject rather than a missing kernel.
 
 ## What is not here
 
@@ -142,16 +149,16 @@ __all__ = [
 def has_kernel(spec: EstimatorSpec) -> bool:
     """Whether this build can actually fit that estimator.
 
-    **The one place that knows.** The routing below and `checks.py`'s warning
-    both ask here, so #88 adds `PLSRegressionSpec` to the tuple once rather
-    than in two files that have to be remembered together — which is the shape
-    #131 was about.
+    **The one place that knows.** The routing below and the `estimator_not_fitted`
+    warning both ask here, so #142 adds `PLSRegressionSpec` to the tuple once
+    rather than in two files that have to be remembered together — which is the
+    shape #131 was about.
     """
     return isinstance(spec, _FITTED)
 
 
 #: What `_estimator` can fit. `PLSRegressionSpec` and `PLSDASpec` are absent,
-#: which is #88.
+#: which is #142.
 _FITTED: tuple[type, ...] = (PCASpec,)
 
 
@@ -296,7 +303,7 @@ class Run:
     resolved_splits: list[ResolvedSplit]
     results: dict[NodeId, EstimatorResult]
     pending_estimators: list[NodeId]
-    """Estimator nodes this build has no kernel for: PLS and PLS-DA, in #88."""
+    """Estimator nodes this build has no kernel for: PLS and PLS-DA, in #142."""
 
     @property
     def computed(self) -> list[NodeId]:


### PR DESCRIPTION
Comments and notes only. No behaviour changes, and the suite is unchanged at 793 passed.

`executor.py:68-71` said PLS and PLS-DA are reported in `Run.pending_estimators` rather than fitted *"because what a PLS result carries — RMSECV over a fold assignment, SEC, SEP, `coefficients_original_units` — is **#88's subject** and is not in the 1.1 fixture to be checked against."*

**#88 closed on 2026-08-27**, merged as #105. It *was* the metrics gap, and every quantity it names has existed since:

| | |
| --- | --- |
| `validation.sec`, `validation.sep`, `validation.q2` | present |
| `regression.coefficients_original_units` | present |
| `regression.cross_validated_predictions`, `regression.rmsecv_curve` | present |
| `regression.PLS` | present, parity-covered — `docs/parity-report.md` §PLS regression |

All exercised on real data on 2026-09-05: 10-fold CV over 7413 mango spectra, RMSECV curve to A=30, 0.9198 RMSE on the paper's own tuning set against their published 0.8281.

So the sentence outlived its reason by nine days. `session-handoff.md` and `feature_list.json` both inherited the claim, and it was repeated into #140 and #141's bodies before it was caught.

## What was actually left, and where it lives now

Not a kernel — a decision. `EstimatorResult` is shaped for a decomposition (scores, loadings, eigenvalues, T², SPE) and a regression carries a different set. That is **#142**, filed today, and it is the critical path to `feature_list.json`'s own exit criterion.

References now point there: `executor.py`'s module docstring, `has_kernel`, `_FITTED`, `Run.pending_estimators`, and `api.py`'s `_not_fitted`. The references that describe #88 accurately — as the metrics gap it was, in `session-handoff.md`'s "carried forward from the specifications" — are left alone.

`feature_list.json` gains a `pls-in-the-executor` entry at priority 2, and `canvas-compare-and-duplicate` now `depends_on` it rather than saying so only in prose. The exit criterion stops claiming #88 is the executor half.

## The part worth keeping

The handoff records why this survived, because it is the general case rather than this instance:

> **A pointer to a closed issue is not a plan, and nothing was watching the pointer.** When a comment defers to an issue, the deferral needs its own issue, or the comment becomes the only record and rots quietly.

That is what made this invisible: the work was real, it was described accurately in a docstring, and it was tracked nowhere.

## Verification

`uv run pytest` — 793 passed, 1 skipped, unchanged. `ruff check`, `ruff format --check` (77 files), `mypy` (53 source files) exit 0. `uv run python -m tests.check_feature_list` — consistent, including the new `depends_on` edge.

Not closing #142 — that issue is the work, and this is only the correction that makes it findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)