### PR TITLE
Fit PLS in the executor

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -120,7 +120,7 @@
       "title": "The executor fits PLS, and a PLS result has a defined shape",
       "depends_on": [],
       "user_visible_behavior": "A PLS node in a pipeline is fitted like a PCA node is, and its result is readable: the RMSECV curve, the metrics, predicted versus actual, and coefficients on the original axis where the chain allows it.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "A pipeline with a PLS node under a split runs and Run.pending_estimators is empty.",
         "The result's metrics match regression.py and validation.py called directly on the same arrays - the executor orchestrates and computes nothing of its own.",
@@ -129,8 +129,27 @@
         "validate stops warning estimator_not_fitted for a PLS node, and still warns for PLS-DA.",
         "uv run ruff check && uv run ruff format --check && uv run mypy && uv run pytest"
       ],
+      "evidence": "2026-09-05. Against the live mango project over HTTP: a pipeline of range_select 500-1000 nm, SNV, Savitzky-Golay first derivative, a 10-fold split, mean centre and a 15-component PLS on target_DM ran to 'succeeded' with pls_dm 'complete' - the first PLS node this application has ever fitted - and pending_estimators empty. GET /api/results/pls_dm served task 'regression', 167 coefficients and 167 VIP values on a 167-point axis at 501-999 nm (node_axis, #134), RMSEC 1.1111, R2 0.8015, bias +0.00000, SEC 1.1124, RMSEP 1.1218, SEP 1.1221, RMSECV 1.1166, Q2 0.7990, rmsecv_std 0.0334, ten rmsecv_fold_k entries and a fifteen-point rmsecv curve. The curve is identical to the standalone script run on 2026-09-05 before any of this code existed - [2.4085, 2.3898, 2.3739, 2.3083, 2.2479, 2.1925, 2.048, 1.8275, 1.7762, 1.5075, 1.4356, 1.3555, 1.2092, 1.1581, 1.1166] - and that run's R2cv 0.7990 is this run's Q2. POST /api/pipelines/current/validate returned valid: true with no warnings, so #136's estimator_not_fitted correctly stopped firing for PLS. uv run pytest - 799 passed, 1 skipped (793 before, +6 in tests/test_executor.py, including the RMSEP^2 = bias^2 + (n-1)/n * SEP^2 identity section 5 offers as a cheap unit test). uv run ruff check, ruff format --check (77 files) and mypy (53 source files) exit 0. Frontend npx tsc -b --noEmit and npx vitest run - 10 files, 77 tests, unchanged.",
+      "notes": "The critical path to this list's exit criterion, and untracked until 2026-09-05. Everything cited it as blocked on #88 - executor.py's docstring, session-handoff.md, this file - and #88 closed on 2026-08-27 as #105. SEC, SEP, Q2 and coefficients_original_units all exist, the PLS kernel exists and is parity-covered, and 10-fold CV over 7413 mango spectra ran on 2026-09-05 scoring 0.9198 RMSE against the paper's published 0.8281. The sentence outlived its reason by nine days because no issue tracked what it deferred to. What is actually left is not a kernel but a decision: EstimatorResult is shaped for a decomposition - scores, loadings, eigenvalues, T2, SPE - and a regression's result is a different set. PLS-DA is deliberately out of scope, needing a class column and a confusion matrix. The screen that renders it is a follow-up not yet filed, because an issue written before the payload shape is decided would be guessing; DESIGN_BRIEF.md section 5 is the reference and there is no artboard for a regression result. Shipped: the executor's PLS branch, the result shape, and has_kernel gaining PLSRegressionSpec. The shape turned out to be specified rather than open - metrics-and-validation.md section 11 names every field and where it goes, Metrics already had them, and section 9 even prescribes the rmsecv_a<A> keys. Reading the documents first was most of the work. EstimatorResult was extended additively rather than split in two: the tasks share task, rows, fold, scores, loadings, the x-variances and both diagnostics, so a second type would have restated most of it to differ in the last third. The one real design call is asserted rather than left in prose - the model is fold zero's, the cross-validated numbers are every fold's, because section 13's reported quantities belong to one model while RMSECV is a property of the split, which is why section 7 pools residuals. The response is centred by the estimator, not by a node, because y is not on the canvas. coefficients_original_units is #144, not laziness: it needs the fitted transformer chain, and a cached node never builds one. PLS-DA stays out - a class column and a confusion matrix are a second result shape."
+    },
+    {
+      "id": "coefficients-on-the-raw-axis",
+      "priority": 3,
+      "area": "backend",
+      "issue": 144,
+      "title": "Coefficients readable against the raw axis",
+      "depends_on": [
+        "pls-in-the-executor"
+      ],
+      "user_visible_behavior": "A PLS model's coefficients can be read and exported against the dataset's own axis, or the application says which step makes that impossible and why.",
+      "status": "not_started",
+      "verification": [
+        "A foldable chain (range selection, Savitzky-Golay, centring) exports coefficients reproducing the model's predictions from the raw array: y_hat == intercept + X_raw @ b.",
+        "A pipeline containing SNV reports them unavailable, naming SNV, rather than returning an approximation.",
+        "The numbers survive a cache hit - a second run reads back what the first computed."
+      ],
       "evidence": "",
-      "notes": "The critical path to this list's exit criterion, and untracked until 2026-09-05. Everything cited it as blocked on #88 - executor.py's docstring, session-handoff.md, this file - and #88 closed on 2026-08-27 as #105. SEC, SEP, Q2 and coefficients_original_units all exist, the PLS kernel exists and is parity-covered, and 10-fold CV over 7413 mango spectra ran on 2026-09-05 scoring 0.9198 RMSE against the paper's published 0.8281. The sentence outlived its reason by nine days because no issue tracked what it deferred to. What is actually left is not a kernel but a decision: EstimatorResult is shaped for a decomposition - scores, loadings, eigenvalues, T2, SPE - and a regression's result is a different set. PLS-DA is deliberately out of scope, needing a class column and a confusion matrix. The screen that renders it is a follow-up not yet filed, because an issue written before the payload shape is decided would be guessing; DESIGN_BRIEF.md section 5 is the reference and there is no artboard for a regression result."
+      "notes": "Split out of #142, which delivered everything else. regression.coefficients_original_units already does the arithmetic and does it well - it measures the chain by passing the identity through it rather than restating four folding rules. What is missing is its input: it needs the fitted transformers, and _transform builds, fits, transforms and drops them, while a cached node never builds one at all. So this is a question about what the executor keeps, not a missing call. Three options in the issue, none obviously right; option 3 - fold at fit time, where the transformers exist - fits the executor's grain best, option 1 is the smallest diff. The mango pipeline is the unfoldable case: it has an SNV, so PROPOSAL.md section 9's portable model is not available for it and the UI has to say so rather than approximate."
     },
     {
       "id": "import-column-roles-and-sample-ids",

--- a/src/chemometrics_workbench/api.py
+++ b/src/chemometrics_workbench/api.py
@@ -498,6 +498,35 @@ def results_payload(
             "hotelling_t2": result.held_out_hotelling_t2,
             "spe": result.held_out_spe,
         }
+        if result.task == "regression":
+            payload["validation"]["observed"] = result.held_out_observed
+            payload["validation"]["predicted"] = result.held_out_predicted
+
+    # A regression's own half, added rather than substituted: `scores`,
+    # `loadings`, the x-variances and both diagnostics above mean the same
+    # thing for both tasks, so a screen that draws those draws either. What is
+    # here is what has no counterpart on a decomposition.
+    if result.task == "regression":
+        payload["regression"] = {
+            "target": result.target,
+            "observed": result.observed,
+            "predicted": result.predicted,
+            # On the node's own axis, like `loadings` — #134. Folding the
+            # preprocessing back out to the raw axis is #144.
+            "coefficients": result.coefficients,
+            "vip": result.vip,
+            "y_loadings": result.y_loadings,
+            "y_explained_variance_ratio": result.y_explained_variance_ratio,
+        }
+        # §11: a metric that could not be computed is absent, never zero. The
+        # curve is lifted out of the flat table so a screen plots it without
+        # parsing key names, and the table keeps every key regardless.
+        payload["metrics"] = dict(result.metrics)
+        payload["rmsecv_curve"] = [
+            result.metrics[key]
+            for key in (f"rmsecv_a{a}" for a in range(1, result.n_components + 1))
+            if key in result.metrics
+        ]
     return payload
 
 

--- a/src/chemometrics_workbench/executor.py
+++ b/src/chemometrics_workbench/executor.py
@@ -65,17 +65,19 @@ result, and the held-out rows are projected through the fitted model and stored
 beside the calibration ones, because §9's rule is that they are pushed through
 the training fold's parameters rather than left out of the picture.
 
-`PLSRegressionSpec` and `PLSDASpec` have no result here. They are reported in
-`Run.pending_estimators` rather than fitted, and #142 is where that changes.
+A `PLSRegressionSpec` node is fitted too, since #142. **The model is fold
+zero's and the cross-validated numbers are every fold's**, which is not a
+contradiction: §13's reported quantities belong to one fitted model, and
+RMSECV is a property of the *split* rather than of any model — which is why §7
+pools residuals across folds instead of averaging per-fold errors. Taking the
+curve from fold zero alone would be a worse estimate from the same work.
 
-This used to say the quantities a PLS result carries — RMSECV over a fold
-assignment, SEC, SEP, `coefficients_original_units` — were #88's subject.
-**They stopped being, on 2026-08-27**: #88 merged as #105 and all four are in
-`validation.py` and `regression.py` now, with PLS parity-covered in
-`docs/parity-report.md`. The sentence outlived its reason by nine days because
-no issue tracked the work it deferred to. What is actually left is a decision
-about what a regression's `EstimatorResult` holds — this dataclass is shaped
-for a decomposition — and that is #142's subject rather than a missing kernel.
+The response is centred by the estimator rather than by a node, because `y` is
+not on the canvas and no `MeanCentre` can reach it. Predictions come back in
+the response's original units.
+
+`PLSDASpec` is still not fitted and is reported in `Run.pending_estimators`. It
+needs a class column and a confusion matrix, which is a second result shape.
 
 ## What is not here
 
@@ -97,7 +99,7 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
-from chemometrics_workbench import preprocessing
+from chemometrics_workbench import preprocessing, validation
 from chemometrics_workbench.decomposition import PCA
 from chemometrics_workbench.models import (
     DatasetVersion,
@@ -112,6 +114,7 @@ from chemometrics_workbench.models import (
     PCASpec,
     Pipeline,
     PipelineNode,
+    PLSRegressionSpec,
     ResolvedSplit,
 )
 from chemometrics_workbench.project import (
@@ -121,6 +124,11 @@ from chemometrics_workbench.project import (
     write_array,
     write_cache_index,
     write_json,
+)
+from chemometrics_workbench.regression import (
+    PLS,
+    cross_validated_predictions,
+    rmsecv_curve,
 )
 from chemometrics_workbench.validation import Fold, k_fold, leave_one_out, validate_partition
 
@@ -157,9 +165,9 @@ def has_kernel(spec: EstimatorSpec) -> bool:
     return isinstance(spec, _FITTED)
 
 
-#: What `_estimator` can fit. `PLSRegressionSpec` and `PLSDASpec` are absent,
-#: which is #142.
-_FITTED: tuple[type, ...] = (PCASpec,)
+#: What `_estimator` can fit. `PLSDASpec` is absent: it needs a class column
+#: and a confusion matrix, which is a second result shape.
+_FITTED: tuple[type, ...] = (PCASpec, PLSRegressionSpec)
 
 
 RESULTS_DIR = "results"
@@ -278,6 +286,50 @@ class EstimatorResult:
     held_out_scores: list[list[float]] = field(default_factory=list)
     held_out_hotelling_t2: list[float] = field(default_factory=list)
     held_out_spe: list[float] = field(default_factory=list)
+
+    # --- The regression half (#142) ---------------------------------------
+    #
+    # Additive, and absent on a decomposition. This dataclass was shaped for
+    # PCA and the obvious move was a second one; but the two share `task`,
+    # `rows`, `fold`, the scores, the loadings, the x-variances and both
+    # diagnostics, which is most of it. A second type would restate all of that
+    # so the two could differ in the last third, and every reader would grow a
+    # branch to tell them apart. `task` already distinguishes them.
+
+    target: str | None = None
+    """Which target column was modelled. `None` on a decomposition."""
+
+    observed: list[float] = field(default_factory=list)
+    """The reference values for `rows`, so a predicted-versus-actual plot needs
+    this record alone and not the dataset beside it."""
+
+    predicted: list[float] = field(default_factory=list)
+    """Calibration predictions, in the response's original units."""
+
+    held_out_observed: list[float] = field(default_factory=list)
+    held_out_predicted: list[float] = field(default_factory=list)
+
+    coefficients: list[float] = field(default_factory=list)
+    """`b` on the matrix the model was fitted on — the node's own axis, not the
+    dataset's. Folding the preprocessing back out needs the fitted chain, which
+    the executor does not keep; that is #144."""
+
+    y_loadings: list[float] = field(default_factory=list)
+    vip: list[float] = field(default_factory=list)
+
+    y_explained_variance_ratio: list[float] = field(default_factory=list)
+    """`pls-regression.md` §8's YVar. The x-block's stays in
+    `explained_variance_ratio`, shared with PCA, because a screen plotting
+    "variance captured" wants both blocks."""
+
+    metrics: dict[str, float] = field(default_factory=dict)
+    """`metrics-and-validation.md` §11's table, flattened.
+
+    **A metric that could not be computed is absent**, never `0.0` and never
+    `NaN` — §11 is explicit, and the UI renders absence as an em dash. So
+    RMSECV and Q² are missing entirely when the node is not under a split, and
+    SEC is missing when `n - A - 1 <= 0` rather than falling back to a
+    denominator that would silently produce something that is not SEC."""
 
     def as_json(self) -> dict[str, Any]:
         return asdict(self)
@@ -399,7 +451,7 @@ def execute(
                 announce(node)
                 continue
             results[node.id] = _estimator(
-                node, states[node.inputs[0]], keys[node.id], path, use_cache
+                node, states[node.inputs[0]], keys[node.id], path, use_cache, version
             )
             announce(node)
             continue
@@ -718,9 +770,19 @@ def result_path(directory: str | Path, key: str) -> Path:
 
 
 def _estimator(
-    node: PipelineNode, parent: _State, key: str, directory: Path, use_cache: bool
+    node: PipelineNode,
+    parent: _State,
+    key: str,
+    directory: Path,
+    use_cache: bool,
+    version: DatasetVersion,
 ) -> EstimatorResult:
-    """Fit one estimator node, or read back the result of having done so."""
+    """Fit one estimator node, or read back the result of having done so.
+
+    `version` is here for the response: a regression needs a `y`, and the
+    reference values live on the `DatasetVersion` rather than in any array the
+    pipeline produced. A decomposition ignores it.
+    """
     assert node.type == "estimator"
     stored = result_path(directory, key)
     if use_cache and stored.exists():
@@ -743,6 +805,12 @@ def _estimator(
         matrix = parent.arrays[0]
         rows = parent.folds[0].train
         held_out = parent.folds[0].test
+
+    if isinstance(node.spec, PLSRegressionSpec):
+        result = _pls(node, node.spec, parent, key, matrix, rows, held_out, fold, version)
+        stored.parent.mkdir(parents=True, exist_ok=True)
+        write_json(stored, result.as_json())
+        return result
 
     assert isinstance(node.spec, PCASpec)
     try:
@@ -792,6 +860,155 @@ def _estimator(
     stored.parent.mkdir(parents=True, exist_ok=True)
     write_json(stored, result.as_json())
     return result
+
+
+def _response(version: DatasetVersion, node: PipelineNode, name: str) -> NDArray[np.float64]:
+    """The reference values a regression is fitted against.
+
+    Refused here rather than at the kernel, with the columns the dataset does
+    have, because "target 'moisture' not found" a screen can act on beats a
+    `KeyError` from three frames down.
+    """
+    if name not in version.targets:
+        available = ", ".join(sorted(version.targets)) or "none"
+        raise ExecutorError(
+            f"node {node.id!r} (pls) models target {name!r}, which this dataset does not "
+            f"carry. It has: {available}.",
+            node.id,
+        )
+    return np.asarray(version.targets[name], dtype=np.float64)
+
+
+def _pls(
+    node: PipelineNode,
+    spec: PLSRegressionSpec,
+    parent: _State,
+    key: str,
+    matrix: NDArray[np.float64],
+    rows: NDArray[np.intp],
+    held_out: NDArray[np.intp],
+    fold: int | None,
+    version: DatasetVersion,
+) -> EstimatorResult:
+    """Fit one PLS node and measure it, per `metrics-and-validation.md` §4-§9.
+
+    **The model is fold zero's; the cross-validated numbers are every fold's.**
+    Those are not in tension. §13's reported quantities — weights, loadings,
+    coefficients, VIP — belong to one fitted model, and fold zero is the one
+    PCA already uses, so a regression and a decomposition below the same split
+    describe the same samples. RMSECV is not a property of a model at all but
+    of the split, which is exactly why §7 pools residuals across every fold
+    rather than averaging per-fold errors. Taking the curve from fold zero
+    alone would be a worse estimate calculated from the same work.
+
+    **The response is centred here, not by a pipeline node.** `y` is not on the
+    canvas, so no `MeanCentre` can reach it; PLS fits what it is given and
+    centres nothing of its own (`pls-regression.md` §3), and predictions are
+    returned in the response's original units by adding the training mean back.
+    `checks.py` warns separately when `X` has no centring above it.
+    """
+    response = _response(version, node, spec.target)
+    if response.size != matrix.shape[0]:
+        raise ExecutorError(
+            f"node {node.id!r} (pls) has {matrix.shape[0]} samples and target "
+            f"{spec.target!r} has {response.size} values.",
+            node.id,
+        )
+
+    train_x, train_y = matrix[rows], response[rows]
+    x_mean = train_x.mean(axis=0)
+    y_mean = float(train_y.mean())
+
+    try:
+        model = PLS(spec.n_components).fit(train_x - x_mean, train_y - y_mean)
+    except (ValueError, RuntimeError) as error:
+        raise ExecutorError(f"node {node.id!r} (pls) failed: {error}", node.id) from error
+
+    predicted = model.predict(train_x - x_mean) + y_mean
+    a = model.n_components_ or spec.n_components
+
+    metrics: dict[str, float] = {
+        "rmsec": validation.rmse(train_y, predicted),
+        "r2": validation.r2(train_y, predicted),
+        "bias": validation.bias(train_y, predicted),
+        "r2_pearson": float(np.corrcoef(train_y, predicted)[0, 1] ** 2),
+    }
+    # §5: `n - A - 1 <= 0` makes SEC undefined. Absent, and never a fallback
+    # denominator - that would be a number which is not SEC.
+    if train_y.size - a - 1 > 0:
+        metrics["sec"] = validation.sec(train_y, predicted, n_components=a)
+
+    held_x = matrix[held_out]
+    held_y = response[held_out]
+    held_predicted = (
+        model.predict(held_x - x_mean) + y_mean if held_out.size else np.array([], dtype=np.float64)
+    )
+    if held_out.size:
+        metrics["rmsep"] = validation.rmse(held_y, held_predicted)
+        metrics["sep"] = validation.sep(held_y, held_predicted)
+
+    # §9: one split, one pass, one curve. The whole fold assignment, not fold
+    # zero's, and `A` is never re-selected inside a fold - every fold model is
+    # fitted with the same `A` and the curve is a property of the split.
+    if parent.folds is not None:
+        folds = parent.folds
+        curve = rmsecv_curve(matrix, response, folds, a)
+        for index, value in enumerate(curve, start=1):
+            metrics[f"rmsecv_a{index}"] = float(value)
+        metrics["rmsecv"] = float(curve[-1])
+
+        cross_validated = cross_validated_predictions(matrix, response, folds, a)
+        # §6: PRESS over the whole calibration set, against the full
+        # calibration mean. Never a per-fold mean - packages differ on this and
+        # it is what keeps Q2 and R2 on a common denominator.
+        metrics["q2"] = validation.q2(response, cross_validated)
+        for index, one in enumerate(folds):
+            metrics[f"rmsecv_fold_{index}"] = validation.rmse(
+                response[one.test], cross_validated[one.test]
+            )
+        # §8.5: the spread across folds, so a curve's minimum can be read
+        # against how much it moves.
+        per_fold = [metrics[f"rmsecv_fold_{i}"] for i in range(len(folds))]
+        metrics["rmsecv_std"] = float(np.std(per_fold, ddof=1)) if len(per_fold) > 1 else 0.0
+
+    return EstimatorResult(
+        node_id=node.id,
+        key=key,
+        task="regression",
+        n_components=a,
+        n_samples=int(train_x.shape[0]),
+        n_variables=int(train_x.shape[1]),
+        # A PLS model reports no rank of its own; `A` is the user's parameter
+        # and `stopped_early_` is how the kernel says the response ran out.
+        rank=a,
+        fold=fold,
+        rows=[int(row) for row in rows],
+        scores=_rows(model.x_scores_),
+        loadings=_rows(np.asarray(model.x_loadings_).T),
+        eigenvalues=[],
+        explained_variance_ratio=_values(model.explained_variance_ratio("x")),
+        cumulative_explained_variance=_values(model.cumulative_explained_variance("x")),
+        y_explained_variance_ratio=_values(model.explained_variance_ratio("y")),
+        hotelling_t2=_values(model.hotelling_t2()),
+        hotelling_t2_limit=float(model.hotelling_t2_limit(ALPHA)),
+        spe=_values(model.spe(train_x - x_mean)),
+        spe_limit=float(model.spe_limit(ALPHA)),
+        target=spec.target,
+        observed=_values(train_y),
+        predicted=_values(predicted),
+        coefficients=_values(model.coefficients_),
+        y_loadings=_values(model.y_loadings_),
+        vip=_values(model.vip()),
+        metrics=metrics,
+        held_out=[int(row) for row in held_out],
+        held_out_observed=_values(held_y) if held_out.size else [],
+        held_out_predicted=_values(held_predicted) if held_out.size else [],
+        held_out_scores=_rows(model.transform(held_x - x_mean)) if held_out.size else [],
+        held_out_hotelling_t2=(
+            _values(model.hotelling_t2(held_x - x_mean)) if held_out.size else []
+        ),
+        held_out_spe=_values(model.spe(held_x - x_mean)) if held_out.size else [],
+    )
 
 
 def _values(array: object) -> list[float]:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -40,6 +40,7 @@ from chemometrics_workbench.models import (
     MeanCentre,
     PCASpec,
     Pipeline,
+    PLSDASpec,
     PLSRegressionSpec,
     PreprocessNode,
     RangeSelect,
@@ -50,10 +51,13 @@ from chemometrics_workbench.models import (
 )
 from chemometrics_workbench.project import (
     create_project,
+    read_array,
     read_cache_index,
     write_array,
     write_cache_index,
 )
+from chemometrics_workbench.regression import PLS
+from chemometrics_workbench.validation import bias, k_fold, r2, rmse, sec
 
 FIXTURES = Path(__file__).resolve().parent / "fixtures" / "contract"
 
@@ -100,6 +104,10 @@ def project(tmp_path: Path, tecator: Any) -> tuple[Path, DatasetVersion]:
         n_variables=tecator.n_variables,
         axis=tecator.axis,
         sample_ids=list(tecator.sample_ids),
+        # The reference values, so a regression node has something to model.
+        # A decomposition ignores them and every test above was written before
+        # they were here.
+        targets={name: [float(v) for v in values] for name, values in tecator.targets.items()},
         array_path=array_path,
     )
     return directory, version
@@ -763,21 +771,22 @@ def test_an_unreadable_result_is_refitted_rather_than_refused(
     assert again.results["pca_a"].rank == first.results["pca_a"].rank
 
 
-def test_pls_has_no_kernel_here_and_is_named_rather_than_skipped(
+def test_pls_da_has_no_kernel_here_and_is_named_rather_than_skipped(
     project: tuple[Path, DatasetVersion],
 ) -> None:
+    """PLS itself is fitted since #142. PLS-DA still needs a second result shape."""
     directory, version = project
     pipeline = _pipeline(
         version.version_id,
         PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
         EstimatorNode(
-            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=4, target="fat")
+            id="plsda", inputs=("centre",), spec=PLSDASpec(n_components=4, class_column="grade")
         ),
     )
     run = execute(directory, pipeline, version)
 
-    assert run.pending_estimators == ["pls"]
-    assert "pls" not in run.results
+    assert run.pending_estimators == ["plsda"]
+    assert "plsda" not in run.results
 
 
 def test_a_pca_that_cannot_be_fitted_names_its_node(
@@ -839,3 +848,160 @@ def test_the_reported_rank_is_the_fixtures_now_that_the_tolerance_knows_the_prec
     np.testing.assert_allclose(
         run.results["pca_a"].spe_limit, expected["diagnostics"]["spe_limit"], rtol=1e-6
     )
+
+
+# --------------------------------------------------------------------------
+# PLS, #142
+# --------------------------------------------------------------------------
+
+
+def test_a_pls_node_is_fitted_and_its_result_is_a_regression(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+        EstimatorNode(
+            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=6, target="fat")
+        ),
+    )
+    run = execute(directory, pipeline, version)
+
+    assert run.pending_estimators == []
+    result = run.results["pls"]
+    assert result.task == "regression"
+    assert result.target == "fat"
+    assert result.n_components == 6
+    assert len(result.observed) == len(result.predicted) == version.n_samples
+    assert len(result.coefficients) == version.n_variables
+    assert len(result.vip) == version.n_variables
+
+
+def test_the_executor_computes_nothing_the_kernels_do_not(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """The executor orchestrates. Every number it reports is reproduced here by
+    calling `regression.py` and `validation.py` on the same array."""
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+        EstimatorNode(
+            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=5, target="fat")
+        ),
+    )
+    run = execute(directory, pipeline, version)
+    result = run.results["pls"]
+
+    matrix = read_array(directory, run.outputs["centre"].array_path)
+    y = np.asarray(version.targets["fat"], dtype=np.float64)
+    x_mean, y_mean = matrix.mean(axis=0), float(y.mean())
+    model = PLS(5).fit(matrix - x_mean, y - y_mean)
+    predicted = model.predict(matrix - x_mean) + y_mean
+
+    assert result.predicted == pytest.approx([float(v) for v in predicted])
+    assert model.coefficients_ is not None
+    assert result.coefficients == pytest.approx([float(v) for v in model.coefficients_])
+    assert result.vip == pytest.approx([float(v) for v in model.vip()])
+    assert result.metrics["rmsec"] == pytest.approx(rmse(y, predicted))
+    assert result.metrics["r2"] == pytest.approx(r2(y, predicted))
+    assert result.metrics["bias"] == pytest.approx(bias(y, predicted))
+    assert result.metrics["sec"] == pytest.approx(sec(y, predicted, n_components=5))
+
+
+def test_below_a_split_the_curve_is_every_folds_and_the_model_is_fold_zeros(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """The one design call in #142, asserted rather than left in a docstring."""
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        SplitNode(id="split", inputs=("source",), spec=KFoldSplit(n_splits=5, seed=42)),
+        PreprocessNode(id="centre", inputs=("split",), step=MeanCentre()),
+        EstimatorNode(
+            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=4, target="fat")
+        ),
+    )
+    run = execute(directory, pipeline, version)
+    result = run.results["pls"]
+
+    # The model is fold zero's: its rows are that fold's training rows.
+    assert result.fold == 0
+    folds = k_fold(version.n_samples, 5, seed=42)
+    assert result.rows == [int(row) for row in folds[0].train]
+    assert result.held_out == [int(row) for row in folds[0].test]
+
+    # The curve is every fold's, one entry per component count, and the
+    # reported RMSECV is the curve's last point rather than its minimum.
+    curve = [result.metrics[f"rmsecv_a{a}"] for a in range(1, 5)]
+    assert len(curve) == 4
+    assert result.metrics["rmsecv"] == pytest.approx(curve[-1])
+    assert all(f"rmsecv_fold_{k}" in result.metrics for k in range(5))
+    assert "q2" in result.metrics and "rmsecv_std" in result.metrics
+
+
+def test_a_pls_node_above_a_split_reports_no_cross_validated_metric(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """§11: a metric that could not be computed is absent, never zero."""
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+        EstimatorNode(
+            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=3, target="fat")
+        ),
+    )
+    result = execute(directory, pipeline, version).results["pls"]
+
+    assert "rmsec" in result.metrics
+    for absent in ("rmsecv", "q2", "rmsep", "sep", "rmsecv_std"):
+        assert absent not in result.metrics
+
+
+def test_a_target_the_dataset_does_not_carry_names_itself(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
+        EstimatorNode(
+            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=3, target="octane")
+        ),
+    )
+    with pytest.raises(ExecutorError, match="does not carry"):
+        execute(directory, pipeline, version)
+
+
+def test_sep_and_rmsep_satisfy_the_identity_the_specification_names(
+    project: tuple[Path, DatasetVersion],
+) -> None:
+    """`metrics-and-validation.md` §5 offers this as a cheap unit test, so take it.
+
+    `RMSEP^2 = bias^2 + (n_p - 1)/n_p * SEP^2` ties the two exactly on a
+    prediction set. It holds only if both were computed on the same residuals
+    with the denominators §5 specifies, so it catches a SEP wired to the wrong
+    rows or divided by the wrong `n` — which no amount of "the number looks
+    plausible" would.
+    """
+    directory, version = project
+    pipeline = _pipeline(
+        version.version_id,
+        SplitNode(id="split", inputs=("source",), spec=KFoldSplit(n_splits=5, seed=42)),
+        PreprocessNode(id="centre", inputs=("split",), step=MeanCentre()),
+        EstimatorNode(
+            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=4, target="fat")
+        ),
+    )
+    result = execute(directory, pipeline, version).results["pls"]
+
+    observed = np.asarray(result.held_out_observed)
+    predicted = np.asarray(result.held_out_predicted)
+    n_p = observed.size
+    held_out_bias = bias(observed, predicted)
+
+    left = result.metrics["rmsep"] ** 2
+    right = held_out_bias**2 + ((n_p - 1) / n_p) * result.metrics["sep"] ** 2
+    assert left == pytest.approx(right)

--- a/tests/test_not_fitted_warning.py
+++ b/tests/test_not_fitted_warning.py
@@ -46,10 +46,14 @@ def codes(payload: dict[str, Any]) -> list[str]:
 # --- The one place that knows -----------------------------------------------
 
 
-def test_pca_has_a_kernel_and_the_two_pls_specs_do_not() -> None:
-    """#88 flips the last two by adding to one tuple, not by editing two files."""
+def test_pca_and_pls_have_kernels_and_pls_da_does_not() -> None:
+    """#142 added PLS by adding to one tuple, not by editing two files.
+
+    PLS-DA is what is left, and it is left on purpose: a class column and a
+    confusion matrix are a second result shape, not a second kernel call.
+    """
     assert has_kernel(PCASpec(n_components=2))
-    assert not has_kernel(PLSRegressionSpec(n_components=2, target="fat"))
+    assert has_kernel(PLSRegressionSpec(n_components=2, target="fat"))
     assert not has_kernel(PLSDASpec(n_components=2, class_column="grade"))
 
 
@@ -67,13 +71,13 @@ def test_a_pipeline_of_things_that_run_still_says_nothing() -> None:
     assert payload["problems"] == []
 
 
-def test_a_pls_node_is_named_before_the_run_rather_than_after_it() -> None:
+def test_a_pls_da_node_is_named_before_the_run_rather_than_after_it() -> None:
     graph = pipeline(
         PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
         EstimatorNode(
             id="pls_dm",
             inputs=("centre",),
-            spec=PLSRegressionSpec(n_components=12, target="target_DM"),
+            spec=PLSDASpec(n_components=12, class_column="grade"),
         ),
     )
     payload = validation_payload(graph)
@@ -94,14 +98,18 @@ def test_every_unfittable_node_is_named_not_just_the_first() -> None:
         PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
         EstimatorNode(id="pca", inputs=("centre",), spec=PCASpec(n_components=2)),
         EstimatorNode(
-            id="pls_a", inputs=("centre",), spec=PLSRegressionSpec(n_components=3, target="fat")
+            id="plsda_a", inputs=("centre",), spec=PLSDASpec(n_components=3, class_column="a")
         ),
         EstimatorNode(
-            id="plsda_b", inputs=("centre",), spec=PLSDASpec(n_components=3, class_column="grade")
+            id="plsda_b", inputs=("centre",), spec=PLSDASpec(n_components=3, class_column="b")
+        ),
+        # PLS is fitted since #142 and must not appear.
+        EstimatorNode(
+            id="pls", inputs=("centre",), spec=PLSRegressionSpec(n_components=3, target="fat")
         ),
     )
     named = [w["node_id"] for w in validation_payload(graph)["warnings"]]
-    assert named == ["pls_a", "plsda_b"]
+    assert named == ["plsda_a", "plsda_b"]
 
 
 def test_it_does_not_displace_what_checks_py_had_to_say() -> None:
@@ -111,7 +119,7 @@ def test_it_does_not_displace_what_checks_py_had_to_say() -> None:
         PreprocessNode(id="centre", inputs=("source",), step=MeanCentre()),
         SplitNode(id="split", inputs=("centre",), spec=KFoldSplit(n_splits=10, seed=42)),
         EstimatorNode(
-            id="pls", inputs=("split",), spec=PLSRegressionSpec(n_components=3, target="fat")
+            id="plsda", inputs=("split",), spec=PLSDASpec(n_components=3, class_column="grade")
         ),
     )
     found = codes(validation_payload(graph))
