### PR TITLE
Duplicate a branch, and compare two terminal nodes

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -146,13 +146,13 @@
         "pls-in-the-executor"
       ],
       "user_visible_behavior": "A subgraph can be duplicated so a variant is built from an existing path rather than from scratch, and selecting two terminal nodes opens a tab comparing their results.",
-      "status": "not_started",
+      "status": "passing",
       "verification": [
         "The duplicate produces an independent branch with fresh node ids, asserted in the browser.",
         "Two terminal nodes open one comparison tab showing both models' metrics."
       ],
-      "evidence": "",
-      "notes": "Items 2 and 3 of #51, deliberately left for a second pass. The comparison tab is a screen with no artboard behind it and no metrics to compare until the executor fits PLS (#142), which is what makes 'compare two models' worth looking at. DESIGN_BRIEF.md section 5 is the reference."
+      "evidence": "2026-09-05. npx playwright test - 43 passed (40 before), including three new cases in e2e/pipeline.spec.ts: duplicating snv produces 'snv copy', 'centre_a copy' and 'pca_a copy' with an edge source->'snv copy', so the copy is a sibling branch; the source offers no duplicate control; and picking pca_a then pls_d opens a tab titled 'pca_a vs pls_d' whose difference column reads an em dash, because only pls_d carries regression metrics. The compare control is absent on snv, which is not terminal. npx vitest run - 11 files, 99 tests (92 before, +7 on compareRows and +8 on duplicate and terminals). npx tsc -b --noEmit and npx eslint . exit 0. Backend untouched: uv run pytest 809 passed, 1 skipped.",
+      "notes": "Items 2 and 3 of #51, deliberately left for a second pass. The comparison tab is a screen with no artboard behind it and no metrics to compare until the executor fits PLS (#142), which is what makes 'compare two models' worth looking at. DESIGN_BRIEF.md section 5 is the reference. Duplicate and terminals are pure functions in edits.ts, tested without a browser like the first half's rules. A copy hangs off the original's parent rather than below it, because a chain is not what 'duplicate' means on a graph whose point is comparison, and ids are derived ('snv copy', then 'snv copy 2') rather than random: a pipeline is read by a person and 'snv copy' beside 'snv' says what happened. Comparison is two clicks rather than a multi-select, because a click on a node body already means 'open this' and selection would need a modifier nobody is told about; the armed node saying so is the affordance. The tab id carries both nodes so picking the same pair twice reuses the tab. The difference column is a subtraction of two served numbers, never a statistic, and it points an arrow without declaring a winner - which model is better depends on what is being calibrated for. A metric only one side carries is kept because that is itself the finding; one neither carries is dropped rather than shown as two dashes."
     },
     {
       "id": "pls-in-the-executor",

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -138,3 +138,54 @@ test("the source has no remove control, because it is where the data enters", as
     page.locator('.react-flow__node[data-id="snv"] button[aria-label^="Remove node"]'),
   ).toHaveCount(1);
 });
+
+test("duplicating a branch copies it and everything below it", async ({ page }) => {
+  await openCanvas(page);
+  const before = await page.locator(".react-flow__node").count();
+
+  // snv feeds centre_a and snv_savgol, so duplicating it copies a whole branch
+  // rather than a node.
+  await page
+    .locator('.react-flow__node[data-id="snv"] button[aria-label^="Duplicate node"]')
+    .click();
+
+  await expect(page.locator('.react-flow__node[data-id="snv copy"]')).toHaveCount(1);
+  await expect(page.locator('.react-flow__node[data-id="centre_a copy"]')).toHaveCount(1);
+  await expect(page.locator('.react-flow__node[data-id="pca_a copy"]')).toHaveCount(1);
+  // The copy is a sibling branch: it reads from snv's own parent, not from snv.
+  await expect(page.locator('.react-flow__edge[data-id="source->snv copy"]')).toHaveCount(1);
+  expect(await page.locator(".react-flow__node").count()).toBeGreaterThan(before);
+});
+
+test("the source offers no duplicate control, because it cannot be copied", async ({ page }) => {
+  await openCanvas(page);
+  await expect(
+    page.locator('.react-flow__node[data-id="source"] button[aria-label^="Duplicate node"]'),
+  ).toHaveCount(0);
+});
+
+test("picking two terminal nodes opens a comparison tab", async ({ page }) => {
+  await openCanvas(page);
+
+  // Offered on terminal estimators only: pca_a is one, snv is not.
+  await expect(
+    page.locator('.react-flow__node[data-id="snv"] button[aria-label*="for comparison"]'),
+  ).toHaveCount(0);
+
+  const armed = page.locator('.react-flow__node[data-id="pca_a"] button[aria-label^="Pick"]');
+  await expect(armed).toHaveCount(1);
+  await armed.click();
+  // The first pick arms rather than opening anything, and says it is armed.
+  await expect(
+    page.locator('.react-flow__node[data-id="pca_a"] button[aria-label^="Unpick"]'),
+  ).toHaveCount(1);
+
+  await page.locator('.react-flow__node[data-id="pls_d"] button[aria-label^="Pick"]').click();
+
+  await expect(page.getByRole("tab", { name: /pca_a vs pls_d/ })).toBeVisible();
+  await expect(page.getByTestId("compare-view")).toBeVisible();
+  // Only pls_d carries regression metrics, so every row is one-sided and the
+  // difference column is an em dash rather than a number.
+  await expect(page.getByRole("region", { name: "Metrics" })).toBeVisible();
+  await expect(page.getByTestId("delta-RMSECV")).toHaveText("—");
+});

