### PR TITLE
Draw a regression on the analysis screen

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -61,6 +61,27 @@
       "notes": "Cleanup found at the Phase 1.3 checkpoint, filed as #131 rather than folded into a feature branch. Six mappings were stated twice - once on the normal path, once in _import_json_project - and the copy that would be forgotten when a column is added is the import path, which has one test and no user until someone opens an old project. Two smaller things went with it: a test asserting datasets.json does not exist, which could no longer fail because nothing writes that file; and the server's lifespan leaving every SQLite engine holding its file, which costs nothing on process exit and is what locks a file on Windows. An unused-export scan flagged fourteen names - executor.NodeOutput, checks.PipelineWarning, project.PROJECT_FILE among them - and none was deleted: each is used inside its own module or is the type a caller receives, so removing them would be churn dressed as cleanup."
     },
     {
+      "id": "analysis-draws-a-regression",
+      "priority": 1,
+      "area": "frontend",
+      "issue": 148,
+      "title": "The analysis screen draws a regression, not only a decomposition",
+      "depends_on": [
+        "demo-walks-the-exit-criterion"
+      ],
+      "user_visible_behavior": "Opening a PLS node shows predicted versus measured, the RMSECV curve and the calibration metrics beside the scores and loadings it already showed. A metric the run could not compute renders as an em dash.",
+      "status": "passing",
+      "verification": [
+        "A PLS node's tab shows the three regression panels; a PCA node's tab shows none of them.",
+        "A metric the payload omits renders as an em dash rather than a zero.",
+        "Held-out points are a separate trace from calibration points.",
+        "npx vitest run, npx tsc -b --noEmit, npx eslint .",
+        "npx playwright test - the walkthrough and the analysis tab."
+      ],
+      "evidence": "2026-09-05. `npx playwright test` - 40 passed (38 before), including two new cases in e2e/analysis.spec.ts: the regression tab renders Scores, Loadings, Explained variance, Diagnostics, Predicted vs measured, RMSECV and Calibration metrics, with the header reading 'PLS on fat 5 components' and RMSECV and Q2 as its headline figures and neither showing an em dash; and a decomposition tab showing none of the three. `npx vitest run` - 10 files, 82 tests (78 before, +4 on the new traces: the 1:1 line spans both sets, held-out is its own trace, it is omitted above a split, and nothing is drawn for a decomposition). `npx tsc -b --noEmit` and `npx eslint .` exit 0. Backend untouched: uv run pytest 799 passed, 1 skipped; ruff check, ruff format --check (77 files) and mypy (53 source files) exit 0.",
+      "notes": "The design question that looked like a blocker was already answered: AnalysisResults.tsx's docstring calls the grid 'the layout Phase 2's predicted-vs-measured panel drops into rather than one that has to be torn up', and the second row carried the slot in a comment. No new screen, no artboard round-trip - the panels dropped into a grid built to take them. Three things were found on the way. The Playwright config serves frontend/dist, a built bundle, so an app-source change needs npm run build before the e2e suite sees it - an earlier run passed only because the changes were test-side. 'RMSECV' appears four times on one screen (header figure, panel title, axis title, metric row), so getByText was a strict-mode violation; Panel's section now carries aria-label={title}, which is the markup a named section already implied and makes panels addressable by name. And a pls node had no case in the sidebar's label switch, so it rendered its own id; it now reads 'PLS 5 LV / fat', latent variables rather than PCs because two PLS nodes differ by what they model. VIP and the coefficient plot are deliberately left: both are served, neither is needed to read a calibration, and the second row is full."
+    },
+    {
       "id": "canvas-direct-editing",
       "priority": 1,
       "area": "frontend",

--- a/frontend/e2e/analysis.spec.ts
+++ b/frontend/e2e/analysis.spec.ts
@@ -87,3 +87,47 @@ test("hovering a score names its sample", async ({ page }) => {
   await expect(page.locator(".hovertext")).toBeVisible();
   await expect(page.locator(".hovertext")).toContainText(/C\d{3}|E\d{3}/);
 });
+
+test("a regression tab draws what a decomposition has no counterpart for", async ({ page }) => {
+  await page.goto("/?token=e2e-token");
+  const outline = page.getByRole("complementary", { name: "Project outline" });
+  await outline.getByRole("button", { name: /PLS 5 LV/ }).first().dblclick();
+
+  // The shared half renders, because a regression and a decomposition mean the
+  // same thing by scores, loadings and both diagnostics.
+  await expect(page.getByTestId("scores-plot")).toBeVisible();
+  for (const panel of ["Scores", "Loadings", "Explained variance", "Diagnostics"]) {
+    await expect(page.getByRole("region", { name: panel })).toBeVisible();
+  }
+
+  // And the half it does not: the row Phase 1.1 reserved in a comment. By
+  // role and name rather than by text - "RMSECV" is also an axis title, a
+  // metric row and a header figure on this same screen.
+  for (const panel of ["Predicted vs measured", "RMSECV", "Calibration metrics"]) {
+    await expect(page.getByRole("region", { name: panel })).toBeVisible();
+  }
+  await expect(page.getByTestId("predicted-plot")).toBeVisible();
+  await expect(page.getByTestId("rmsecv-plot")).toBeVisible();
+
+  // The header says what the model is and leads with the two numbers that say
+  // whether it generalises, rather than PC1 and cumulative variance.
+  const header = page.getByTestId("analysis-header");
+  await expect(header).toContainText("PLS on fat 5 components · 216 × 100");
+  await expect(header).toContainText("RMSECV");
+  await expect(header).toContainText("Q²");
+
+  // A metric the payload carries is a number; one it omits is an em dash, per
+  // metrics-and-validation.md section 11. This node is below a split, so
+  // RMSECV is present - and nothing here is ever rendered as 0.0000.
+  await expect(page.getByTestId("metric-RMSECV")).not.toHaveText("—");
+  await expect(page.getByTestId("metric-Q²")).not.toHaveText("—");
+});
+
+test("a decomposition tab is unchanged, and shows none of the regression panels", async ({
+  page,
+}) => {
+  await openResults(page);
+  for (const panel of ["Predicted vs measured", "RMSECV", "Calibration metrics"]) {
+    await expect(page.getByRole("region", { name: panel })).toHaveCount(0);
+  }
+});

--- a/frontend/src/__tests__/analysis.test.ts
+++ b/frontend/src/__tests__/analysis.test.ts
@@ -16,6 +16,8 @@ import {
   ellipseTrace,
   loadingsTraces,
   outliers,
+  predictedTraces,
+  rmsecvTrace,
   scoresTrace,
   varianceFigure,
 } from "@/plot/analysis";
@@ -133,5 +135,65 @@ describe("the T² ellipse on a regression", () => {
     expect((ellipse.x as number[]).every(Number.isFinite)).toBe(true);
     expect((ellipse.y as number[]).every(Number.isFinite)).toBe(true);
     expect(Math.max(...(ellipse.x as number[]))).toBeGreaterThan(0);
+  });
+});
+
+describe("a regression's own panels", () => {
+  /* `results/{node}` serves these only when `task === "regression"`. The
+   * fixture is a decomposition, so a regression payload is built from it -
+   * the shared half is genuinely identical, which is the point of #142's
+   * additive shape. */
+  const pls: PcaPayload = {
+    ...pca,
+    task: "regression",
+    regression: {
+      target: "fat",
+      observed: [10, 20, 30, 40],
+      predicted: [11, 19, 31, 39],
+      coefficients: [0.1, 0.2],
+      vip: [1.0, 0.9],
+      y_loadings: [0.5],
+      y_explained_variance_ratio: [0.8],
+    },
+    metrics: { rmsec: 1.0, rmsecv: 1.2, r2: 0.99 },
+    rmsecv_curve: [4.9, 3.2, 2.8, 2.5],
+  };
+
+  it("draws calibration against a 1:1 line, and held-out separately", () => {
+    const withHeld: PcaPayload = {
+      ...pls,
+      validation: {
+        fold: 0,
+        samples: [],
+        scores: [],
+        hotelling_t2: [],
+        spe: [],
+        observed: [15, 25],
+        predicted: [14, 26],
+      },
+    };
+    const traces = predictedTraces(withHeld, theme);
+
+    expect(traces).toHaveLength(3);
+    const [line, calibration, heldOut] = traces as Record<string, unknown>[];
+    // y = x across the full extent of both sets, not a fit of either.
+    expect(line.x).toEqual([10, 40]);
+    expect(line.y).toEqual([10, 40]);
+    expect(calibration.name).toBe("calibration");
+    expect(heldOut.name).toBe("held out");
+  });
+
+  it("omits the held-out trace when the node is not below a split", () => {
+    expect(predictedTraces(pls, theme)).toHaveLength(2);
+  });
+
+  it("draws nothing at all for a decomposition", () => {
+    expect(predictedTraces(pca, theme)).toEqual([]);
+  });
+
+  it("plots RMSECV against component count starting at one", () => {
+    const trace = rmsecvTrace(pls, theme) as Record<string, unknown>;
+    expect(trace.x).toEqual([1, 2, 3, 4]);
+    expect(trace.y).toEqual([4.9, 3.2, 2.8, 2.5]);
   });
 });

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -157,6 +157,34 @@ export interface PcaPayload {
     spe_limit: number;
     alpha: number;
   };