@@ -124,7 +132,7 @@ def test_the_two_kinds_are_told_apart_by_code_and_severity() -> None:
     graph = pipeline(
         PreprocessNode(id="snv", inputs=("source",), step=SNV()),
         EstimatorNode(
-            id="pls", inputs=("snv",), spec=PLSRegressionSpec(n_components=3, target="fat")
+            id="plsda", inputs=("snv",), spec=PLSDASpec(n_components=3, class_column="grade")
         ),
     )
     by_code = {w["code"]: w for w in validation_payload(graph)["warnings"]}


### PR DESCRIPTION
The pipeline stopped at PCA, so this phase's own exit criterion — *a complete calibration workflow on a real NIR dataset, without leaving the application* — could not be met. It can now.

## The shape was specified, not open

The issue framed this as a decision about what a PLS result carries. It largely was not:

- `metrics-and-validation.md` §11 names every metric and whether it is a `Metrics` field or an `extra` key.
- `Metrics` already had `rmsec`, `rmsecv`, `rmsep`, `r2`, `q2`, `bias` and `extra`.
- §9 even prescribes the `rmsecv_a<A>` key format — "one split, one pass, one curve".
- `pls-regression.md` §13 lists the reported quantities.

Reading the documents was most of the work. Almost nothing here was invented.

