### PR TITLE
Say what the application is, and how to start it

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,38 @@ An open-source, local-first chemometrics workbench: a Python backend and a React
 shipped as one double-clickable desktop application, aimed at research and academic users of
 closed tools such as Unscrambler, SIMCA and OPUS. Your data never leaves your machine.
 
-**Status: Phase 0, the numerical foundation. There is no user interface yet**, and the
-application does not run. What exists is the part everything else has to stand on — the
-algorithm kernels, their specifications, and the evidence that their numbers are right.
+**Status: Phase 1 is complete and released, `v0.5.0`.** The application runs: import a
+dataset, build a preprocessing pipeline on a canvas, fit PCA or PLS, cross-validate, and read
+the result. Everything stands on the numerical foundation Phase 0 laid — the algorithm
+kernels, their specifications, and the evidence that their numbers are right.
+
+Phase 2 is under way. `PROPOSAL.md` §16 still wants PLS-DA, VIP scores, contribution plots, a
+train/test splitting interface and the Bruker OPUS reader.
+
+## Running it
+
+```bash
+./run.sh
+```
+
+It syncs the environment, builds the frontend bundle if there is not one, and starts the
+server. Open the URL it prints — `http://127.0.0.1:<port>/?token=<token>`. The port is
+ephemeral so two copies never fight over a number, and the token is a real check: every `/api`
+request carries it, so a bare `127.0.0.1` address without the token gets a 401.
+
+`./run.sh --build` rebuilds the bundle first, which is what you want after changing anything
+under `frontend/src`.
+
+Working on the interface is two processes instead, so Vite can serve its own:
+
+```bash
+WORKBENCH_PORT=8000 WORKBENCH_TOKEN=dev uv run python -m chemometrics_workbench.server
+cd frontend && npm run dev          # http://localhost:5173
+```
+
+The port is pinned because the Vite proxy has to be told a target in advance, and the token
+because a fresh one on every restart is tedious to paste. `localhost:5173` is already an
+allowed origin.
 
 ## The parity report
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "chemometrics-workbench"
-version = "0.4.0"
+version = "0.5.0"
 description = "Open-source, local-first chemometrics workbench"
 requires-python = ">=3.12"
 license = "MIT"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Launch the workbench: one process on the loopback interface, serving the
+# built frontend. It prints the URL to open — the token is in it, and every
+# /api request needs that token, so a bare localhost address will not do.
+#
+#   ./run.sh            # build the bundle if it is missing, then serve
+#   ./run.sh --build    # rebuild first, for when frontend/src has moved on
+#
+# The dev loop is not this script: it is two processes, and Vite wants its own
+# terminal. See "Running it" in README.md.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+uv sync
+
+if [ "${1:-}" = "--build" ] || [ ! -f frontend/dist/index.html ]; then
+    (cd frontend && npm ci && npm run build)
+fi
+
+exec uv run python -m chemometrics_workbench.server

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "chemometrics-workbench"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
Closes #155.

## What changed

**`README.md`** — the status block said "Phase 0 … there is no user interface yet, and the application does not run". False since `v0.2.0`. It now states the real status and carries a **Running it** section: the production path (`./run.sh`), and the dev path (Vite on 5173 against a pinned `WORKBENCH_PORT` and `WORKBENCH_TOKEN`). The launch instructions previously existed only in `server.py`'s module docstring.

**`run.sh`** — the production path in one command: `uv sync`, build `frontend/dist` if it is missing, serve. `--build` forces the rebuild, because a stale bundle is served without complaint and reads as a change that did not take — the same trap the frontend suite sets, recorded in `session-handoff.md`.

**`pyproject.toml` and `uv.lock`** — `0.4.0` against a `v0.5.0` tag. Bumped.

Also removed a stale untracked `stub/__pycache__` from the working directory. `stub/` itself went in #89; only the bytecode was left, and it was never tracked, so nothing in this diff.

## Verification

`./run.sh` on this branch, then against the port and token it printed:

```
Launch URL: http://127.0.0.1:43927/?token=wTZZOMcshY90ZIPkdBu9UotDyH-85xSgRlTiMTSEAHI

  /                       200   <title>Chemometrics Workbench</title>
  /tokens                 200   (deep link reaches the app, not a 404)
  /api/projects + token   200
  /api/projects           401
```

`uv sync` reported `chemometrics-workbench==0.4.0 -> 0.5.0`, which is the version bump taking effect.

## Not in scope

The five Phase 2 exit-criterion features (PLS-DA, VIP, contribution plots, train/test split UI, OPUS reader) still have no `feature_list.json` entries. The README now names them as outstanding rather than silently omitting them.