+  /** The held-out rows of the fitted fold, present only below a split. Its
+   * `observed` and `predicted` are there only for a regression. */
+  validation?: {
+    fold: number;
+    samples: { index: number; sample_id: string }[];
+    scores: number[][];
+    hotelling_t2: number[];
+    spe: number[];
+    observed?: number[];
+    predicted?: number[];
+  };
+  /** Present only when `task === "regression"`. The half of a PLS result that
+   * has no counterpart on a decomposition; everything above is shared. */
+  regression?: {
+    target: string | null;
+    observed: number[];
+    predicted: number[];
+    coefficients: number[];
+    vip: number[];
+    y_loadings: number[];
+    y_explained_variance_ratio: number[];
+  };
+  /** `metrics-and-validation.md` section 11's table, flat. **A metric that
+   * could not be computed is absent** - never zero, never NaN - so a reader
+   * must render `undefined` as an em dash rather than a number. */
+  metrics?: Partial<Record<string, number>>;
+  /** RMSECV against component count, one point per `A`. Empty above a split. */
+  rmsecv_curve?: number[];
 }
 
 export interface Job {

--- a/frontend/src/plot/analysis.ts
+++ b/frontend/src/plot/analysis.ts
@@ -120,3 +120,72 @@ export function outliers(pca: PcaPayload): { sample: string; t2: number; spe: nu
         row.t2 > pca.diagnostics.hotelling_t2_limit || row.spe > pca.diagnostics.spe_limit,
     );
 }
