### PR TITLE
Send the edit, and redraw what the run rewrote

### DIFF
--- a/frontend/e2e/inspector.spec.ts
+++ b/frontend/e2e/inspector.spec.ts
@@ -78,3 +78,48 @@ test("provenance is collapsed until asked for, and hashes are truncated in the m
   // it belonged to the fixture before #89 and belongs to the imported file now.
   await expect(inspector.getByText(/^sha256:[0-9a-f]{4}…[0-9a-f]{4}$/)).toBeVisible();
 });
+
+test("an accepted edit is written to the pipeline, not only to the screen", async ({ page }) => {
+  // #157. Apply validated the step, marked the node stale and sent nothing, so
+  // the run that followed read the old number back off disk and the edit
+  // looked ignored - the same curve, however many times it was re-run.
+  //
+  // Asserted against the pipeline the server holds rather than against a
+  // reopened form. A node's label is built from its parameters, so the moment
+  // this edit lands the node stops being called "SG d1 w11" and becomes "SG d1
+  // w9" - and `snv_savgol`, which carries the same window, inherits the old
+  // label alone. Looking the node up a second time by the name it used to have
+  // finds the wrong node and reads 11 off it, which is a passing bug rather
+  // than a failing one. "Written to the pipeline" is the claim; ask the
+  // pipeline.
+  const outline = page.goto("/?token=e2e-token").then(() =>
+    page.getByRole("complementary", { name: "Project outline" }),
+  );
+  await (await outline).getByRole("button", { name: /SG d1 w11/ }).first().dblclick();
+  const inspector = page.getByRole("complementary", { name: "Inspector" });
+
+  await expect(inspector.getByLabel("Window Length")).toHaveValue("11");
+  await inspector.getByLabel("Window Length").fill("9");
+  await inspector.getByRole("button", { name: "Apply" }).click();
+  await expect(page.getByText("Downstream results are stale.")).toBeVisible();
+
+  const saved = await page.request.get("/api/pipelines/current", {
+    headers: { Authorization: "Bearer e2e-token" },
+  });
+  const nodes = (await saved.json()).nodes as { id: string; step?: { window_length?: number } }[];
+  expect(nodes.find((node) => node.id === "savgol")?.step?.window_length).toBe(9);
+
+  // Put it back: the project outlives this test, and the file above opens by
+  // asserting the seeded 11.
+  await inspector.getByLabel("Window Length").fill("11");
+  await inspector.getByRole("button", { name: "Apply" }).click();
+  await expect
+    .poll(async () => {
+      const back = await page.request.get("/api/pipelines/current", {
+        headers: { Authorization: "Bearer e2e-token" },
+      });
+      const list = (await back.json()).nodes as { id: string; step?: { window_length?: number } }[];
+      return list.find((node) => node.id === "savgol")?.step?.window_length;
+    })
+    .toBe(11);
+});

