### PR TITLE
Let a node say it holds a result

### DIFF
--- a/design/canvas/_base.css
+++ b/design/canvas/_base.css
@@ -2,8 +2,8 @@
 *{box-sizing:border-box}
 body{margin:0;font-family:'IBM Plex Sans',system-ui,sans-serif;-webkit-font-smoothing:antialiased}
 a{color:#0B6B62}a:hover{color:#075049}
-.t-light{--ground:#E7EBEA;--panel:#F3F6F5;--surface:#FFFFFF;--sunken:#EDF1F0;--ink:#0F1A18;--ink2:#44524E;--ink3:#6E7D79;--rule:#D2DAD8;--rule2:#E5EAE8;--accent:#0B6B62;--accentSoft:#DCEDE9;--accentInk:#075049;--stale:#9A6206;--staleSoft:#F7EEDD;--fail:#A93226;--failSoft:#F9E8E5;--d1:#0072B2;--d2:#E69F00;--d3:#009E73;--d4:#CC79A7;--d5:#56B4E9;--d6:#D55E00;--grid:#EDF1F0;--band:#CBD7D4}
-.t-dark{--ground:#080D0C;--panel:#101816;--surface:#0C1413;--sunken:#141E1C;--ink:#E3EAE8;--ink2:#A6B5B1;--ink3:#788985;--rule:#22302D;--rule2:#192523;--accent:#54BFAB;--accentSoft:#122A26;--accentInk:#7FD3C2;--stale:#DFA85A;--staleSoft:#2A2216;--fail:#E8887C;--failSoft:#2C1A17;--d1:#5AA9DE;--d2:#F0B33C;--d3:#3FC79E;--d4:#DE9DC4;--d5:#8FCCF0;--d6:#F0855A;--grid:#16211F;--band:#263532}
+.t-light{--ground:#E7EBEA;--panel:#F3F6F5;--surface:#FFFFFF;--sunken:#EDF1F0;--ink:#0F1A18;--ink2:#44524E;--ink3:#6E7D79;--rule:#D2DAD8;--rule2:#E5EAE8;--accent:#0B6B62;--accentSoft:#DCEDE9;--accentInk:#075049;--ok:#1E7A3C;--stale:#9A6206;--staleSoft:#F7EEDD;--fail:#A93226;--failSoft:#F9E8E5;--d1:#0072B2;--d2:#E69F00;--d3:#009E73;--d4:#CC79A7;--d5:#56B4E9;--d6:#D55E00;--grid:#EDF1F0;--band:#CBD7D4}
+.t-dark{--ground:#080D0C;--panel:#101816;--surface:#0C1413;--sunken:#141E1C;--ink:#E3EAE8;--ink2:#A6B5B1;--ink3:#788985;--rule:#22302D;--rule2:#192523;--accent:#54BFAB;--accentSoft:#122A26;--accentInk:#7FD3C2;--ok:#63C67E;--stale:#DFA85A;--staleSoft:#2A2216;--fail:#E8887C;--failSoft:#2C1A17;--d1:#5AA9DE;--d2:#F0B33C;--d3:#3FC79E;--d4:#DE9DC4;--d5:#8FCCF0;--d6:#F0855A;--grid:#16211F;--band:#263532}
 .app{width:1440px;height:900px;display:flex;flex-direction:column;background:var(--ground);color:var(--ink);font-size:12.5px;line-height:1.45}
 .mono{font-family:'IBM Plex Mono',ui-monospace,monospace;font-variant-numeric:tabular-nums}
 .tbar{height:40px;flex:none;display:flex;align-items:center;justify-content:space-between;padding:0 12px;gap:12px;background:var(--panel);border-bottom:1px solid var(--rule)}

--- a/feature_list.json
+++ b/feature_list.json
@@ -247,6 +247,23 @@
         "By hand against a real server: window_length 11 to 9, one press, then reload."
       ],
       "evidence": "2026-09-05. Two commits, merged as #158 and #159. Diagnosis: `ParameterForm.apply()` POSTed to /steps/validate - which only validates - and marked the node stale in the cache; PUT /pipelines/current was never called from the inspector, so a re-run recomputed the old spec. Second half: only ['pipeline-state'] was invalidated on a job, never ['spectra', nodeId] / ['results', nodeId], both of which carry staleTime: Infinity. The backend was never involved - driven over HTTP on a seeded project, GET /api/spectra/savgol digest 392e2b377d89657e at window_length 11, PUT 200 at 9, state 'not_run', run 'succeeded', digest f0c7544b7b2191da. `npx playwright test` - 44 passed (1.4m). `npm run test` - 99 passed, 11 files. `npm run typecheck` and `npm run lint` clean. The new e2e test was run against a bundle built from the pre-fix source and failed there (Expected 9, Received 11), then passed after. Driven by hand in Chrome against 127.0.0.1: window_length 11 to 9, one press; after the run the node reads 'SG d1 w9', 'complete', the form shows 9 and the plot is drawn from the recomputed arrays, surviving a reload. Confirmed working by the reporter."
+    },
+    {
+      "id": "complete-reads-green",
+      "priority": 1,
+      "area": "frontend",
+      "issue": 161,
+      "title": "A finished node reads green, and a queued one is not a never-run one",
+      "depends_on": [],
+      "user_visible_behavior": "A node holding a result is bordered green, solid, in both themes; a node waiting its turn during a run is dashed in the accent with an empty progress track, so a run visibly sweeps the graph instead of only the one node the executor is inside.",
+      "status": "passing",
+      "verification": [
+        "pnpm test - tokens.test.ts proves design/canvas/_base.css and frontend/src/styles/tokens.css still agree, with `ok` in both palettes.",
+        "pnpm typecheck && pnpm lint && pnpm build",
+        "pnpm exec playwright test - the whole suite, including the new assertion that node-complete's border resolves to --ok and that --ok is not --accent.",
+        "By eye on a seeded project, both themes."
+      ],
+      "evidence": "2026-09-05. `--ok` added to design/canvas/_base.css first (it is the token source) as #1E7A3C light / #63C67E dark, then ported verbatim to frontend/src/styles/tokens.css and added to the Run state group in tokens.ts. Neither value collides with --accent (#0B6B62 / #54BFAB, which means *running*) nor with the Okabe-Ito series, and tokens.test.ts's 'keeps the accent off the data palette' check now covers `ok` too. `pnpm test` - 99 passed, 11 files, including the two drift checks that compare the artboard palette against the ported one. `pnpm typecheck` and `pnpm lint` clean; `pnpm build` succeeded. `pnpm exec playwright test` - 44 passed (1.4m); the '[WebServer] job ... failed' line in that log is runs.spec.ts's deliberate failing-run fixture, not a test failure. The new assertion in pipeline.spec.ts reads borderTopColor off node-complete, converts it from rgb() to hex and asserts it equals --ok resolved from .app, and separately that --ok is not --accent; it passed as test 14 of 44. Confirmed by eye on a seeded 15-node project served at 127.0.0.1:8793: every node carries a solid green border where all fifteen were previously the same grey as an unrun node. complete stays *solid* while every other state is dashed, hatched or striped, so pipeline.spec.ts's existing form assertion (borderTopStyle 'solid', opacity 1) passed unchanged and the greyscale reading still works."
     }
   ]
 }

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -6,14 +6,25 @@ import { expect, test, type Page } from "@playwright/test";
  * The stub could show all five node states at once because its fixture said
  * so. A real state is a fact about the project: every node here has its arrays
  * on disk, so every node is `complete`. `running`, `failed` and `not_run` are
- * asserted in `runs.spec.ts`, where a run really runs, and `stale` in
- * `inspector.spec.ts`, where an edit really invalidates one. */
+ * asserted in `runs.spec.ts`, where a run really runs. `stale` is asserted
+ * nowhere: the server never reports it (`api.py:955-958`) and #159 removed the
+ * client-side marking that used to, so a node edited but not re-run comes back
+ * `not_run`. The state stays defined and styled against the day it is
+ * derivable. */
 
 async function openCanvas(page: Page) {
   await page.goto("/?token=e2e-token");
   await page.getByRole("button", { name: "Pipeline", exact: true }).click();
   await expect(page.getByTestId("pipeline-canvas")).toBeVisible();
   await expect(page.locator(".react-flow__node").first()).toBeVisible();
+}
+
+/** `getComputedStyle` reports a border colour as `rgb(r, g, b)`; the token is
+ * a hex string. One of them has to be converted, and the hex is the shorter
+ * trip. */
+function hexOf(rgb: string): string {
+  const [r, g, b] = rgb.match(/\d+/g)!.map(Number);
+  return `#${[r, g, b].map((part) => part.toString(16).padStart(2, "0")).join("")}`;
 }
 
 test("the branching pipeline renders with every node the executor ran", async ({ page }) => {
@@ -43,6 +54,21 @@ test("a node that has been run is complete, and says so by form", async ({ page 
     });
   expect(drawn.style).toBe("solid");
   expect(drawn.opacity).toBe(1);
+
+  // Colour as well as form: a node holding a result reads green, and green is
+  // its own token rather than the accent - the accent means *running*, and a
+  // finished node must not be the same colour as one still working.
+  const paint = await page.evaluate(() => {
+    const style = getComputedStyle(document.querySelector(".app")!);
+    const complete = document.querySelector('[data-testid="node-complete"]')!;
+    return {
+      border: getComputedStyle(complete).borderTopColor,
+      ok: style.getPropertyValue("--ok").trim(),
+      accent: style.getPropertyValue("--accent").trim(),
+    };
+  });
+  expect(hexOf(paint.border)).toBe(paint.ok.toLowerCase());
+  expect(paint.ok).not.toBe(paint.accent);
 });
 
 test("selecting a node focuses its tab", async ({ page }) => {

--- a/frontend/src/__tests__/tokens.test.ts
+++ b/frontend/src/__tests__/tokens.test.ts
@@ -52,7 +52,7 @@ it("keeps the accent off the data palette", () => {
   // --fail and --stale are semantic and --d1 to --d6 are Okabe-Ito.
   for (const theme of ["t-light", "t-dark"]) {
     const data = ["d1", "d2", "d3", "d4", "d5", "d6"].map((n) => ported[theme][n]);
-    for (const semantic of ["accent", "fail", "stale"]) {
+    for (const semantic of ["accent", "ok", "fail", "stale"]) {
       expect(data).not.toContain(ported[theme][semantic]);
     }
   }

--- a/frontend/src/canvas/NodeCard.tsx
+++ b/frontend/src/canvas/NodeCard.tsx
@@ -41,11 +41,19 @@ function frame(state: NodeData["state"]): React.CSSProperties {
         borderLeft: "3px solid var(--fail)",
         background: "var(--surface)",
       };
-    case "not_run":
     case "queued":
+      // Dashed like `not_run`, because it has produced nothing either - but in
+      // the accent, so a run visibly sweeps the graph instead of only the one
+      // node the executor happens to be inside.
+      return { border: "1px dashed var(--accent)", background: "var(--surface)" };
+    case "not_run":
       return { border: "1px dashed var(--rule)", background: "var(--surface)" };
     default:
-      return { border: "1px solid var(--rule)", background: "var(--surface)" };
+      // Complete. Solid *and* green: the brief asks for form as well as
+      // colour, and solid is what the other five states are distinguished
+      // from - a canvas read in greyscale still says which nodes hold a
+      // result.
+      return { border: "1px solid var(--ok)", background: "var(--surface)" };
   }
 }
 
@@ -146,9 +154,9 @@ export function NodeCard({ data, selected }: NodeProps) {
         <div className="mono" style={{ fontSize: 9.5, color: "var(--ink3)", marginTop: 2 }}>
           {node.parameters}
         </div>
-        {node.state === "running" && typeof node.progress === "number" ? (
+        {node.state === "running" || node.state === "queued" ? (
           <div className="prog" style={{ width: "100%", marginTop: 6 }}>
-            <i style={{ width: `${Math.round(node.progress * 100)}%` }} />
+            <i style={{ width: `${Math.round((node.progress ?? 0) * 100)}%` }} />
           </div>
         ) : null}
       </div>

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -22,6 +22,7 @@
   --accent:#0B6B62;
   --accentSoft:#DCEDE9;
   --accentInk:#075049;
+  --ok:#1E7A3C;
   --stale:#9A6206;
   --staleSoft:#F7EEDD;
   --fail:#A93226;
@@ -48,6 +49,7 @@
   --accent:#54BFAB;
   --accentSoft:#122A26;
   --accentInk:#7FD3C2;
+  --ok:#63C67E;
   --stale:#DFA85A;
   --staleSoft:#2A2216;
   --fail:#E8887C;

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -8,7 +8,7 @@ export const TOKEN_GROUPS = [
   { label: "Ink", names: ["ink", "ink2", "ink3"] },
   { label: "Rules", names: ["rule", "rule2"] },
   { label: "Accent", names: ["accent", "accentSoft", "accentInk"] },
-  { label: "Run state", names: ["stale", "staleSoft", "fail", "failSoft"] },
+  { label: "Run state", names: ["ok", "stale", "staleSoft", "fail", "failSoft"] },
   { label: "Data series", names: ["d1", "d2", "d3", "d4", "d5", "d6"] },
   { label: "Plot furniture", names: ["grid", "band"] },
 ] as const;


### PR DESCRIPTION
Closes #161. First stage of the editable-canvas work (#164).

A run that worked looked like a run that did nothing. `complete` fell through to `frame()`'s `default` case and drew the same `1px solid var(--rule)` grey as a node nothing had touched, so fifteen finished nodes and fifteen untouched ones were the same picture.

## `--ok` is its own token

Not a reuse of `--accent` (`#0B6B62` / `#54BFAB`): that teal means **running** — the border, the progress bar and the animated edge all use it — and a finished node borrowing it says the executor is still inside it. Not drawn from the Okabe-Ito series either; `tokens.css:8-10` has said since it was written that a failing node must never read as a red spectrum, and the same argument holds for a finished one. `design/canvas/_base.css` is edited **first**, because it is the source the artboards are drawn from and `tokens.test.ts` checks the port against it.

`#1E7A3C` light, `#63C67E` dark.

## Complete stays solid

`design/DESIGN_BRIEF.md` §5 asks that states read "in form as well as colour", and solid is what the other five states are distinguished *from*. The canvas still works in greyscale, and `frontend/e2e/pipeline.spec.ts`'s existing form assertion (`borderTopStyle === "solid"`, `opacity === 1`) passes untouched.

## `queued` is no longer `not_run`

They were byte-identical, so a run in progress was invisible except for the single node the executor happened to be inside. Queued is now dashed in the accent **and** carries the progress track at zero width — an empty track is a *present element*, which survives greyscale where a colour alone does not, and it reuses `.prog` from `frontend/src/styles/shell.css:37` rather than adding CSS.

## Also

`pipeline.spec.ts`'s docstring claimed `inspector.spec.ts` asserts `stale`. It has not since #159 removed the client-side marking, and the server never emitted it. Corrected to say so, and why the state stays defined.

## Verification

- `pnpm test` — **99 passed**, 11 files, including both drift checks comparing the artboard palette to the ported one, now covering `ok`.
- `pnpm typecheck`, `pnpm lint` clean; `pnpm build` succeeded.
- `pnpm exec playwright test` — **44 passed** (1.4m). The `[WebServer] job … failed` line in that log is `runs.spec.ts`'s deliberate failing-run fixture, not a test failure.
- New assertion in `pipeline.spec.ts`: reads `borderTopColor` off `node-complete`, converts `rgb()` to hex, and asserts it equals `--ok` resolved from `.app` — plus that `--ok` is not `--accent`. Passed as test 14 of 44.
- By eye on a seeded 15-node project: every node carries a solid green border where all fifteen were previously the same grey as an unrun node.

## Known limitation, accepted

A node edited but not re-run derives to `not_run` and looks identical to one that never ran. `stale` stays defined and styled but unreachable — the server deliberately never emits it, and deriving it is unsound as framed (`db.CacheEntryRow` has no node-id column). Recorded on #161 and #164.