+
+/** Predicted against measured, with the 1:1 line a reader judges it against.
+ *
+ * Calibration and held-out rows are separate traces rather than one coloured
+ * series: they are different claims — a residual on a row the model was fitted
+ * on and one on a row it never saw — and `metrics-and-validation.md` §9 keeps
+ * them apart for that reason. Held-out rows take a second *series* colour and
+ * an open marker, deliberately not `stale`: that token is a warning about an
+ * outlier, and a validation row is not one.
+ *
+ * The line is drawn from the extremes of the data rather than from a
+ * regression of it: it is `y = x`, not a fit, and fitting one here would be
+ * deciding something rather than drawing it. */
+export function predictedTraces(pca: PcaPayload, theme: PlotTheme) {
+  const regression = pca.regression;
+  if (!regression) return [];
+
+  const held = pca.validation;
+  const all = [
+    ...regression.observed,
+    ...regression.predicted,
+    ...(held?.observed ?? []),
+    ...(held?.predicted ?? []),
+  ];
+  const low = Math.min(...all);
+  const high = Math.max(...all);
+
+  const points = (x: number[], y: number[], name: string, colour: string, open: boolean) => ({
+    type: "scattergl",
+    mode: "markers",
+    name,
+    x,
+    y,
+    marker: { size: 5, color: open ? "transparent" : colour, line: { width: 1, color: colour } },
+    hovertemplate: `${name}<br>measured %{x:.4g}<br>predicted %{y:.4g}<extra></extra>`,
+  });
+
+  return [
+    {
+      type: "scattergl",
+      mode: "lines",
+      name: "1:1",
+      x: [low, high],
+      y: [low, high],
+      line: { width: 1, dash: "dot", color: theme.grid },
+      hoverinfo: "skip",
+      showlegend: false,
+    },
+    points(regression.observed, regression.predicted, "calibration", theme.series[0], false),
+    ...(held?.observed && held.predicted
+      ? [points(held.observed, held.predicted, "held out", theme.series[1], true)]
+      : []),
+  ];
+}
+
+/** RMSECV against component count. One trace, because §9's curve is one
+ * experiment over one fold assignment rather than `A` unrelated ones. */
+export function rmsecvTrace(pca: PcaPayload, theme: PlotTheme) {
+  const curve = pca.rmsecv_curve ?? [];
+  return {
+    type: "scattergl",
+    mode: "lines+markers",
+    x: curve.map((_, index) => index + 1),
+    y: curve,
+    line: { width: 1.5, color: theme.series[0] },
+    marker: { size: 5, color: theme.series[0] },
+    hovertemplate: "A = %{x}<br>RMSECV %{y:.4g}<extra></extra>",
+  };
+}

