### PR TITLE
Make the demo walk the exit criterion

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -77,6 +77,27 @@
       "notes": "Items 1 and 4 of #51. The rules live in frontend/src/canvas/edits.ts, pure and tested, and are enforced during the drag through React Flow's isValidConnection - each refusal is the client half of a models.py validator. Every non-source node holds exactly one input (tuple[NodeId]), so connecting replaces rather than appends and a branch is one node with several children; an edge cannot be cut on its own because the child would be left dangling. The remove control is on the node rather than in the side panel: clicking a node opens its tab, which replaces the panel before it could be used. Edits are held locally and saved by the existing whole-list PUT (#108). Node positions are still not draggable - layout lives in pipeline_state.json and nothing writes it back."
     },
     {
+      "id": "demo-walks-the-exit-criterion",
+      "priority": 1,
+      "area": "backend",
+      "issue": 146,
+      "title": "The seeded demo walks the exit criterion, and the ellipse it exposed",
+      "depends_on": [
+        "pls-in-the-executor"
+      ],
+      "user_visible_behavior": "The demo project the Playwright suite walks now cross-validates a PLS calibration, so the path the exit criterion names runs in CI on three platforms rather than once by hand.",
+      "status": "passing",
+      "verification": [
+        "A seeded project holds a pls_d node that runs, with pending_estimators empty.",
+        "GET /api/results/pls_d serves task 'regression' with eigenvalues as long as n_components, and the metrics table.",
+        "The T2 ellipse radii are finite for a regression - asserted in the frontend unit tests.",
+        "npx playwright test - the whole suite, including the failing-branch tests.",
+        "uv run ruff check && uv run ruff format --check && uv run mypy && uv run pytest"
+      ],
+      "evidence": "2026-09-05. `uv run python tests/seed_e2e.py --fresh <dir>` seeded '240 x 100, 15 nodes' (14 before) and every estimator produced a result: pca_a..pca_d task=decomposition, pls_d task=regression with eig=5. Served over HTTP from the seeded project: task regression, target fat, A=5, eigenvalues 5, RMSEC 2.2432, R2 0.9755, SEC 2.2750, RMSECV 2.3909, Q2 0.9722, rmsecv_std 0.4744, RMSEP 2.2122, SEP 2.2049, curve [4.863, 3.183, 2.762, 2.463, 2.391], 100 VIP and 100 coefficients on a 100-point axis. `npx playwright test` - 38 passed, having first caught two real failures: the runs seed uses the synthetic dataset, which carried no targets, so pls_d failed there with \"models target 'fat', which this dataset does not carry. It has: none.\" `npx vitest run` - 10 files, 78 tests (77 before). `uv run pytest` - 799 passed, 1 skipped. ruff check, ruff format --check (77 files), mypy (53 source files), tsc -b --noEmit and eslint all exit 0.",
+      "notes": "The seed's branch D was commented 'the path the exit criterion walks' and ended at a PCA, so nothing in the demo cross-validated anything. Adding pls_d needed no new dataset: Tecator carries fat and the seed already writes it. Two things fell out. First, a bug from #142: eigenvalues were published as an empty list for a regression, and analysis.ts:37 draws the T2 ellipse as sqrt(limit * eigenvalues[x]), so both radii were NaN. Unreachable until now because no fixture or demo had a PLS node to open - which is the argument for the demo covering the whole path. PLS.score_eigenvalues() is public now; the formula stays in one place. Second, the runs seed uses synthetic_dataset for a run slow enough to watch, and it had targets={}, so the shared pipeline could not fit there. It now carries a response built from two of its own band amplitudes, so PLS models something real rather than noise; no number is claimed from it, the same footing as the spectra. Playwright's hard-coded node and edge counts moved 14/13 to 15/14."
+    },
+    {
       "id": "pending-estimator-is-announced",
       "priority": 1,
       "area": "backend",

--- a/frontend/e2e/inspector.spec.ts
+++ b/frontend/e2e/inspector.spec.ts
@@ -49,7 +49,7 @@ test("an accepted edit marks downstream nodes stale and offers a re-run", async 
   expect(await page.getByTestId("node-stale").count()).toBeGreaterThan(staleBefore);
 
   // A stale result dims; it does not vanish. Every node is still on the canvas.
-  await expect(page.locator(".react-flow__node")).toHaveCount(14);
+  await expect(page.locator(".react-flow__node")).toHaveCount(15);
 
   // The re-run is offered, and taking it clears what the edit made stale.
   //
@@ -62,7 +62,7 @@ test("an accepted edit marks downstream nodes stale and offers a re-run", async 
   await page.getByRole("button", { name: "Re-run" }).click();
   await expect(page.getByText("Downstream results are stale.")).toHaveCount(0);
   await expect(page.getByTestId("node-stale")).toHaveCount(0);
-  await expect(page.getByTestId("node-complete")).toHaveCount(14);
+  await expect(page.getByTestId("node-complete")).toHaveCount(15);
 });
 
 test("provenance is collapsed until asked for, and hashes are truncated in the middle", async ({

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -18,8 +18,8 @@ async function openCanvas(page: Page) {
 
 test("the branching pipeline renders with every node the executor ran", async ({ page }) => {
   await openCanvas(page);
-  await expect(page.locator(".react-flow__node")).toHaveCount(14);
-  await expect(page.locator(".react-flow__edge")).toHaveCount(13);
+  await expect(page.locator(".react-flow__node")).toHaveCount(15);
+  await expect(page.locator(".react-flow__edge")).toHaveCount(14);
 
   // The node bodies carry their parameters, which is what makes the graph
   // readable without opening anything.
@@ -30,7 +30,7 @@ test("the branching pipeline renders with every node the executor ran", async ({
 test("a node that has been run is complete, and says so by form", async ({ page }) => {
   await openCanvas(page);
   await expect(page.getByTestId("node-complete").first()).toBeVisible();
-  await expect(page.getByTestId("node-complete")).toHaveCount(14);
+  await expect(page.getByTestId("node-complete")).toHaveCount(15);
 
   // Form, not only colour: complete is a solid border, which is what the other
   // four states are distinguished *from*.
@@ -99,10 +99,10 @@ test("dragging from an output port moves a branch onto a new parent", async ({ p
   await connect(page, "msc", "centre_a");
 
   // Exactly one input, so the old edge is replaced rather than added to: the
-  // graph keeps its thirteen edges and centre_a now reads from msc.
+  // graph keeps its fourteen edges and centre_a now reads from msc.
   await expect(page.locator('.react-flow__edge[data-id="msc->centre_a"]')).toHaveCount(1);
   await expect(page.locator('.react-flow__edge[data-id="snv->centre_a"]')).toHaveCount(0);
-  await expect(page.locator(".react-flow__edge")).toHaveCount(13);
+  await expect(page.locator(".react-flow__edge")).toHaveCount(14);
 });
 
 test("a connection that would make a cycle does not drop, and says why", async ({ page }) => {
@@ -126,7 +126,7 @@ test("removing a node reconnects its children to its parent", async ({ page }) =
   await expect(page.locator('.react-flow__node[data-id="snv"]')).toHaveCount(0);
   await expect(page.locator('.react-flow__edge[data-id="source->centre_a"]')).toHaveCount(1);
   await expect(page.locator('.react-flow__edge[data-id="source->snv_savgol"]')).toHaveCount(1);
-  await expect(page.locator(".react-flow__node")).toHaveCount(13);
+  await expect(page.locator(".react-flow__node")).toHaveCount(14);
 });
 
 test("the source has no remove control, because it is where the data enters", async ({ page }) => {

--- a/frontend/src/__tests__/analysis.test.ts
+++ b/frontend/src/__tests__/analysis.test.ts
@@ -117,3 +117,21 @@ it("lists exactly the samples the served limits put outside", () => {
   expect(beyond.length).toBeGreaterThan(0);
   expect(beyond.length).toBeLessThan(pca.n_samples);
 });
+
+describe("the T² ellipse on a regression", () => {
+  /* A PLS node reaches this screen through the same payload a PCA node does -
+   * `task` differs and the shared half does not. The ellipse is drawn from
+   * `eigenvalues`, which #142 published as an empty array for a regression, so
+   * both radii were `Math.sqrt(limit * undefined)`. Nothing caught it: the
+   * frozen `pca.json` fixture is a decomposition and no demo had a PLS node to
+   * open. #146 publishes the score variances and this asserts the consequence
+   * rather than the cause - radii that are numbers. */
+  it("has finite semi-axes, which an absent eigenvalue would not give", () => {
+    const regression: PcaPayload = { ...pca, task: "regression" };
+    const ellipse = ellipseTrace(regression, 0, 1, theme);
+
+    expect((ellipse.x as number[]).every(Number.isFinite)).toBe(true);
+    expect((ellipse.y as number[]).every(Number.isFinite)).toBe(true);
+    expect(Math.max(...(ellipse.x as number[]))).toBeGreaterThan(0);
+  });
+});

--- a/src/chemometrics_workbench/executor.py
+++ b/src/chemometrics_workbench/executor.py
@@ -985,7 +985,12 @@ def _pls(
         rows=[int(row) for row in rows],
         scores=_rows(model.x_scores_),
         loadings=_rows(np.asarray(model.x_loadings_).T),
-        eigenvalues=[],
+        # The score variances, not a decomposition's spectrum of them - but the
+        # same quantity `PCA.eigenvalues_` carries and the same one the T2
+        # ellipse is drawn from. #142 published an empty list here on the
+        # reasoning that "a PLS model reports no rank of its own", which is
+        # true of `rank` and irrelevant to these; the ellipse came out NaN.
+        eigenvalues=_values(model.score_eigenvalues()),
         explained_variance_ratio=_values(model.explained_variance_ratio("x")),
         cumulative_explained_variance=_values(model.cumulative_explained_variance("x")),
         y_explained_variance_ratio=_values(model.explained_variance_ratio("y")),

--- a/src/chemometrics_workbench/regression.py
+++ b/src/chemometrics_workbench/regression.py
@@ -360,7 +360,7 @@ class PLS:
         score matrix whose columns were correlated this sum would not be a
         Mahalanobis distance at all. Defaults to the calibration samples.
         """
-        eigenvalues = self._score_eigenvalues()
+        eigenvalues = self.score_eigenvalues()
         scores = self._fitted("x_scores_") if X is None else self.transform(X)
         t2: NDArray[np.float64] = ((scores**2) / eigenvalues).sum(axis=1)
         return t2
@@ -468,7 +468,15 @@ class PLS:
             raise self._unfitted()
         return self.n_components_
 
-    def _score_eigenvalues(self) -> NDArray[np.float64]:
+    def score_eigenvalues(self) -> NDArray[np.float64]:
+        """`lambda_a = t_a't_a / (n - 1)`, the variance each component's scores carry (§9).
+
+        Public because it is reported rather than internal: it is what
+        `hotelling_t2` divides by, and it is what a T-squared ellipse is drawn
+        from — `PCA.eigenvalues_` is the same quantity for the same purpose.
+        Publishing it was missed when #142 gave PLS a result, which left the
+        ellipse on a regression's scores plot with `NaN` radii (#146).
+        """
         scores = self._fitted("x_scores_")
         eigenvalues: NDArray[np.float64] = (scores**2).sum(axis=0) / (self._fitted_n_samples() - 1)
         return eigenvalues

--- a/tests/seed_e2e.py
+++ b/tests/seed_e2e.py
@@ -104,9 +104,14 @@ def synthetic_dataset(directory: Path, project, n_samples: int = 3000, n_variabl
     the slowest machine rather than the fastest is backwards.
 
     Generated, not measured, and **no number is claimed from it** - the same
-    footing as #86's decimation fixture. It is shaped like spectra (a smooth
-    baseline plus a few gaussian bands) so that SNV and Savitzky-Golay do the
-    work they would do on a real file rather than degenerating on noise.
+    footing as #86's decimation fixture. That covers the response as much as
+    the spectra: `fat` here is a linear combination of two band amplitudes
+    plus noise, so the PLS node in the demo pipeline models something real
+    rather than fitting noise, and it means nothing outside this file.
+
+    The spectra are shaped like spectra - a smooth baseline plus a few gaussian
+    bands - so that SNV and Savitzky-Golay do the work they would do on a real
+    file rather than degenerating on noise.
     """
     import numpy as np
 
@@ -122,12 +127,29 @@ def synthetic_dataset(directory: Path, project, n_samples: int = 3000, n_variabl
     axis = np.linspace(1000.0, 2500.0, n_variables)
     rng = np.random.default_rng(20260828)
     baseline = 0.6 + 0.25 * np.exp(-((axis - 1400.0) ** 2) / 90_000.0)
+    shapes = ((1210.0, 28.0), (1720.0, 41.0), (2100.0, 35.0), (2310.0, 22.0))
+    # Kept rather than summed away, because the response below is built from
+    # them: a target uncorrelated with the spectra would make the PLS node in
+    # the demo pipeline fit noise, and a run nobody can interpret is a worse
+    # demonstration than no run.
+    amplitudes = rng.uniform(0.05, 0.35, (len(shapes), n_samples, 1))
     bands = sum(
-        rng.uniform(0.05, 0.35, (n_samples, 1)) * np.exp(-((axis - centre) ** 2) / (2 * width**2))
-        for centre, width in ((1210.0, 28.0), (1720.0, 41.0), (2100.0, 35.0), (2310.0, 22.0))
+        amplitude * np.exp(-((axis - centre) ** 2) / (2 * width**2))
+        for amplitude, (centre, width) in zip(amplitudes, shapes, strict=True)
     )
     spectra = baseline + bands + rng.normal(0.0, 0.002, (n_samples, n_variables))
     spectra *= rng.uniform(0.9, 1.1, (n_samples, 1))  # the scatter SNV is for
+
+    # A response two of the bands genuinely drive, so PLS has something to
+    # find. Named `fat` because `demo_pipeline` is shared with the Tecator
+    # seed and a pipeline cannot name two different columns. **No number is
+    # claimed from it**, the same footing as the spectra above.
+    response = (
+        18.0
+        + 40.0 * amplitudes[1, :, 0]
+        + 15.0 * amplitudes[3, :, 0]
+        + rng.normal(0.0, 0.35, n_samples)
+    )
 
     array_path, content_hash = write_array(directory, spectra)
     dataset = Dataset(project_id=project.project_id, name="synthetic_wide", description="")
@@ -139,7 +161,7 @@ def synthetic_dataset(directory: Path, project, n_samples: int = 3000, n_variabl
         n_variables=n_variables,
         axis=VariableAxis(kind=AxisKind.WAVELENGTH_NM, values=[float(v) for v in axis], unit="nm"),
         sample_ids=[f"S{index + 1:04d}" for index in range(n_samples)],
-        targets={},
+        targets={"fat": [float(value) for value in response]},
         source=SourceFile(
             filename="synthetic_wide.npy",
             file_hash=content_hash,
@@ -169,6 +191,7 @@ def build_pipeline(project_id: UUID, version_id: UUID):  # type: ignore[no-untyp
         MeanCentre,
         PCASpec,
         Pipeline,
+        PLSRegressionSpec,
         PreprocessNode,
         SavitzkyGolay,
         SourceNode,
@@ -198,6 +221,16 @@ def build_pipeline(project_id: UUID, version_id: UUID):  # type: ignore[no-untyp
             SplitNode(id="split_d", inputs=("snv_savgol",), spec=KFoldSplit(n_splits=10, seed=42)),
             PreprocessNode(id="centre_d", inputs=("split_d",), step=MeanCentre()),
             EstimatorNode(id="pca_d", inputs=("centre_d",), spec=PCASpec(n_components=5)),
+            # ...and the calibration the criterion actually asks for. Until
+            # #146 the branch called "the path the exit criterion walks" ended
+            # at a decomposition, so nothing in the demo cross-validated
+            # anything. Tecator carries `fat`, the CSV above writes it and the
+            # reader classifies it, so this needs no new dataset.
+            EstimatorNode(
+                id="pls_d",
+                inputs=("centre_d",),
+                spec=PLSRegressionSpec(n_components=5, target="fat"),
+            ),
         ],
     )
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -876,6 +876,12 @@ def test_a_pls_node_is_fitted_and_its_result_is_a_regression(
     assert len(result.observed) == len(result.predicted) == version.n_samples
     assert len(result.coefficients) == version.n_variables
     assert len(result.vip) == version.n_variables
+    # One per component, because the T-squared ellipse is drawn from these and
+    # `analysis.ts` indexes them directly. #142 published an empty list and the
+    # ellipse came out with NaN radii; nothing caught it because no fixture or
+    # demo had a PLS node to draw (#146).
+    assert len(result.eigenvalues) == result.n_components
+    assert all(value > 0 for value in result.eigenvalues)
 
 
 def test_the_executor_computes_nothing_the_kernels_do_not(


### PR DESCRIPTION
`tests/seed_e2e.py` builds the project the Playwright suite walks — Tecator through the real import handler, the real pipeline store, `executor.execute`. Genuinely end to end, green on three platforms. **And every estimator in it was a PCA.**

The branch its own comment calls *"the path the exit criterion walks"* (`snv_savgol → split_d → centre_d`) ended at a `PCASpec`. So the criterion's PLS stretch — fit, cross-validate, read the metrics back — had been run exactly once, by hand, over curl, against data in a scratch directory. Recorded in evidence strings and nowhere that runs.

One node fixes it, and needs no new dataset:

```python
EstimatorNode(id="pls_d", inputs=("centre_d",),
              spec=PLSRegressionSpec(n_components=5, target="fat")),
```

## Two bugs fell out of adding it

Which is the argument for the demo covering the whole path rather than most of it.

**The T² ellipse was drawing `NaN` on a regression.** #142 published `eigenvalues=[]` for PLS, on the reasoning that *"a PLS model reports no rank of its own"* — true of `rank`, irrelevant to these. `frontend/src/plot/analysis.ts:37` draws the ellipse as `Math.sqrt(limit * pca.eigenvalues[x])`, so both radii were `NaN`. Unreachable until now because no fixture, test or demo had a PLS node to open.

`PLS.hotelling_t2` already computed the quantity — `λ_a = t_a't_a/(n−1)`, the same thing `PCA.eigenvalues_` carries, for the same purpose — through a private helper. `score_eigenvalues()` is public now and the formula stays in one place; the executor does not restate it.

**The runs seed could not fit the shared pipeline.** It uses `synthetic_dataset` for a run slow enough for a browser to catch a node `running`, and that carried `targets={}`. Playwright found it:

```
node 'pls_d' (pls) models target 'fat', which this dataset does not carry. It has: none.
```

Which is exactly the sentence that executor error was built to give — it named the node, the target and the columns available. The synthetic set now carries a response built from two of its own band amplitudes, so PLS models something real rather than noise. **No number is claimed from it**, the same footing as the spectra.

## Verification

Seeded and served:

```
seeded …/demo: 240 x 100, 15 nodes        (14 before)
pca_a..pca_d  task=decomposition          pls_d  task=regression  eig=5

GET /api/results/pls_d   target fat   A=5   eigenvalues 5
  RMSEC  2.2432   R2 0.9755   SEC 2.2750
  RMSECV 2.3909   Q2 0.9722   rmsecv_std 0.4744
  RMSEP  2.2122   SEP 2.2049
  curve  [4.863, 3.183, 2.762, 2.463, 2.391]
  100 VIP, 100 coefficients, 100-point axis
```

`npx playwright test` — **38 passed**, run locally, after first catching both failures above. `npx vitest run` — 10 files, **78 tests** (77 before; the new one asserts finite ellipse radii, where the `NaN` would have shown). `uv run pytest` — 799 passed, 1 skipped. `ruff check`, `ruff format --check` (77 files), `mypy` (53 source files), `tsc -b --noEmit`, `eslint` all exit 0.

Playwright's hard-coded node and edge counts move 14/13 → 15/14 in `pipeline.spec.ts` and `inspector.spec.ts`.

## Not in scope

The regression half of the analysis screen — the metrics table, the RMSECV curve, predicted-versus-actual. `results/{node}` has served all of it since #142; this PR makes the **shared** half render correctly for both tasks. Drawing the half that has no counterpart on a decomposition is the next piece.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)