### PR TITLE
Install with the package manager this project uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Working on the interface is two processes instead, so Vite can serve its own:
 
 ```bash
 WORKBENCH_PORT=8000 WORKBENCH_TOKEN=dev uv run python -m chemometrics_workbench.server
-cd frontend && npm run dev          # http://localhost:5173
+cd frontend && pnpm dev             # http://localhost:5173
 ```
 
 The port is pinned because the Vite proxy has to be told a target in advance, and the token

--- a/run.sh
+++ b/run.sh
@@ -14,7 +14,10 @@ cd "$(dirname "$0")"
 uv sync
 
 if [ "${1:-}" = "--build" ] || [ ! -f frontend/dist/index.html ]; then
-    (cd frontend && npm ci && npm run build)
+    # pnpm, and --frozen-lockfile, because that is what CI installs with:
+    # frontend/pnpm-lock.yaml is the only lockfile here, and `npm ci` refuses a
+    # project it cannot find a package-lock.json in.
+    (cd frontend && pnpm install --frozen-lockfile && pnpm build)
 fi
 
 exec uv run python -m chemometrics_workbench.server

--- a/session-handoff.md
+++ b/session-handoff.md
@@ -189,7 +189,7 @@ to be torn up", with the second row carrying the slot in a literal comment. Phas
 it. Before treating a design gap as a blocker, read what the screen says about itself.
 
 **Three things about the frontend suite, learned the slow way.** Playwright serves `frontend/dist`,
-a **built** bundle, so an app-source change needs `npm run build` before the e2e suite sees it — a
+a **built** bundle, so an app-source change needs `pnpm build` before the e2e suite sees it — a
 run that passes without it proves nothing about the change. `getByText` is a strict-mode violation
 on any word a screen repeats, and "RMSECV" appears four times on the analysis tab, so `Panel` now
 names its `<section>` with `aria-label` and panels are addressed by role and name. And a new


### PR DESCRIPTION
Closes #160.

`run.sh` installed with `npm ci`. There is no `package-lock.json` in this repository — only `frontend/pnpm-lock.yaml`, which is what CI installs from (`.github/workflows/ci.yml:108`). `npm ci` refuses a project it cannot find its own lockfile in, so **the build branch of `run.sh` failed on any checkout that did not already have a `frontend/dist`.**

#156 shipped that line, and its verification did not catch it: the tree it ran on had a bundle, so the `if` never entered. The branch that was broken is exactly the branch the check skipped.

Also changed `npm run dev` in the README's dev loop and `npm run build` in `session-handoff.md`'s note about the e2e bundle. Both work — npm runs scripts without a lockfile — but a project whose instructions name two package managers is one `npm install` away from a second lockfile that disagrees with the first.

## Verification

`rm -rf frontend/dist` **first** — the step the original verification skipped — then `./run.sh`:

```
Packages: +399
✓ built in 5.99s
INFO:     Uvicorn running on http://127.0.0.1:44461

  Launch URL: http://127.0.0.1:44461/?token=QiNprNeq1OTD2kW-MgQ3RuSbEIuQwOMH5VhieUocCnI
```

Against that port and token:

```
GET /?token=…            200
GET /api/projects + token 200
```

No `npm` invocations remain outside the comment explaining why.

## Context

Not part of the editable-canvas feature — a defect found while planning it (#164), and it blocks anyone building from a clean checkout, so it goes first.