--- a/frontend/src/screens/analysis/AnalysisResults.tsx
+++ b/frontend/src/screens/analysis/AnalysisResults.tsx
@@ -6,6 +6,8 @@ import {
   ellipseTrace,
   loadingsTraces,
   outliers,
+  predictedTraces,
+  rmsecvTrace,
   scoresTrace,
   varianceFigure,
 } from "@/plot/analysis";
@@ -237,6 +239,92 @@ function Diagnostics({ pca }: { pca: PcaPayload }) {
   );
 }
 
+/** `metrics-and-validation.md` §11: a metric that could not be computed is
+ * absent, never zero and never NaN, and absence renders as an em dash. RMSECV
+ * and Q² really are missing above a split and SEC really is missing when
+ * `n - A - 1 <= 0`, so printing 0.0000 would assert something false. */
+function metric(value: number | undefined, digits = 4) {
+  return value === undefined ? "—" : value.toFixed(digits);
+}
+
+function PredictedVsMeasured({ pca }: { pca: PcaPayload }) {
+  const host = usePlot(
+    (theme) => ({
+      data: predictedTraces(pca, theme),
+      layout: {
+        xaxis: axisLayout(theme, `Measured ${pca.regression?.target ?? ""}`),
+        yaxis: axisLayout(theme, "Predicted"),
+        margin: { l: 48, r: 12, t: 8, b: 38 },
+        showlegend: true,
+        legend: { orientation: "h", y: 1.02, yanchor: "bottom", x: 0, font: { size: 9.5 } },
+      },
+    }),
+    [pca],
+  );
+  const held = pca.validation?.observed?.length ?? 0;
+  return (
+    <Panel
+      title="Predicted vs measured"
+      note={held ? `${pca.n_samples} calibration · ${held} held out` : `${pca.n_samples} samples`}
+    >
+      <div ref={host} data-testid="predicted-plot" style={{ flex: 1, minHeight: 0 }} />
+    </Panel>
+  );
+}
+
+function RmsecvCurve({ pca }: { pca: PcaPayload }) {
+  const curve = pca.rmsecv_curve ?? [];
+  const host = usePlot(
+    (theme) => ({
+      data: [rmsecvTrace(pca, theme)],
+      layout: {
+        xaxis: { ...axisLayout(theme, "Components"), dtick: 1 },
+        yaxis: { ...axisLayout(theme, "RMSECV"), rangemode: "tozero" },
+        margin: { l: 48, r: 12, t: 8, b: 38 },
+      },
+    }),
+    [pca],
+  );
+  // The minimum is reported, never chosen: §9 says picking A there and then
+  // quoting that minimum as the model's expected error is optimistic, and that
+  // it is the user's call rather than the application's.
+  const best = curve.length ? curve.indexOf(Math.min(...curve)) + 1 : undefined;
+  return (
+    <Panel title="RMSECV" note={best ? `lowest at A = ${best}` : "needs a split"} width={340}>
+      <div ref={host} data-testid="rmsecv-plot" style={{ flex: 1, minHeight: 0 }} />
+    </Panel>
+  );
+}
+
+function RegressionMetrics({ pca }: { pca: PcaPayload }) {
+  const m = pca.metrics ?? {};
+  const rows: [string, string][] = [
+    ["RMSEC", metric(m.rmsec)],
+    ["RMSECV", metric(m.rmsecv)],
+    ["RMSEP", metric(m.rmsep)],
+    ["R²", metric(m.r2)],
+    ["Q²", metric(m.q2)],
+    ["Bias", metric(m.bias)],
+    ["SEC", metric(m.sec)],
+    ["SEP", metric(m.sep)],
+    ["RMSECV spread", metric(m.rmsecv_std)],
+  ];
+  return (
+    <Panel title="Calibration metrics" note={pca.regression?.target ?? ""} width={260}>
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto", padding: "6px 0" }}>
+        {rows.map(([label, value]) => (
+          <div className="kv" key={label}>
+            <b>{label}</b>
+            <span className="mono" data-testid={`metric-${label}`}>
+              {value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </Panel>
+  );
+}
+
 export function AnalysisResults({ nodeId, title }: { nodeId: string; title: string }) {
   const results = useResults(nodeId);
 
@@ -251,6 +339,7 @@ export function AnalysisResults({ nodeId, title }: { nodeId: string; title: stri
   }
 
   const pca = results.data;
+  const regression = pca.task === "regression";
   return (
     <div className="pane">
       <div
@@ -268,14 +357,23 @@ export function AnalysisResults({ nodeId, title }: { nodeId: string; title: stri
         <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
           <span style={{ fontWeight: 600, fontSize: 13.5 }}>{title}</span>
           <span className="mono" style={{ fontSize: 11, color: "var(--ink3)" }}>
-            PCA {pca.n_components} components · {pca.n_samples} × {pca.n_variables}
+            {regression ? `PLS on ${pca.regression?.target ?? "?"}` : "PCA"} {pca.n_components}{" "}
+            components · {pca.n_samples} × {pca.n_variables}
           </span>
         </div>
         <div style={{ display: "flex", alignItems: "stretch" }}>
-          {[
-            ["PC1", `${(pca.explained_variance_ratio[0] * 100).toFixed(1)}%`],
-            ["CUMULATIVE", `${(pca.cumulative_explained_variance.at(-1)! * 100).toFixed(1)}%`],
-          ].map(([label, value]) => (
+          {(regression
+            ? // What a reader of a calibration looks at first, and the pair
+              // that says whether it generalises. Absent renders as an em dash.
+              ([
+                ["RMSECV", metric(pca.metrics?.rmsecv)],
+                ["Q²", metric(pca.metrics?.q2, 3)],
+              ] as [string, string][])
+            : ([
+                ["PC1", `${(pca.explained_variance_ratio[0] * 100).toFixed(1)}%`],
+                ["CUMULATIVE", `${(pca.cumulative_explained_variance.at(-1)! * 100).toFixed(1)}%`],
+              ] as [string, string][])
+          ).map(([label, value]) => (
             <div
               key={label}
               style={{
@@ -317,9 +415,18 @@ export function AnalysisResults({ nodeId, title }: { nodeId: string; title: stri
         <div style={{ display: "flex", gap: 12, flex: 1, minHeight: 0 }}>
           <Variance pca={pca} />
           <Diagnostics pca={pca} />
-          {/* Predicted vs measured belongs here, and is Phase 2. The row is
-              laid out so it arrives beside these rather than replacing them. */}
         </div>
+        {/* The row this comment reserved in Phase 1.1, now filled. It arrives
+            beside the two above rather than replacing them, exactly as the
+            layout was drawn for - and only for a regression, because these
+            three have no counterpart on a decomposition. */}
+        {regression && (
+          <div style={{ display: "flex", gap: 12, flex: 1, minHeight: 0 }}>
+            <PredictedVsMeasured pca={pca} />
+            <RmsecvCurve pca={pca} />
+            <RegressionMetrics pca={pca} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/screens/analysis/Panel.tsx
+++ b/frontend/src/screens/analysis/Panel.tsx
@@ -18,6 +18,12 @@ export function Panel({
 }) {
   return (
     <section
+      // A `section` is only a landmark when it is named, so this is the markup
+      // the element already implied - and it makes a panel addressable by what
+      // it is called rather than by a chain of styles. Several panels repeat a
+      // word: "RMSECV" is a title, an axis label, a metric row and a header
+      // figure on one screen.
+      aria-label={title}
       style={{
         width: width ?? "auto",
         height,

--- a/frontend/src/shell/Sidebar.tsx
+++ b/frontend/src/shell/Sidebar.tsx
@@ -83,6 +83,11 @@ export function nodeLabel(node: PipelineNode): string {
       return `K-fold ${spec?.n_splits} · seed ${spec?.seed}`;
     case "pca":
       return `PCA ${spec?.n_components} PC`;
+    case "pls":
+      // Latent variables rather than PCs, and the response, because two PLS
+      // nodes on one branch differ by what they model rather than by their
+      // component count.
+      return `PLS ${spec?.n_components} LV · ${spec?.target}`;
     case "source":
       return "Source";
     default:


### PR DESCRIPTION
The last piece of the demo. Since #142 a PLS node fits and since #146 the seeded project contains one — but only half its result was visible. Scores, loadings, explained variance and the diagnostics render, because those mean the same thing for both tasks. The metrics, the RMSECV curve and predicted versus measured were served and not drawn.

So the demo ran a calibration whose result could not be read.

## The design question was already answered

Worth recording, because it looked like the blocker. `AnalysisResults.tsx`'s own docstring:

> the artboard's answer to open design question 11.1, and **the layout Phase 2's predicted-vs-measured panel drops into rather than one that has to be torn up**

and the second row carried the slot in a comment:

> `{/* Predicted vs measured belongs here, and is Phase 2. The row is laid out so it arrives beside these rather than replacing them. */}`

**No new screen, no artboard round-trip.** Three panels drop into a grid built to take them, in a row that appears only for a regression, beside the two already there rather than replacing them.

## What it draws

| Panel | From |
| --- | --- |
| Predicted vs measured | calibration and held-out as separate traces, over a 1:1 line drawn from the data's extremes — `y = x`, not a fit |
| RMSECV | `rmsecv_curve`, one point per component count |
| Calibration metrics | RMSEC, RMSECV, RMSEP, R², Q², bias, SEC, SEP, RMSECV spread |

The header reads `PLS on fat 5 components · 216 × 100` and leads with RMSECV and Q² instead of PC1 and cumulative variance.

**Absence renders as an em dash, never as a number.** RMSECV and Q² really are missing above a split, SEC really is missing when `n − A − 1 ≤ 0`, and printing `0.0000` there would assert something false. §11 requires the dash and the payload is built for it.

The RMSECV panel names the curve's lowest point and does not select it — §9 says choosing `A` there and then quoting that minimum as the expected error is optimistic, and that it is the user's call.

Held-out points take a second *series* colour rather than `stale`: that token is documented as "a warning, never a series", and a validation row is not a warning.

## Three things found on the way

- **Playwright serves `frontend/dist`, a built bundle**, so an app-source change needs `npm run build` before the suite sees it. An earlier run passed only because the changes were test-side.
- **"RMSECV" appears four times on one screen** — header figure, panel title, axis title, metric row — so `getByText` was a strict-mode violation. `Panel`'s `<section>` now carries `aria-label={title}`, which is the markup a named section already implied and makes panels addressable by what they are called.
- **A `pls` node had no case in the sidebar's label switch** and rendered its own id. It reads `PLS 5 LV · fat` now: latent variables rather than PCs, and the response, because two PLS nodes on one branch differ by what they model.

## Verification

`npx playwright test` — **40 passed** (38 before), run locally. Two new cases: the regression tab renders all seven panels with the right header and no em dash on RMSECV or Q²; a decomposition tab renders none of the three.

`npx vitest run` — 10 files, **82 tests** (78 before; +4 on the new traces: the 1:1 line spans both sets, held-out is its own trace, it is omitted above a split, nothing is drawn for a decomposition). `tsc -b --noEmit` and `eslint .` exit 0.

Backend untouched — `pytest` 799 passed, 1 skipped; `ruff`, `mypy` clean.

## Not in scope

VIP and the coefficient plot. Both are served and both are worth drawing, but neither is needed to read a calibration, the loadings panel already answers "which wavelengths matter", and the second row is full.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)