### PR TITLE
Run the edit on the press that made it

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -228,6 +228,25 @@
       ],
       "evidence": "2026-09-05. `diff src/chemometrics_workbench/data/tecator/README.md src/chemometrics_workbench/data/gasoline/README.md` reports the files differ; it reported them identical before. The README now names tecator, quotes the permission note from the committed tecator.txt verbatim, states the obligation to name the instrument and company when publishing, and carries tecator's own SHA-256 (e435c053...) and StatLib source rather than gasoline's CRAN URL and two gasoline hashes. datasets.py's load_tecator docstring now points at the note where it actually is - tecator.txt - with the README as the record of the rest. uv run pytest - 799 passed, 1 skipped, including tests/test_datasets.py (19 tests). ruff check, ruff format --check (77 files) and mypy (53 source files) exit 0.",
       "notes": "Found while choosing a dataset for an end-to-end run: data/tecator/README.md is byte-identical to data/gasoline/README.md, so it is titled 'Gasoline / octane' and asserts tecator is NOT committed, is GPL-2 and comes from CRAN - all four false, and the two SHA-256 rows are gasoline's. Nothing is redistributed wrongly: tecator.txt carries its own permission note ('can be redistributed as long as this permission note is attached') and that file is committed. What is wrong is the record. Three places designate that README as where the terms live - datasets.py:308-310 says the note is 'reproduced in data/tecator/README.md', CONTRIBUTING.md:78, session-handoff.md:313 - and for tecator it reproduces another dataset's. The publication obligation currently survives only in a docstring and in session-handoff.md, which is overwritten every session. The source URL was checked rather than copied: lib.stat.cmu.edu/datasets/tecator answers 301 on http and 403 on https, so the host and path exist but the page refuses a direct fetch - the table says exactly that rather than claiming a clean verification. The CRLF paragraph was kept and sharpened because it is the reason this file's bytes matter: .gitattributes marks *.txt as -text and test_the_committed_data_is_checked_out_byte_for_byte asserts it."
+    },
+    {
+      "id": "apply-saves-and-runs",
+      "priority": 0,
+      "area": "frontend",
+      "issue": 157,
+      "title": "Applying a parameter saves it and recomputes on the one press",
+      "depends_on": [
+        "pls-in-the-executor"
+      ],
+      "user_visible_behavior": "Changing a preprocessing parameter and pressing 'Apply and re-run' writes the step through PUT /pipelines/current, starts the run, and redraws the open plot when it settles. No banner, and no second press.",
+      "status": "passing",
+      "verification": [
+        "npx playwright test - the whole suite, including 'an accepted edit recomputes on the one press, and nothing is left dimmed' and 'an accepted edit is written to the pipeline, not only to the screen'.",
+        "The regression test fails against a bundle built before the fix.",
+        "npm run test && npm run typecheck && npm run lint",
+        "By hand against a real server: window_length 11 to 9, one press, then reload."
+      ],
+      "evidence": "2026-09-05. Two commits, merged as #158 and #159. Diagnosis: `ParameterForm.apply()` POSTed to /steps/validate - which only validates - and marked the node stale in the cache; PUT /pipelines/current was never called from the inspector, so a re-run recomputed the old spec. Second half: only ['pipeline-state'] was invalidated on a job, never ['spectra', nodeId] / ['results', nodeId], both of which carry staleTime: Infinity. The backend was never involved - driven over HTTP on a seeded project, GET /api/spectra/savgol digest 392e2b377d89657e at window_length 11, PUT 200 at 9, state 'not_run', run 'succeeded', digest f0c7544b7b2191da. `npx playwright test` - 44 passed (1.4m). `npm run test` - 99 passed, 11 files. `npm run typecheck` and `npm run lint` clean. The new e2e test was run against a bundle built from the pre-fix source and failed there (Expected 9, Received 11), then passed after. Driven by hand in Chrome against 127.0.0.1: window_length 11 to 9, one press; after the run the node reads 'SG d1 w9', 'complete', the form shows 9 and the plot is drawn from the recomputed arrays, surviving a reload. Confirmed working by the reporter."
     }
   ]
 }