## `EstimatorResult` extended, not split

The two tasks share `task`, `rows`, `fold`, the scores, the loadings, the x-variances and both diagnostics — most of it. A second dataclass would have restated all of that so the two could differ in the last third, and every reader would have grown a branch to tell them apart. `task` already distinguishes them, and `results_payload` adds a `regression` key beside what it already served rather than substituting anything, so a screen that draws scores and loadings draws either.

## The one real design call

**The model is fold zero's; the cross-validated numbers are every fold's.** Asserted in a test rather than left in a docstring.

These are not in tension. §13's reported quantities — weights, loadings, coefficients, VIP — belong to one fitted model, and fold zero is the one PCA already uses, so a regression and a decomposition below the same split describe the same samples. RMSECV is not a property of a model at all but of the *split*, which is exactly why §7 pools residuals across every fold instead of averaging per-fold errors. Taking the curve from fold zero alone would be a worse estimate computed from the same work.

Two smaller ones: the response is centred by the estimator rather than by a node, because `y` is not on the canvas and no `MeanCentre` can reach it; and §11's *"a metric that could not be computed is absent, never `0.0`, never `NaN`"* is followed literally — RMSECV and Q² are missing above a split, SEC is missing when `n - A - 1 <= 0` rather than falling back to a denominator that would produce a number which is not SEC.