--- a/frontend/src/inspector/ParameterForm.tsx
+++ b/frontend/src/inspector/ParameterForm.tsx
@@ -14,7 +14,7 @@ interface Props {
   spec: StepSpec;
   values: Record<string, string>;
   onChange: (values: Record<string, string>) => void;
-  onApply: () => void;
+  onApply: (step: Record<string, unknown>) => void;
 }
 
 function Field({
@@ -115,7 +115,9 @@ export function ParameterForm({ spec, values, onChange, onApply }: Props) {
     setChecking(false);
     if (result.valid) {
       setServerProblems({});
-      onApply();
+      // The payload the server just accepted is the one that gets saved: a
+      // second coercion of `values` could differ from the one validated.
+      onApply(payload);
       return;
     }
     // A field-level complaint lands on its field; a cross-field one - which

--- a/frontend/src/shell/Inspector.tsx
+++ b/frontend/src/shell/Inspector.tsx
@@ -22,7 +22,7 @@ interface Props {
   state: PipelineState | undefined;
   metrics: Record<string, number | null> | undefined;
   collapsed: boolean;
-  onEdit: (nodeId: string) => void;
+  onEdit: (nodeId: string, step: Record<string, unknown>) => void;
 }
 
 function Kv({ label, value }: { label: string; value: string | number }) {
@@ -136,7 +136,7 @@ export function Inspector({
           spec={spec}
           values={values}
           onChange={setValues}
-          onApply={() => onEdit(node!.id)}
+          onApply={(step) => onEdit(node!.id, step)}
         />
       ) : node ? (
         <div style={{ padding: "8px 0", borderBottom: "1px solid var(--rule)" }}>

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -12,6 +12,7 @@ import {
   usePipelineState,
   useProjects,
   useRunExperiment,
+  useSavePipeline,
 } from "@/api/queries";
 import { DatasetView } from "@/screens/DatasetView";
 import { EmptyProject } from "@/screens/EmptyProject";
@@ -168,6 +169,7 @@ export function Shell() {
   const [startedAt, setStartedAt] = useState<number | null>(null);
   const job = useJob(jobId);
   const run = useRunExperiment();
+  const save = useSavePipeline();
   const cancel = useCancelJob();
 
   /** A run moves the canvas, so the canvas has to be asked again.
@@ -187,6 +189,22 @@ export function Shell() {
     if (!jobId) return;
     void queryClient.invalidateQueries({ queryKey: ["pipeline-state"] });
   }, [advanced, jobId, queryClient]);
+
+  /** A run rewrites the arrays every open tab is drawing, and #157 was that
+   * nothing said so: only `pipeline-state` was invalidated, so a tab kept
+   * drawing what it fetched before the run and a re-run read as a run that
+   * did nothing.
+   *
+   * Once it has settled, not on every advance. A node whose arrays are being
+   * recomputed has none under its new key, so refetching mid-run asks for
+   * something that does not exist yet, takes a 404 and leaves the tab holding
+   * an error instead of the stale plot it is supposed to keep showing. */
+  const settled = job.data?.status === "succeeded" || job.data?.status === "failed";
+  useEffect(() => {
+    if (!jobId || !settled) return;
+    void queryClient.invalidateQueries({ queryKey: ["spectra"] });
+    void queryClient.invalidateQueries({ queryKey: ["results"] });
+  }, [settled, jobId, queryClient]);
 
   const open = useCallback(
     (tab: Omit<Tab, "transient">, transient: boolean) =>
@@ -226,10 +244,29 @@ export function Shell() {
   );
 
   /** Editing a parameter invalidates everything computed from it. The results
-   * stay on screen, dimmed - a stale result must not vanish. */
-  const markStale = useCallback(
-    (nodeId: string) => {
+   * stay on screen, dimmed - a stale result must not vanish.
+   *
+   * The edit is written through before it is marked. Marking alone was #157:
+   * the node went stale, the run that followed read the pipeline from disk,
+   * and the disk still held the old number - so re-running produced the same
+   * curve and the edit looked ignored. Which field it lands in follows the
+   * node: preprocessing carries `step`, estimators and splits carry `spec`. */
+  const applyEdit = useCallback(
+    async (nodeId: string, step: Record<string, unknown>) => {
       if (!pipeline.data) return;
+      const nodes = pipeline.data.nodes.map((node) =>
+        node.id === nodeId
+          ? { ...node, [node.step ? "step" : "spec"]: step as { kind: string } }
+          : node,
+      );
+      await save.mutateAsync(nodes);
+      // The save invalidates `pipeline-state`, and that refetch would land on
+      // top of the marking below. The server never reports `stale` - it says
+      // `not_run`, deliberately, because a flag beside the graph can disagree
+      // with the arrays - so the reason for the staleness is the client's to
+      // hold, and the in-flight refetch has to be stood down before it is
+      // written.
+      await queryClient.cancelQueries({ queryKey: ["pipeline-state"] });
       const affected = [nodeId, ...downstreamOf(pipeline.data, nodeId)];
       queryClient.setQueryData<PipelineState>(["pipeline-state"], (current) =>
         current
@@ -253,7 +290,7 @@ export function Shell() {
       );
       setStaleFrom(nodeId);
     },
-    [pipeline.data, queryClient],
+    [pipeline.data, queryClient, save],
   );
 
   const activeTab = state.tabs.find((tab) => tab.id === state.activeId);
@@ -415,7 +452,7 @@ export function Shell() {
               state={pipelineState.data}
               metrics={metricsFor(activeTab)}
               collapsed={inspectorCollapsed}
-              onEdit={markStale}
+              onEdit={applyEdit}
             />
           </div>
         </div>


### PR DESCRIPTION
Closes #157.

Changing a preprocessing parameter and pressing **Apply** marked the node stale and changed nothing, however many times it was re-run. Two bugs sat behind that; the staleness itself was not one of them.

## 1. Apply never sent the edit

`ParameterForm.apply()` POSTed to `/steps/validate` — which only validates — then called `onApply()`, which marked the node stale in the react-query cache. `PUT /pipelines/current` was never called from the inspector at all. The run that followed read the pipeline off disk, found the old number, and recomputed the same curve.

The payload the server has just accepted is now the one that gets saved, rather than a second coercion of the form's values that could differ from the one that was validated. It lands in `step` or `spec` according to the node.

The save is awaited **before** the staleness is written, and the in-flight `pipeline-state` refetch that `useSavePipeline` triggers is cancelled first — otherwise it lands on top of the marking. The server never reports `stale`, deliberately (`get_pipeline_state`: a flag beside the graph can disagree with the arrays), so that reason is the client's to hold.

`markStale` is now `applyEdit`, because it no longer only marks.

## 2. A finished run never redrew the plot

`Shell.tsx` invalidated only `["pipeline-state"]` when a job advanced. The open tab reads `["spectra", nodeId]` / `["results", nodeId]`, which nothing invalidated — and both carry `staleTime: Infinity`, so the tab kept drawing what it fetched before the run.

Invalidated on a **settled** job rather than on every advance. Refetching mid-run asks for arrays that do not exist yet under the node's new key: measured against a live server, that took two 404s and left the tab holding an error instead of the dimmed stale plot it is supposed to keep showing.

## The backend was never involved

Driven over HTTP against a seeded project, no frontend:

```
GET  /api/spectra/savgol            digest 392e2b377d89657e   (window_length 11)
PUT  /api/pipelines/current         200      (window_length 9)
GET  /api/pipelines/current/state   savgol: not_run
POST /api/experiments/current/run   succeeded
GET  /api/spectra/savgol            digest f0c7544b7b2191da   (changed)
```

`put_pipeline` behaved exactly as its docstring says throughout.

## Verification

- `npx playwright test` — **44 passed**.
- `npm run test` — 99 passed. `npm run typecheck`, `npm run lint`, `ruff check`, `mypy` clean.
- New e2e test `an accepted edit is written to the pipeline, not only to the screen`, **confirmed to fail against the pre-fix bundle** and pass after.
- Driven by hand in Chrome against a real server: Window Length 11 → 9 → Apply → Run pipeline → reload. The node is now `SG d1 w9`, `complete`, the form reads 9, and the plot is drawn from the recomputed arrays.

## A trap worth recording

The first version of the regression test reopened the node by label after a reload and read `11` back — a passing bug, not a failing one. **A node's label is built from its parameters**, so the moment the edit lands the node stops being called `SG d1 w11` and becomes `SG d1 w9` — and `snv_savgol`, which carries the same window, inherits the old label alone. Looking a node up by the name it used to have finds a different node. The test now asks the pipeline, which is the claim being made anyway.