--- a/frontend/e2e/inspector.spec.ts
+++ b/frontend/e2e/inspector.spec.ts
@@ -1,13 +1,26 @@
 import { expect, test, type Page } from "@playwright/test";
 
 /** The inspector: a typed form built from the schema, a message that comes
- * from the model, and an edit that marks downstream results stale. */
+ * from the model, and an edit that recomputes on the press that made it. */
 
 async function selectNode(page: Page, name: RegExp) {
   await page.goto("/?token=e2e-token");
   const outline = page.getByRole("complementary", { name: "Project outline" });
   await outline.getByRole("button", { name }).first().dblclick();
   return page.getByRole("complementary", { name: "Inspector" });
+}
+
+/** The window length the server holds for `savgol`, which is the claim an edit
+ * makes: what is on disk, not what the form is showing. */
+async function savedWindow(page: Page): Promise<number | undefined> {
+  const response = await page.request.get("/api/pipelines/current", {
+    headers: { Authorization: "Bearer e2e-token" },
+  });
+  const nodes = (await response.json()).nodes as {
+    id: string;
+    step?: { window_length?: number };
+  }[];
+  return nodes.find((node) => node.id === "savgol")?.step?.window_length;
 }
 
 test("a preprocessing node gets a typed form with the schema's own bounds", async ({ page }) => {
@@ -20,7 +33,7 @@ test("a preprocessing node gets a typed form with the schema's own bounds", asyn
   // The bound comes from models.py: deriv is ge=0, le=2.
   await inspector.getByLabel("Deriv").fill("5");
   await expect(inspector.getByRole("alert")).toHaveText("Deriv must be at most 2");
-  await expect(inspector.getByRole("button", { name: "Apply" })).toBeDisabled();
+  await expect(inspector.getByRole("button", { name: "Apply and re-run" })).toBeDisabled();
 });
 
 test("a rule the schema cannot express is answered by the model itself", async ({ page }) => {
@@ -29,40 +42,36 @@ test("a rule the schema cannot express is answered by the model itself", async (
   // An even window is legal JSON Schema and illegal chemometrics. The form
   // does not know that; models.py does, and its sentence is what appears.
   await inspector.getByLabel("Window Length").fill("10");
-  await expect(inspector.getByRole("button", { name: "Apply" })).toBeEnabled();
-  await inspector.getByRole("button", { name: "Apply" }).click();
+  await expect(inspector.getByRole("button", { name: "Apply and re-run" })).toBeEnabled();
+  await inspector.getByRole("button", { name: "Apply and re-run" }).click();
   await expect(inspector.getByRole("alert")).toHaveText("window_length must be odd");
 });
 
-test("an accepted edit marks downstream nodes stale and offers a re-run", async ({ page }) => {
+test("an accepted edit recomputes on the one press, and nothing is left dimmed", async ({
+  page,
+}) => {
   const inspector = await selectNode(page, /^MSC/);
-  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
-  const staleBefore = await page.getByTestId("node-stale").count();
-
   await page.getByRole("tab", { name: /MSC/ }).click();
   await inspector.getByLabel("Reference").selectOption("median");
-  await inspector.getByRole("button", { name: "Apply" }).click();
+  await inspector.getByRole("button", { name: "Apply and re-run" }).click();
 
-  await expect(page.getByText("Downstream results are stale.")).toBeVisible();
-
-  await page.getByRole("tab", { name: "Pipeline" }).click();
-  expect(await page.getByTestId("node-stale").count()).toBeGreaterThan(staleBefore);
-
-  // A stale result dims; it does not vanish. Every node is still on the canvas.
-  await expect(page.locator(".react-flow__node")).toHaveCount(15);
-
-  // The re-run is offered, and taking it clears what the edit made stale.
-  //
   // The outcome rather than a frame of the middle: the edited node is the only
   // one whose arrays have to be recomputed and every other node is already in
   // the store, so this run is over in milliseconds - well inside one poll of
   // the job. Asserting "Queued" or even "Done" here asserts that the machine
   // was slow enough to be caught looking, which is why this test was flaky.
   // `runs.spec.ts` watches a run advance, on a project seeded large enough.
-  await page.getByRole("button", { name: "Re-run" }).click();
-  await expect(page.getByText("Downstream results are stale.")).toHaveCount(0);
-  await expect(page.getByTestId("node-stale")).toHaveCount(0);
+  await page.getByRole("button", { name: "Pipeline", exact: true }).click();
   await expect(page.getByTestId("node-complete")).toHaveCount(15);
+  await expect(page.getByTestId("node-stale")).toHaveCount(0);
+
+  // Nothing is left asking to be pressed: the edit ran, so there is no banner
+  // and no second button to find.
+  await expect(page.getByText("Downstream results are stale.")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Re-run" })).toHaveCount(0);
+
+  // A run does not cost anyone a node. Every one is still on the canvas.
+  await expect(page.locator(".react-flow__node")).toHaveCount(15);
 });
 
 test("provenance is collapsed until asked for, and hashes are truncated in the middle", async ({
@@ -100,26 +109,16 @@ test("an accepted edit is written to the pipeline, not only to the screen", asyn
 
   await expect(inspector.getByLabel("Window Length")).toHaveValue("11");
   await inspector.getByLabel("Window Length").fill("9");
-  await inspector.getByRole("button", { name: "Apply" }).click();
-  await expect(page.getByText("Downstream results are stale.")).toBeVisible();
+  await inspector.getByRole("button", { name: "Apply and re-run" }).click();
 
-  const saved = await page.request.get("/api/pipelines/current", {
-    headers: { Authorization: "Bearer e2e-token" },
-  });
-  const nodes = (await saved.json()).nodes as { id: string; step?: { window_length?: number } }[];
-  expect(nodes.find((node) => node.id === "savgol")?.step?.window_length).toBe(9);
+  // Polled, not read once: the press validates, saves and starts a run, and
+  // nothing on screen has to change before the save lands - so a single read
+  // races the PUT it is checking for.
+  await expect.poll(() => savedWindow(page)).toBe(9);
 
   // Put it back: the project outlives this test, and the file above opens by
   // asserting the seeded 11.
   await inspector.getByLabel("Window Length").fill("11");
-  await inspector.getByRole("button", { name: "Apply" }).click();
-  await expect
-    .poll(async () => {
-      const back = await page.request.get("/api/pipelines/current", {
-        headers: { Authorization: "Bearer e2e-token" },
-      });
-      const list = (await back.json()).nodes as { id: string; step?: { window_length?: number } }[];
-      return list.find((node) => node.id === "savgol")?.step?.window_length;
-    })
-    .toBe(11);
+  await inspector.getByRole("button", { name: "Apply and re-run" }).click();
+  await expect.poll(() => savedWindow(page)).toBe(11);
 });

--- a/frontend/src/inspector/ParameterForm.tsx
+++ b/frontend/src/inspector/ParameterForm.tsx
@@ -163,7 +163,7 @@ export function ParameterForm({ spec, values, onChange, onApply }: Props) {
       {spec.fields.length > 0 ? (
         <div style={{ padding: "8px 12px 0" }}>
           <button className="btn" style={{ height: 24 }} disabled={blocked || checking} onClick={apply}>
-            {checking ? "Checking…" : "Apply"}
+            {checking ? "Checking…" : "Apply and re-run"}
           </button>
         </div>
       ) : null}

--- a/frontend/src/shell/Shell.tsx
+++ b/frontend/src/shell/Shell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 import { useQueryClient } from "@tanstack/react-query";
 
-import type { DatasetEntry, PipelineState } from "@/api/queries";
+import type { DatasetEntry } from "@/api/queries";
 import {
   useCancelJob,
   useDatasets,
@@ -27,7 +27,6 @@ import { Sidebar } from "@/shell/Sidebar";
 import { StatusBar } from "@/shell/StatusBar";
 import { TabStrip } from "@/shell/TabStrip";
 import { FlaskIcon, KIND_ICONS } from "@/shell/icons";
-import { downstreamOf } from "@/inspector/stale";
 import { emptyTabs, tabsReducer, type Tab } from "@/shell/tabs";
 
 /** The frame every screen opens inside. The measurements are the artboard's -
@@ -163,7 +162,6 @@ export function Shell() {
   const pipelineState = usePipelineState();
   const experiment = useExperiment();
 
-  const [staleFrom, setStaleFrom] = useState<string | null>(null);
   const [dismissedFailure, setDismissedFailure] = useState(false);
   const [jobId, setJobId] = useState<string | null>(null);
   const [startedAt, setStartedAt] = useState<number | null>(null);
@@ -243,14 +241,18 @@ export function Shell() {
     [open],
   );
 
-  /** Editing a parameter invalidates everything computed from it. The results
-   * stay on screen, dimmed - a stale result must not vanish.
+  /** Applying a parameter writes it through and runs it.
    *
-   * The edit is written through before it is marked. Marking alone was #157:
-   * the node went stale, the run that followed read the pipeline from disk,
-   * and the disk still held the old number - so re-running produced the same
-   * curve and the edit looked ignored. Which field it lands in follows the
-   * node: preprocessing carries `step`, estimators and splits carry `spec`. */
+   * It used to take two presses: Apply marked the node stale and a banner
+   * offered a re-run, which is one press more than an edit is worth and read
+   * as an application refusing its own form. Only the edited node and what is
+   * below it are recomputed - everything else is still in the store under an
+   * unchanged key - so the second press was buying a saving nobody asked for.
+   *
+   * Which field the step lands in follows the node: preprocessing carries
+   * `step`, estimators and splits carry `spec`. The run is started from the
+   * saved pipeline rather than the sent one, because #157 was exactly the gap
+   * between what was on screen and what was on disk. */
   const applyEdit = useCallback(
     async (nodeId: string, step: Record<string, unknown>) => {
       if (!pipeline.data) return;
@@ -260,37 +262,11 @@ export function Shell() {
           : node,
       );
       await save.mutateAsync(nodes);
-      // The save invalidates `pipeline-state`, and that refetch would land on
-      // top of the marking below. The server never reports `stale` - it says
-      // `not_run`, deliberately, because a flag beside the graph can disagree
-      // with the arrays - so the reason for the staleness is the client's to
-      // hold, and the in-flight refetch has to be stood down before it is
-      // written.
-      await queryClient.cancelQueries({ queryKey: ["pipeline-state"] });
-      const affected = [nodeId, ...downstreamOf(pipeline.data, nodeId)];
-      queryClient.setQueryData<PipelineState>(["pipeline-state"], (current) =>
-        current
-          ? {
-              ...current,
-              nodes: {
-                ...current.nodes,
-                ...Object.fromEntries(
-                  affected.map((id) => [
-                    id,
-                    {
-                      ...current.nodes[id],
-                      state: "stale",
-                      reason: id === nodeId ? "edited - downstream stale" : "upstream changed",
-                    },
-                  ]),
-                ),
-              },
-            }
-          : current,
-      );
-      setStaleFrom(nodeId);
+      const started = await run.mutateAsync();
+      setJobId(started.job_id);
+      setStartedAt(Date.now());
     },
-    [pipeline.data, queryClient, save],
+    [pipeline.data, run, save],
   );
 
   const activeTab = state.tabs.find((tab) => tab.id === state.activeId);
@@ -458,41 +434,6 @@ export function Shell() {
         </div>
       </div>
 
-      {staleFrom ? (
-        <div
-          role="status"
-          style={{
-            position: "absolute",
-            right: 304,
-            bottom: 36,
-            display: "flex",
-            alignItems: "center",
-            gap: 8,
-            padding: "6px 10px",
-            borderRadius: 3,
-            border: "1px solid var(--stale)",
-            background: "var(--staleSoft)",
-            fontSize: 11.5,
-          }}
-        >
-          <span style={{ color: "var(--stale)" }}>Downstream results are stale.</span>
-          <button
-            className="btn"
-            style={{ height: 22 }}
-            onClick={async () => {
-              const started = await run.mutateAsync();
-              setJobId(started.job_id);
-              setStartedAt(Date.now());
-              setStaleFrom(null);
-            }}
-          >
-            Re-run
-          </button>
-          <button className="tabx" aria-label="Dismiss" onClick={() => setStaleFrom(null)}>
-            ×
-          </button>
-        </div>
-      ) : null}
 
       <StatusBar
         job={job.data}

--- a/session-handoff.md
+++ b/session-handoff.md
@@ -11,8 +11,9 @@ Compact state for the next session. **Overwrite this file at the end of every se
 **Phase 1 is complete and released** — `v0.1.0`, `v0.2.0`, `v0.3.0`, `v0.4.0`, the last merged into
 `main` and tagged on 2026-08-30 (`2277b5b`).
 
-**Every entry on the live Phase 2 list is `passing`, and one issue is open.** The list is twelve
-entries; the twelve are done. That is not the same as the phase being finished — see *Next action*.
+**Every entry on the live Phase 2 list is `passing`, and one issue is open.** The list is thirteen
+entries; the thirteen are done. That is not the same as the phase being finished — see *Next
+action*.
 
 | Priority | Feature | Issue | Status |
 | --- | --- | --- | --- |
@@ -28,14 +29,29 @@ entries; the twelve are done. That is not the same as the phase being finished �
 | 3 | Coefficients readable against the raw axis | #144 | passing |
 | 3 | A numeric id column is not imported as a target | #135 | passing |
 | 4 | `data/tecator/README.md` records tecator's terms | #137 | passing |
+| 0 | Applying a parameter saves it and recomputes on one press | #157 | passing |
 
 ## Current work
 
-**Nothing is `in_progress`.** The tree is clean, no branches remain and no pull requests are open.
-`main` is tagged `v0.4.0`; `dev` is **thirty-one commits ahead of it** — nothing merges to `main`
-until the phase closes. Merged on 2026-09-05: #139 (#138), #140 (#134), #141 (#136), #143 the
-stale-reference correction, #145 (#142), #147 (#146), #149 (#148), #150 (#137), #151 (#135),
-#152 (#144) and #153 (#51).
+**Nothing is `in_progress`.** The tree is clean apart from an untracked `tecator.csv` at the
+repository root, written by hand while looking for something importable. No branch remains and no
+pull request is open.
+
+**`main` is tagged `v0.5.0`** (`015f9ec`, 2026-09-05), which is a mid-phase snapshot rather than a
+phase close — the tag's own message says so. Merged on 2026-09-05: #139 (#138), #140 (#134),
+#141 (#136), #143, #145 (#142), #147 (#146), #149 (#148), #150 (#137), #151 (#135), #152 (#144),
+#153 (#51), #154 (the release), #156 (#155), #158 and #159 (both #157).
+
+**The application has a way in.** `./run.sh` syncs, builds the bundle if there is not one, and
+serves; it prints `http://127.0.0.1:<port>/?token=<token>`, and `--build` forces the rebuild that a
+changed `frontend/src` needs. The README says the real status and carries both that path and the
+two-process Vite one. Before #156 it opened by saying the application does not run, which had been
+false since `v0.2.0`.
+
+**Nothing openly licensed is importable without a step.** Tecator is committed but carries a prose
+header; corn and gasoline are archives in `~/.cache`. `uv run python tests/seed_e2e.py --fresh
+--serve <dir>` is the way in: it seeds Tecator, a four-branch pipeline and every node run, then
+serves it.
 
 **The demo runs the whole path.** Import, preprocess, split, fit PLS, cross-validate, read the
 result — on the seeded Tecator project, walked by CI on three platforms. Opening `PLS 5 LV · fat`
@@ -43,9 +59,53 @@ gives scores with a T² ellipse, loadings, explained variance, diagnostics, pred
 measured, the RMSECV curve and the calibration metrics. Terminal nodes can be picked in pairs and
 compared, and a branch can be duplicated and edited rather than rebuilt.
 
+## What a user found by using the editor (#157)
+
+The first bug on this list found by using the application rather than reading it, and the shape of
+it is worth keeping.
+
+**Changing a Savitzky-Golay window and pressing Apply did nothing.** The node went
+`stale · edited - downstream stale`, and re-running produced the same curve however many times it
+was pressed. Two bugs, and the staleness was not one of them:
+
+- **`Apply` never sent the edit.** `ParameterForm.apply()` POSTed to `/steps/validate` — which only
+  validates — and then marked the node stale in the react-query cache. `PUT /pipelines/current` was
+  never called from the inspector at all, so the run that followed read the old number off disk.
+- **A finished run never invalidated the plot.** Only `["pipeline-state"]` was invalidated on a job;
+  the open tab reads `["spectra", nodeId]` / `["results", nodeId]`, both `staleTime: Infinity`.
+
+**The backend did exactly what its docstrings say, throughout.** Driven over HTTP with no frontend:
+`GET /api/spectra/savgol` digest `392e2b37…` at `window_length` 11, `PUT` 200 at 9, state `not_run`,
+run `succeeded`, digest `f0c7544b…`. That comparison is what turned a UI complaint into a one-sided
+diagnosis in a few minutes, and it is the cheapest first move whenever a screen and a kernel
+disagree.
+
+**Then the two-press flow went too** (#159, at the reporter's request). Apply saves *and* runs; the
+button reads **"Apply and re-run"**; the banner, its Re-run button and the client-side stale marking
+are deleted. Only the edited node and its descendants recompute, so the press being saved bought a
+saving nobody asked for. `NodeState` still carries `stale` and the canvas still renders it — the
+fixtures use it — but nothing writes it any more.
+
+**Three traps, all of which cost real time:**
+
+- **A node's label is built from its parameters.** Editing `SG d1 w11` to a window of 9 renames it
+  `SG d1 w9`, and `snv_savgol` — same window, same label — inherits the old name alone. The first
+  regression test reopened the node by the name it used to have, found the *other* node, read 11 off
+  it and failed. Never re-find an edited node by a label derived from what was edited.
+- **An assertion that waits on an unrelated visible thing is an undeclared synchronisation point.**
+  The persistence check waited for the stale banner before reading the pipeline. Removing the banner
+  exposed the read as a race with its own `PUT`, on the first full run. It polls now.
+- **Killing stray processes kills Playwright's own web servers.** A `pkill` during a run failed three
+  tests that had nothing wrong with them, and a leftover server on 8765 later made a whole run exit
+  before its first test. `fuser -k -n tcp 8765 8766 8767 8768` first, and never mid-run.
+
 ## Next action
 
-**Two decisions, neither of them coding, and they are the only things left.**
+**Write the five missing entries.** §16 names **PLS-DA, VIP scores, contribution plots, a train/test
+splitting UI and the Bruker OPUS reader**. None has a `feature_list.json` entry. Thirteen green
+entries means the list is finished, not the phase, and writing those five is the first job.
+
+**Two decisions, neither of them coding.**
 
 **1. Is the exit criterion met?** §16 asks that the workflow "match reference software within stated
 tolerance". PLS is parity-covered at kernel level in `docs/parity-report.md`, and the workflow now
@@ -56,11 +116,6 @@ close is.
 **2. #71 — what a non-positive `h0` should do** in the Jackson–Mudholkar SPE limit. Gasoline's `h0`
 is −0.0190; this kernel uses it as computed, `mdatools` clamps it to 0.001. The divergence is
 recorded and proven. It is a specification decision and has been waiting since Phase 0.
-
-**And the list is not the phase.** §16 also names **PLS-DA, VIP and contribution plots, a train/test
-splitting UI, and the Bruker OPUS reader**. None has an entry. The exit criterion text says so, and
-it stays true: the twelve entries being green means the list is finished, not the phase. Writing
-those five entries is the natural next session's first job.
 
 ## What an end-to-end run against a public dataset found
 


### PR DESCRIPTION
Follow-on to #158, which made the edit reach disk. This makes it reach the plot without a second press.

## Why

Applying a parameter marked the node stale and put a banner in the corner offering a re-run. That is one press more than an edit is worth, and the first press read as an application refusing its own form: the number changed, the plot did not, and nothing said the work was still to come.

## What changed

- **Apply saves and runs.** The button says what it now does: **"Apply and re-run"**.
- **The banner, its Re-run button and the client-side stale marking are gone.** They existed to offer the second press. The states the run itself reports — queued, running, complete — say more than a flag written beside the graph, which is the same argument `get_pipeline_state` makes for deriving staleness rather than storing it.

Only the edited node and what is below it are recomputed — everything else is still in the store under an unchanged key — so the press that was being saved bought a saving nobody asked for.

## Verification

- `npx playwright test` — **44 passed**.
- `npm run test` — 99 passed. `npm run typecheck` and `npm run lint` clean.
- `an accepted edit marks downstream nodes stale and offers a re-run` is now `an accepted edit recomputes on the one press, and nothing is left dimmed`: after one press every node is `complete`, none is stale, and neither the banner nor a Re-run button exists.
- Confirmed working by the reporter.

## One thing worth recording

The persistence check now polls rather than reading once. Nothing on screen has to change before the save lands, so a single read races the `PUT` it is checking for — which it did, on the first full run after this change. **The banner it used to wait on had been hiding that race**, which is the general shape: an assertion that waits on an unrelated visible thing is a synchronisation point nobody wrote down, and removing the visible thing exposes every read that depended on it.