--- a/frontend/src/__tests__/compare.test.ts
+++ b/frontend/src/__tests__/compare.test.ts
@@ -1,0 +1,75 @@
+/** The comparison table's arithmetic, without a browser.
+ *
+ * The rule from #48 holds here too: nothing is computed in the frontend. The
+ * difference column is a subtraction of two numbers the server sent, which is
+ * arithmetic on displayed values rather than a statistic - and this is where
+ * that distinction is pinned.
+ */
+import { describe, expect, it } from "vitest";
+
+import { compareRows } from "@/screens/analysis/CompareResults";
+
+describe("comparing two results", () => {
+  it("subtracts the left from the right, and says which is better", () => {
+    const rows = compareRows({ rmsecv: 2.4 }, { rmsecv: 2.1 });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].delta).toBeCloseTo(-0.3, 10);
+    // Lower is better for an error, so the right-hand model wins.
+    expect(rows[0].better).toBe(true);
+  });
+
+  it("reverses that for a metric where higher is better", () => {
+    expect(compareRows({ q2: 0.9 }, { q2: 0.95 })[0].better).toBe(true);
+    expect(compareRows({ q2: 0.95 }, { q2: 0.9 })[0].better).toBe(false);
+    expect(compareRows({ rmsecv: 1.0 }, { rmsecv: 2.0 })[0].better).toBe(false);
+  });
+
+  it("calls a tie neither, rather than picking one", () => {
+    expect(
+      compareRows({ rmsec: 1.5 }, { rmsec: 1.5 })[0].better,
+    ).toBeUndefined();
+  });
+
+  it("keeps a metric only one of them carries, with no difference", () => {
+    const rows = compareRows({ rmsecv: 2.4 }, {});
+    expect(rows).toHaveLength(1);
+    expect(rows[0].a).toBe(2.4);
+    expect(rows[0].b).toBeUndefined();
+    expect(rows[0].delta).toBeUndefined();
+    expect(rows[0].better).toBeUndefined();
+  });
+
+  it("drops a metric neither carries rather than showing an empty row", () => {
+    expect(
+      compareRows({ rmsec: 1.0 }, { rmsec: 1.1 }).map((row) => row.metric),
+    ).toEqual(["rmsec"]);
+  });
+
+  it("has nothing to say about two decompositions", () => {
+    expect(compareRows(undefined, undefined)).toEqual([]);
+    expect(compareRows({}, {})).toEqual([]);
+  });
+
+  it("lists the metrics in the order section 11 does", () => {
+    const both = {
+      rmsec: 1,
+      rmsecv: 1,
+      rmsep: 1,
+      r2: 1,
+      q2: 1,
+      bias: 1,
+      sec: 1,
+      sep: 1,
+    };
+    expect(compareRows(both, both).map((row) => row.metric)).toEqual([
+      "rmsec",
+      "rmsecv",
+      "rmsep",
+      "r2",
+      "q2",
+      "bias",
+      "sec",
+      "sep",
+    ]);
+  });
+});

--- a/frontend/src/__tests__/edits.test.ts
+++ b/frontend/src/__tests__/edits.test.ts
@@ -8,7 +8,15 @@
 import { describe, expect, it } from "vitest";
 
 import type { PipelineNode } from "@/api/queries";