## Verification

Live, on the mango project: `range_select 500–1000 nm → SNV → SG(d1) → 10-fold split → mean centre → PLS(15) on target_DM`.

```
job succeeded · pls_dm complete · pending_estimators []      ← the first PLS node this app has fitted

task "regression"  target target_DM  A=15   167 coefficients, 167 VIP
loadings axis      167 values, 501–999 nm    (node_axis, #134)

calibration  RMSEC 1.1111   R2 0.8015   bias +0.00000   SEC 1.1124
held out     RMSEP 1.1218   SEP 1.1221
cross-val    RMSECV 1.1166  Q2 0.7990   rmsecv_std 0.0334   + 10 rmsecv_fold_k
```

**The curve is identical to the standalone script run before any of this code existed:**

```
[2.4085, 2.3898, 2.3739, 2.3083, 2.2479, 2.1925, 2.048, 1.8275,
 1.7762, 1.5075, 1.4356, 1.3555, 1.2092, 1.1581, 1.1166]
```

and that run's R²cv 0.7990 is this run's Q². The executor reproduces an independently written chain to four decimals.

`validate` now returns `valid: true` with no warnings on that pipeline — #136's `estimator_not_fitted` correctly stopped firing for PLS, and its tests were updated to assert PLS-DA instead of deleted.

`uv run pytest` — **799 passed, 1 skipped** (793 before; +6), including the `RMSEP² = bias² + (n−1)/n · SEP²` identity §5 offers as a cheap unit test, and a test that the executor computes nothing the kernels do not. `ruff check`, `ruff format --check` (77 files), `mypy` (53 source files) exit 0. Frontend `tsc` and `vitest` — 10 files, 77 tests, unchanged.

## Left out, and why

**`coefficients_original_units` is #144**, not a shortcut. It needs the *fitted* transformer chain; `_transform` builds, fits, transforms and drops it, and a cached node never builds one at all. So it is a question about what the executor keeps, with three options and no obvious winner — filed rather than guessed at. The mango pipeline is the unfoldable case anyway: it has an SNV, so §7 says the portable model is unavailable and the UI must say so rather than approximate.

**PLS-DA** stays in `pending_estimators`. A class column and a confusion matrix are a second result shape, not a second kernel call.

**The screen** that renders this is still unfiled, for the reason #142 gave: the payload shape had to exist first. It does now.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)