-import { connect, connectionRefusal, remove, removalRefusal } from "@/canvas/edits";
+import {
+  connect,
+  connectionRefusal,
+  duplicate,
+  duplicationRefusal,
+  remove,
+  removalRefusal,
+  terminals,
+} from "@/canvas/edits";
 
 /** source → snv → pca, the shape the walkthrough builds. */
 const chain: PipelineNode[] = [
@@ -98,5 +106,87 @@ describe("removing", () => {
 
   it("refuses a node that is not in the pipeline", () => {
     expect(removalRefusal(chain, "pls")).toContain("not in this pipeline");
+  });
+});
+
+describe("duplicating a subgraph", () => {
+  /** source → snv → centre → pca, plus a second branch, so a copy has to take
+   * only what is below its root. */
+  const forked: PipelineNode[] = [
+    { id: "source", type: "source", inputs: [], version_id: "v1" },
+    { id: "snv", type: "preprocess", inputs: ["source"], step: { kind: "snv" } },
+    { id: "centre", type: "preprocess", inputs: ["snv"], step: { kind: "mean_centre" } },
+    { id: "pca", type: "estimator", inputs: ["centre"], spec: { kind: "pca", n_components: 5 } },
+    { id: "msc", type: "preprocess", inputs: ["source"], step: { kind: "msc" } },
+  ];
+
+  it("copies the root and everything below it, and nothing beside it", () => {
+    const after = duplicate(forked, "snv");
+    const added = after.filter((node) => !forked.some((original) => original.id === node.id));
+
+    expect(added.map((node) => node.id)).toEqual(["snv copy", "centre copy", "pca copy"]);
+    // msc is a sibling of snv, not a descendant, so it is untouched.
+    expect(added.some((node) => node.id.startsWith("msc"))).toBe(false);
+  });
+
+  it("hangs the copy off the original's parent, making a branch not a chain", () => {
+    const after = duplicate(forked, "snv");
+
+    expect(after.find((node) => node.id === "snv copy")!.inputs).toEqual(["source"]);
+    // Everything below points at its own copy, never back at the original.
+    expect(after.find((node) => node.id === "centre copy")!.inputs).toEqual(["snv copy"]);
+    expect(after.find((node) => node.id === "pca copy")!.inputs).toEqual(["centre copy"]);
+  });
+
+  it("leaves the original branch exactly as it was", () => {
+    const after = duplicate(forked, "snv");
+    for (const original of forked) {
+      expect(after.find((node) => node.id === original.id)).toEqual(original);
+    }
+  });
+
+  it("numbers a second copy rather than colliding with the first", () => {
+    const ids = duplicate(duplicate(forked, "snv"), "snv").map((node) => node.id);
+
+    expect(ids).toContain("snv copy");
+    expect(ids).toContain("snv copy 2");
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("copies a leaf on its own", () => {
+    const after = duplicate(forked, "pca");
+    expect(after.find((node) => node.id === "pca copy")!.inputs).toEqual(["centre"]);
+    expect(after).toHaveLength(forked.length + 1);
+  });
+
+  it("refuses the source, and says why", () => {
+    expect(duplicationRefusal(forked, "source")).toMatch(/data enters/);
+    expect(() => duplicate(forked, "source")).toThrow(/data enters/);
+  });
+
+  it("refuses a node that is not in the pipeline", () => {
+    expect(duplicationRefusal(forked, "ghost")).toMatch(/not in this pipeline/);
+  });
+
+  it("allows every other node", () => {
+    for (const id of ["snv", "centre", "pca", "msc"]) {
+      expect(duplicationRefusal(forked, id)).toBeNull();
+    }
+  });
+});
+
+describe("terminal nodes", () => {
+  it("are the ones nothing reads from", () => {
+    const forked: PipelineNode[] = [
+      { id: "source", type: "source", inputs: [], version_id: "v1" },
+      { id: "snv", type: "preprocess", inputs: ["source"], step: { kind: "snv" } },
+      { id: "pca_a", type: "estimator", inputs: ["snv"], spec: { kind: "pca", n_components: 5 } },
+      { id: "pca_b", type: "estimator", inputs: ["snv"], spec: { kind: "pca", n_components: 3 } },
+    ];
+    expect(terminals(forked).map((node) => node.id)).toEqual(["pca_a", "pca_b"]);
+  });
+
+  it("is the last node of a plain chain", () => {
+    expect(terminals(chain).map((node) => node.id)).toEqual(["pca"]);
   });
 });

--- a/frontend/src/canvas/NodeCard.tsx
+++ b/frontend/src/canvas/NodeCard.tsx
@@ -94,19 +94,49 @@ export function NodeCard({ data, selected }: NodeProps) {
             that rule, and the source has no control at all because it is where
             the data enters. The click is stopped here: it would otherwise also
             open the node's tab, which is what a click on the body means. */}
-        {node.onRemove ? (
-          <button
-            className="tabx"
-            aria-label={`Remove node ${node.label}`}
-            style={{ marginLeft: "auto" }}
-            onClick={(event) => {
-              event.stopPropagation();
-              node.onRemove!();
-            }}
-          >
-            ×
-          </button>
-        ) : null}
+        <span style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 2 }}>
+          {/* Comparing is a toggle, not a verb: the first click arms it and the
+              second node opens the tab, so an armed node has to say it is armed.
+              Offered only where there is something to compare. */}
+          {node.onCompare ? (
+            <button
+              className="tabx"
+              aria-label={`${node.comparing ? "Unpick" : "Pick"} ${node.label} for comparison`}
+              aria-pressed={node.comparing}
+              style={{ color: node.comparing ? "var(--accentInk)" : undefined }}
+              onClick={(event) => {
+                event.stopPropagation();
+                node.onCompare!();
+              }}
+            >
+              ⇄
+            </button>
+          ) : null}
+          {node.onDuplicate ? (
+            <button
+              className="tabx"
+              aria-label={`Duplicate node ${node.label}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                node.onDuplicate!();
+              }}
+            >
+              ⧉
+            </button>
+          ) : null}
+          {node.onRemove ? (
+            <button
+              className="tabx"
+              aria-label={`Remove node ${node.label}`}
+              onClick={(event) => {
+                event.stopPropagation();
+                node.onRemove!();
+              }}
+            >
+              ×
+            </button>
+          ) : null}
+        </span>
       </div>
 
       <div style={{ flex: 1, padding: "5px 8px 0", minHeight: 0 }}>

--- a/frontend/src/canvas/PipelineCanvas.tsx
+++ b/frontend/src/canvas/PipelineCanvas.tsx
@@ -1,12 +1,12 @@
 import { Background, BackgroundVariant, ReactFlow, type Node } from "@xyflow/react";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 import { ApiError, api } from "@/api/client";
 import type { PipelineNode } from "@/api/queries";
 import { usePipeline, usePipelineState, useSavePipeline } from "@/api/queries";
 import { NodeCard } from "@/canvas/NodeCard";
 import { StepList } from "@/canvas/StepList";
-import { connect, connectionRefusal, remove } from "@/canvas/edits";
+import { connect, connectionRefusal, duplicate, remove, terminals } from "@/canvas/edits";
 import { draftGraph, toEdges, toNodes, type DraftStep } from "@/canvas/graph";
 import { nodeLabel } from "@/shell/Sidebar";
 
@@ -70,7 +70,14 @@ export function withDrafts(saved: PipelineNode[], drafts: DraftStep[]): Pipeline
 }
 
 
-export function PipelineCanvas({ onOpenNode }: { onOpenNode: (id: string, label: string) => void }) {
+export function PipelineCanvas({
+  onOpenNode,
+  onCompare,
+}: {
+  onOpenNode: (id: string, label: string) => void;
+  /** Opens the comparison tab once two terminal estimators are picked (#51). */
+  onCompare?: (left: string, right: string) => void;
+}) {
   const pipeline = usePipeline();
   const state = usePipelineState();
   const save = useSavePipeline();
@@ -82,6 +89,9 @@ export function PipelineCanvas({ onOpenNode }: { onOpenNode: (id: string, label:
   // and never reports the drop it refused. The reason for the last refusal is
   // kept here so the end of the drag can say why nothing happened.
   const refusal = useRef<string | null>(null);
+  /** The nodes picked for a comparison. Two opens the tab and clears it, so
+   * the control is a toggle with a very short memory rather than a mode. */
+  const [picked, setPicked] = useState<string[]>([]);
 
   // Memoised because it feeds the graph's useMemo: a fresh [] every render
   // would rebuild the whole graph on every keystroke elsewhere in the tab.
@@ -90,13 +100,44 @@ export function PipelineCanvas({ onOpenNode }: { onOpenNode: (id: string, label:
     [edited, pipeline.data],
   );
 
+  /** Pick a node for comparison; the second pick opens the tab.
+   *
+   * Two clicks rather than a multi-select because a click on a node body
+   * already means "open this", so a selection would need a modifier nobody is
+   * told about. The armed node saying so is the affordance instead.
+   *
+   * Memoised for the same reason `nodes` is: it feeds the graph's useMemo, and
+   * a fresh function each render would rebuild the whole graph.
+   */
+  const pick = useCallback(
+    (id: string) => {
+      setPicked((current) => {
+        if (current.includes(id)) return current.filter((other) => other !== id);
+        const next = [...current, id];
+        if (next.length < 2) return next;
+        onCompare?.(next[0], next[1]);
+        return [];
+      });
+    },
+    [onCompare],
+  );
+
   const graph = useMemo(() => {
     if (!pipeline.data) return { nodes: [], edges: [] };
     const style = getComputedStyle(document.documentElement);
     const token = (name: string) => style.getPropertyValue(`--${name}`).trim() || "currentColor";
     const committed = {
-      nodes: toNodes({ ...pipeline.data, nodes }, state.data, nodeLabel, (id) =>
-        edit(() => remove(nodes, id)),
+      nodes: toNodes(
+        { ...pipeline.data, nodes },
+        state.data,
+        nodeLabel,
+        (id) => edit(() => remove(nodes, id)),
+        onCompare && {
+          ids: picked,
+          terminals: new Set(terminals(nodes).map((node) => node.id)),
+          onCompare: pick,
+        },
+        (id) => edit(() => duplicate(nodes, id)),
       ),
       edges: toEdges(
         { ...pipeline.data, nodes },
@@ -108,7 +149,7 @@ export function PipelineCanvas({ onOpenNode }: { onOpenNode: (id: string, label:
     const lowest = Math.max(...committed.nodes.map((node) => node.position.y), 0);
     const draft = draftGraph(steps, { x: 40, y: lowest + 150 });
     return { nodes: [...committed.nodes, ...draft.nodes], edges: [...committed.edges, ...draft.edges] };
-  }, [pipeline.data, state.data, steps, nodes]);
+  }, [pipeline.data, state.data, steps, nodes, picked, onCompare, pick]);
 
   /** An edit that a rule refuses says so, rather than throwing into the void. */
   const edit = (apply: () => PipelineNode[]) => {

--- a/frontend/src/canvas/edits.ts
+++ b/frontend/src/canvas/edits.ts
@@ -105,3 +105,77 @@ export function remove(nodes: PipelineNode[], id: string): PipelineNode[] {
     .filter((node) => node.id !== id)
     .map((node) => (parentOf(node) === id ? { ...node, inputs: [inherited] } : node));
 }
+
+/** Why this subgraph cannot be duplicated, or null. */
+export function duplicationRefusal(nodes: PipelineNode[], id: string): string | null {
+  const node = nodes.find((candidate) => candidate.id === id);
+  if (!node) return "That node is not in this pipeline.";
+  if (node.type === "source") {
+    return "The source is where the data enters — duplicating it would copy the whole pipeline.";
+  }
+  return null;
+}
+
+/** An unused id derived from `base`: `snv copy`, then `snv copy 2`, and so on. */
+function freeId(taken: Set<string>, base: string): string {
+  const first = `${base} copy`;
+  if (!taken.has(first)) return first;
+  for (let n = 2; ; n += 1) {
+    const candidate = `${first} ${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/** Copy `id` and everything below it, hanging the copy off the same parent.
+ *
+ * **This is what the canvas is for.** DESIGN_BRIEF.md section 5 draws one
+ * dataset forked into four competing preprocessing paths, and building the
+ * fourth by hand when it differs from the third by one parameter is the work
+ * this removes: duplicate the branch, then edit the copy.
+ *
+ * The copy reads from the original's parent, so it is a sibling branch rather
+ * than a continuation - attaching it below the original would make a chain,
+ * which is not what "duplicate" means on a graph whose point is comparison.
+ *
+ * Ids are derived rather than random. A pipeline is read by a person, and
+ * `snv copy` beside `snv` says what happened; a uuid says only that something
+ * did. `models.py` types `NodeId` as a plain string, so a space is legal.
+ */
+export function duplicate(nodes: PipelineNode[], id: string): PipelineNode[] {
+  const refusal = duplicationRefusal(nodes, id);
+  if (refusal) throw new Error(refusal);
+
+  const copied = descendants(nodes, id);
+  const taken = new Set(nodes.map((node) => node.id));
+  const renamed = new Map<string, string>();
+  // In the pipeline's own order, so a parent is always renamed before the
+  // child that has to point at its new name.
+  for (const node of nodes) {
+    if (!copied.has(node.id)) continue;
+    const fresh = freeId(taken, node.id);
+    taken.add(fresh);
+    renamed.set(node.id, fresh);
+  }
+
+  const copies = nodes
+    .filter((node) => copied.has(node.id))
+    .map((node) => {
+      const parent = parentOf(node);
+      return {
+        ...node,
+        id: renamed.get(node.id)!,
+        // The root of the copy keeps the original's parent; everything below
+        // it points at its own copied parent.
+        inputs: parent ? [renamed.get(parent) ?? parent] : [],
+      };
+    });
+
+  return [...nodes, ...copies];
+}
+
+/** The nodes nothing reads from — what DESIGN_BRIEF.md section 5 calls
+ * terminal, and what a comparison is offered between. */
+export function terminals(nodes: PipelineNode[]): PipelineNode[] {
+  const consumed = new Set(nodes.flatMap((node) => node.inputs));
+  return nodes.filter((node) => !consumed.has(node.id));
+}

--- a/frontend/src/canvas/graph.ts
+++ b/frontend/src/canvas/graph.ts
@@ -23,6 +23,14 @@ export interface NodeData extends Record<string, unknown> {
    * so a control in the side panel is replaced by the tab before it can be
    * used. Absent on a draft and on the source, which cannot be removed. */
   onRemove?: () => void;
+  /** Copy this node and everything below it into a sibling branch (#51).
+   * Absent on the source, which cannot be duplicated. */
+  onDuplicate?: () => void;
+  /** Pick this node for a comparison, or unpick it. Offered only on terminal
+   * estimator nodes: comparing anything else has nothing to put side by side. */
+  onCompare?: () => void;
+  /** Already picked, so the control reads as a toggle rather than a verb. */
+  comparing?: boolean;
 }
 
 export interface FlowNode {
@@ -85,6 +93,8 @@ export function toNodes(
   state: PipelineState | undefined,
   labelOf: (node: PipelineNode) => string,
   onRemove?: (id: string) => void,
+  compare?: { ids: string[]; terminals: Set<string>; onCompare: (id: string) => void },
+  onDuplicate?: (id: string) => void,
 ): FlowNode[] {
   return pipeline.nodes.map((node) => {
     const status = nodeStateOf(node.id, state);
@@ -101,6 +111,13 @@ export function toNodes(
         footer: status.footer,
         onRemove:
           onRemove && node.type !== "source" ? () => onRemove(node.id) : undefined,
+        onDuplicate:
+          onDuplicate && node.type !== "source" ? () => onDuplicate(node.id) : undefined,
+        onCompare:
+          compare && node.type === "estimator" && compare.terminals.has(node.id)
+            ? () => compare.onCompare(node.id)
+            : undefined,
+        comparing: compare?.ids.includes(node.id) ?? false,
       },
     };
   });

--- a/frontend/src/screens/analysis/CompareResults.tsx
+++ b/frontend/src/screens/analysis/CompareResults.tsx
@@ -1,0 +1,214 @@
+import { useResults, type PcaPayload } from "@/api/queries";
+import { Panel } from "@/screens/analysis/Panel";
+
+/** Two terminal nodes side by side — DESIGN_BRIEF.md §5's reason for the canvas.
+ *
+ * The brief draws one dataset forked into four preprocessing paths with an
+ * RMSECV against each, and says the canvas exists so those can be compared.
+ * This is the two-model case of that picture.
+ *
+ * **Nothing here is computed, including the difference.** Every figure is a
+ * number the server sent; the delta column is a subtraction of two of them,
+ * which is arithmetic on displayed values rather than a statistic. A screen
+ * that computed a metric would be a second implementation of it.
+ *
+ * The rows are the union of what the two carry, so comparing a regression with
+ * a decomposition is legible rather than refused: what one has and the other
+ * does not reads as an em dash, which is the same rule §11 sets for a metric
+ * that could not be computed.
+ */
+
+const METRICS: [string, string][] = [
+  ["RMSEC", "rmsec"],
+  ["RMSECV", "rmsecv"],
+  ["RMSEP", "rmsep"],
+  ["R²", "r2"],
+  ["Q²", "q2"],
+  ["Bias", "bias"],
+  ["SEC", "sec"],
+  ["SEP", "sep"],
+];
+
+function figure(value: number | undefined, digits = 4) {
+  return value === undefined ? "—" : value.toFixed(digits);
+}
+
+/** Lower is better for an error, higher for a fit. Only used to point an
+ * arrow, never to declare a winner: which model is better is the user's call
+ * and depends on what they are calibrating for. */
+const LOWER_IS_BETTER = new Set(["rmsec", "rmsecv", "rmsep", "sec", "sep"]);
+
+export interface CompareRow {
+  label: string;
+  /** The `metrics` key. Not called `key`: it is spread into a React element,
+   * where that name is reserved and would be swallowed. */
+  metric: string;
+  a?: number;
+  b?: number;
+  /** `b - a`, or undefined when only one of them carries the metric. */
+  delta?: number;
+  /** Whether `b` is the better of the two, or undefined when they tie or when
+   * only one reported. Points an arrow; never declares a winner - which model
+   * is better depends on what is being calibrated for and is the user's call. */
+  better?: boolean;
+}
+
+/** The rows two results have between them, in the order §11 lists them.
+ *
+ * A metric neither carries is dropped rather than shown as two dashes: an
+ * all-empty row says nothing and pushes the ones that matter off the panel.
+ * A metric only one carries is kept, because that difference between the two
+ * models is itself the finding.
+ */
+export function compareRows(
+  a: PcaPayload["metrics"],
+  b: PcaPayload["metrics"],
+): CompareRow[] {
+  return METRICS.filter(
+    ([, key]) => a?.[key] !== undefined || b?.[key] !== undefined,
+  ).map(([label, key]) => {
+    const left = a?.[key];
+    const right = b?.[key];
+    const delta =
+      left !== undefined && right !== undefined ? right - left : undefined;
+    return {
+      label,
+      metric: key,
+      a: left,
+      b: right,
+      delta,
+      better:
+        delta === undefined || delta === 0
+          ? undefined
+          : LOWER_IS_BETTER.has(key)
+            ? delta < 0
+            : delta > 0,
+    };
+  });
+}
+
+function Row({ label, a, b, delta, better }: CompareRow) {
+  return (
+    <tr>
+      <td style={{ color: "var(--ink2)" }}>{label}</td>
+      <td className="n">{figure(a)}</td>
+      <td className="n">{figure(b)}</td>
+      <td
+        className="n"
+        style={{
+          color: better === undefined ? "var(--ink3)" : "var(--accentInk)",
+        }}
+        data-testid={`delta-${label}`}
+      >
+        {delta === undefined
+          ? "—"
+          : `${delta > 0 ? "+" : ""}${delta.toFixed(4)}`}
+        {better === undefined ? "" : better ? " ▾" : " ▴"}
+      </td>
+    </tr>
+  );
+}
+
+function Column({ payload }: { payload: PcaPayload }) {
+  const regression = payload.task === "regression";
+  return (
+    <>
+      <div className="kv">
+        <b>Model</b>
+        <span className="mono">
+          {regression ? `PLS · ${payload.regression?.target ?? "?"}` : "PCA"}
+        </span>
+      </div>
+      <div className="kv">
+        <b>Components</b>
+        <span className="mono">{payload.n_components}</span>
+      </div>
+      <div className="kv">
+        <b>Fitted on</b>
+        <span className="mono">
+          {payload.n_samples} × {payload.n_variables}
+        </span>
+      </div>
+    </>
+  );
+}
+
+export function CompareResults({
+  left,
+  right,
+}: {
+  left: string;
+  right: string;
+}) {
+  const a = useResults(left);
+  const b = useResults(right);
+
+  if (!a.data || !b.data) {
+    return (
+      <div className="pane">
+        <div className="empty" style={{ padding: 16 }}>
+          Loading both results…
+        </div>
+      </div>
+    );
+  }
+
+  const rows = compareRows(a.data.metrics, b.data.metrics);
+
+  return (
+    <div className="pane">
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          padding: "12px 14px",
+          display: "flex",
+          gap: 12,
+        }}
+        data-testid="compare-view"
+      >
+        <Panel title={left} width={220}>
+          <div style={{ padding: "6px 0" }}>
+            <Column payload={a.data} />
+          </div>
+        </Panel>
+        <Panel title={right} width={220}>
+          <div style={{ padding: "6px 0" }}>
+            <Column payload={b.data} />
+          </div>
+        </Panel>
+        <Panel
+          title="Metrics"
+          note={rows.length ? "" : "neither node reports one"}
+        >
+          <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+            <table>
+              <thead>
+                <tr>
+                  <th style={{ width: 110 }}>Metric</th>
+                  <th className="n">{left}</th>
+                  <th className="n">{right}</th>
+                  <th className="n" style={{ width: 92 }}>
+                    Difference
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <Row key={row.metric} {...row} />
+                ))}
+              </tbody>
+            </table>
+            {rows.length === 0 ? (
+              <div className="empty" style={{ padding: 12 }}>
+                Neither of these carries a regression metric. A decomposition
+                reports explained variance rather than an error, and those are
+                on each node&rsquo;s own tab.
+              </div>
+            ) : null}
+          </div>
+        </Panel>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -19,6 +19,7 @@ import { CannotLoad } from "@/states/CannotLoad";
 import { Import } from "@/screens/Import";
 import { PipelineCanvas } from "@/canvas/PipelineCanvas";
 import { AnalysisResults } from "@/screens/analysis/AnalysisResults";
+import { CompareResults } from "@/screens/analysis/CompareResults";
 import { SpectraView } from "@/screens/SpectraView";
 import { Inspector } from "@/shell/Inspector";
 import { Sidebar } from "@/shell/Sidebar";
@@ -70,10 +71,12 @@ function Pane({
   onImported,
   onCloseImport,
   onOpenNode,
+  onCompare,
 }: {
   tab: Tab | undefined;
   datasets: DatasetEntry[] | undefined;
   onOpenNode: (id: string, label: string) => void;
+  onCompare: (left: string, right: string) => void;
   onImported: (versionId: string, name: string) => void;
   onCloseImport: () => void;
 }) {
@@ -81,7 +84,8 @@ function Pane({
     return <Import onImported={onImported} onCancel={onCloseImport} />;
   }
 
-  if (tab?.kind === "pipeline") return <PipelineCanvas onOpenNode={onOpenNode} />;
+  if (tab?.kind === "pipeline")
+    return <PipelineCanvas onOpenNode={onOpenNode} onCompare={onCompare} />;
   if (tab?.kind === "spectra") {
     const shape = datasets?.[0]?.versions.at(-1);
     return (
@@ -94,6 +98,12 @@ function Pane({
     );
   }
   if (tab?.kind === "results") return <AnalysisResults nodeId={tab.id} title={tab.title} />;
+  if (tab?.kind === "compare") {
+    // The id carries both nodes, so this tab is stable across opens the way
+    // every other one is: picking the same pair twice reuses it.
+    const [left, right] = tab.id.split("|");
+    return <CompareResults left={left} right={right} />;
+  }
 
   const found = datasets
     ?.flatMap((entry) => entry.versions.map((version) => ({ entry, version })))
@@ -205,6 +215,14 @@ export function Shell() {
       );
     },
     [open, pipeline.data],
+  );
+
+  const openCompare = useCallback(
+    // Pinned rather than transient: a comparison took two deliberate picks, so
+    // replacing it with the next preview would throw away what was just built.
+    (left: string, right: string) =>
+      open({ id: `${left}|${right}`, kind: "compare", title: `${left} vs ${right}` }, false),
+    [open],
   );
 
   /** Editing a parameter invalidates everything computed from it. The results
@@ -376,11 +394,11 @@ export function Shell() {
             <EmptyProject onImport={openImport} />
           ) : state.splitId ? (
             <div className="split">
-              <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} />
-              <Pane tab={splitTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} />
+              <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} onCompare={openCompare} />
+              <Pane tab={splitTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} onCompare={openCompare} />
             </div>
           ) : (
-            <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} />
+            <Pane tab={activeTab} datasets={datasets.data} onImported={imported} onCloseImport={() => dispatch({ type: "close", id: "import" })} onOpenNode={openNode} onCompare={openCompare} />
           )}
         </main>
 

--- a/frontend/src/shell/icons.tsx
+++ b/frontend/src/shell/icons.tsx
@@ -89,12 +89,23 @@ export const ImportIcon = () => (
   </Icon>
 );
 
+/** Two paths side by side: a comparison is two models on one screen. */
+export const CompareIcon = () => (
+  <Icon>
+    <path d="M4 20V8" />
+    <path d="M10 20V4" />
+    <path d="M16 20v-9" />
+    <path d="M22 20V6" />
+  </Icon>
+);
+
 export const KIND_ICONS = {
   dataset: DatasetIcon,
   import: ImportIcon,
   pipeline: NodeIcon,
   spectra: PlotIcon,
   results: PlotIcon,
+  compare: CompareIcon,
   experiment: FlaskIcon,
   model: ModelIcon,
 } as const;

--- a/frontend/src/shell/tabs.ts
+++ b/frontend/src/shell/tabs.ts
@@ -12,6 +12,7 @@ export type TabKind =
   | "pipeline"
   | "spectra"
   | "results"
+  | "compare"
   | "experiment"
   | "model";
 


### PR DESCRIPTION
The second half of #51 — and the half `DESIGN_BRIEF.md` §5 says the canvas exists for:

```
                    ┌── SNV ──────── PLS 6LV ──► Model A   RMSECV 0.412
   corn_raw ────────┼── MSC ──────── PLS 6LV ──► Model B   RMSECV 0.418
                    ├── SG d1 ────── PLS 5LV ──► Model C   RMSECV 0.389
                    └── SNV + SG ─── PLS 5LV ──► Model D   RMSECV 0.381
```

Both halves were deferred for having nothing to compare. Since #142 there is.

## Duplicate

Copies a node and everything below it into a **sibling** branch, reading from the original's parent. Below it would be a chain, which is not what duplicating means on a graph whose point is comparison.

Ids are derived — `snv copy`, then `snv copy 2` — rather than random. A pipeline is read by a person: `snv copy` beside `snv` says what happened, where a uuid says only that something did. The same argument `node_label` makes against a table of pretty names.

## Comparison is two clicks, not a multi-select

A click on a node body already means *open this*, so a selection would need a modifier nobody is told about. The first pick arms the control and the node says it is armed; the second opens the tab. Offered only on **terminal estimator** nodes, because comparing anything else has nothing to put side by side.

The tab id carries both nodes, so picking the same pair twice reuses the tab rather than stacking duplicates — the same identity rule every other tab follows. Pinned rather than transient, because two deliberate picks should not be thrown away by the next preview.

## The difference column

A subtraction of two numbers the server sent. **Arithmetic on displayed values, never a statistic** — a screen that computed a metric would be a second implementation of it.

It points an arrow and does not declare a winner: which model is better depends on what is being calibrated for, and that is the user's call. A metric only one side carries is kept, because that difference between the two models is itself the finding; one neither carries is dropped rather than rendered as two em dashes.

## Verification

`npx playwright test` — **43 passed** (40 before), run locally. Three new cases: duplicating `snv` produces `snv copy`, `centre_a copy` and `pca_a copy` with an edge `source->snv copy`; the source offers no duplicate control; picking `pca_a` then `pls_d` opens a tab titled `pca_a vs pls_d` whose difference column reads an em dash, because only `pls_d` carries regression metrics. The compare control is absent on `snv`, which is not terminal.

`npx vitest run` — 11 files, **99 tests** (92 before; +8 on `duplicate`/`terminals`, +7 on `compareRows`). `tsc -b --noEmit` and `eslint .` exit 0. Backend untouched — `pytest` 809 passed, 1 skipped.

`duplicate` and `terminals` are pure and tested without a browser, like the first half's rules; `compareRows` was extracted from the table for the same reason, which also let a slow save-and-run e2e case be replaced by seven fast unit assertions.

## A note on the diff

I briefly ran `prettier --write` across `frontend/src`, which reformatted ~35 unrelated files to prettier's 80-column default against a codebase written to ~100. That is reverted; this diff touches only the ten files the feature needs. The repo has no prettier config, and adding one is a convention decision that does not belong in this PR.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)