### PR TITLE
Let a node be dragged, and remember where it went

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -264,6 +264,24 @@
         "By eye on a seeded project, both themes."
       ],
       "evidence": "2026-09-05. `--ok` added to design/canvas/_base.css first (it is the token source) as #1E7A3C light / #63C67E dark, then ported verbatim to frontend/src/styles/tokens.css and added to the Run state group in tokens.ts. Neither value collides with --accent (#0B6B62 / #54BFAB, which means *running*) nor with the Okabe-Ito series, and tokens.test.ts's 'keeps the accent off the data palette' check now covers `ok` too. `pnpm test` - 99 passed, 11 files, including the two drift checks that compare the artboard palette against the ported one. `pnpm typecheck` and `pnpm lint` clean; `pnpm build` succeeded. `pnpm exec playwright test` - 44 passed (1.4m); the '[WebServer] job ... failed' line in that log is runs.spec.ts's deliberate failing-run fixture, not a test failure. The new assertion in pipeline.spec.ts reads borderTopColor off node-complete, converts it from rgb() to hex and asserts it equals --ok resolved from .app, and separately that --ok is not --accent; it passed as test 14 of 44. Confirmed by eye on a seeded 15-node project served at 127.0.0.1:8793: every node carries a solid green border where all fifteen were previously the same grey as an unrun node. complete stays *solid* while every other state is dashed, hatched or striped, so pipeline.spec.ts's existing form assertion (borderTopStyle 'solid', opacity 1) passed unchanged and the greyscale reading still works."
+    },
+    {
+      "id": "canvas-nodes-are-dragged",
+      "priority": 1,
+      "area": "frontend",
+      "issue": 162,
+      "title": "A node is dragged, and stays where it is put",
+      "depends_on": [],
+      "user_visible_behavior": "A node on the canvas is dragged to a new place and stays there, across a reload and across a restart. The drag writes through on the drop rather than waiting on Save, and does not open the node's tab. A node the server has never placed lands beside its parent instead of at the origin.",
+      "status": "passing",
+      "verification": [
+        "uv run pytest - PUT /api/pipelines/current/layout stores a position, GET .../state reports it, and GET /api/pipelines/current is byte-identical either side, so the cache key does not move.",
+        "A position for a node not in the pipeline is dropped rather than refused; a non-numeric coordinate is 422; an unknown pipeline id is 404.",
+        "pnpm test - a node absent from the layout lands beside its parent, and two new children of one parent do not stack.",
+        "pnpm exec playwright test - the whole suite, including the drag writing through and not opening the tab.",
+        "uv run ruff check && uv run ruff format --check && uv run mypy; pnpm typecheck && pnpm lint && pnpm build"
+      ],
+      "evidence": "2026-09-05. `PUT /pipelines/{id}/layout` added beside put_pipeline, with its own LayoutWrite body and a typed Position, so layout still never touches Pipeline.content_hash() - the reason it has its own table. Positions for unknown node ids are filtered rather than refused, which also collects a removed node's coordinates instead of leaving them in a table nothing prunes. Frontend: nodesDraggable={false} removed, onNodesChange narrowed to position changes only (React Flow will not move a controlled node without it), onNodeDragStop writes through useSaveLayout with no debounce because it already fires once per drag. Two regressions were anticipated and handled: the click that ends a drag is consumed so moving a node does not also open its tab, and the three header buttons got React Flow's `nodrag` class or they would have become drag handles. graph.ts gained `placements`, which puts an unplaced node beside its parent at the same 170/130 step the server uses - previously graph.ts:104 fell back to {x:0,y:0} and duplicates stacked at the origin. `uv run pytest` exit 0. `uv run ruff check` and `uv run mypy` (54 files) clean; ruff format reformatted one file, then clean. `pnpm test` - 102 passed, 11 files (99 before, +3 for placements). `pnpm typecheck` and `pnpm lint` clean after fixing a real exhaustive-deps warning: `moved` was read inside the graph useMemo but missing from its deps, so a drag would not have redrawn. `pnpm exec playwright test` - 45 passed (2.2m), 44 before plus the new drag test. One test failure along the way was the test's own fault and worth recording: the first version compared the node's screen bounding box either side of a reload and failed 529 vs 383, because `fitView` re-fits the viewport on every mount - a node that has not moved in the graph still lands on a different pixel. It now asserts the layout the server holds, which is the actual claim; that the canvas draws what the layout says is graph.test.ts's job and it has one."
     }
   ]
 }

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -215,3 +215,64 @@ test("picking two terminal nodes opens a comparison tab", async ({ page }) => {
   await expect(page.getByRole("region", { name: "Metrics" })).toBeVisible();
   await expect(page.getByTestId("delta-RMSECV")).toHaveText("—");
 });
+
+/** Dragging a node writes its position through on the drop, without waiting on
+ * Save - a position is not part of the recipe.
+ *
+ * The survival of a reload is asserted against the layout the server holds,
+ * not against a screen coordinate: `fitView` re-fits the viewport on every
+ * mount, so a node that has not moved an inch in the graph still lands on a
+ * different pixel. Reading the box either side of a reload compares two
+ * different zoom levels and fails on a change that did not happen. That the
+ * canvas draws what the layout says is `graph.test.ts`'s job, and it has one.
+ *
+ * Unlike the edits above, this one *does* change the seeded project on 8765.
+ * Safe because every other spec there asserts node counts, edges and states,
+ * never coordinates - said out loud so the next person to assert a position
+ * knows why theirs might move.
+ */
+test("a dragged node is written through on the drop, and not opened by the drag", async ({
+  page,
+}) => {
+  await openCanvas(page);
+  const node = page.locator('.react-flow__node[data-id="snv"]');
+  const before = (await node.boundingBox())!;
+
+  // A real mouse path, for the same reason `connect` uses one: React Flow
+  // follows pointer movement rather than a drop event.
+  await page.mouse.move(before.x + before.width / 2, before.y + 10);
+  await page.mouse.down();
+  await page.mouse.move(before.x + before.width / 2 + 160, before.y + 130, { steps: 12 });
+  await page.mouse.up();
+
+  // Within one mount the viewport is fixed, so the box is a fair comparison.
+  const after = (await node.boundingBox())!;
+  expect(Math.round(after.x - before.x)).toBeGreaterThan(100);
+
+  // The drag consumed the click that ends it: moving a node must not open it.
+  await expect(page.getByRole("tab", { name: /SNV/ })).toHaveCount(0);
+
+  // The claim: the server holds it, so it outlives this page.
+  await expect
+    .poll(async () => {
+      const state = await page.request.get("/api/pipelines/current/state", {
+        headers: { Authorization: "Bearer e2e-token" },
+      });
+      return (await state.json()).layout.snv;
+    })
+    .not.toEqual({ x: 40, y: 170 });
+
+  const moved = await (
+    await page.request.get("/api/pipelines/current/state", {
+      headers: { Authorization: "Bearer e2e-token" },
+    })
+  ).json();
+
+  await openCanvas(page);
+  const reloaded = await (
+    await page.request.get("/api/pipelines/current/state", {
+      headers: { Authorization: "Bearer e2e-token" },
+    })
+  ).json();
+  expect(reloaded.layout.snv).toEqual(moved.layout.snv);
+});

--- a/frontend/src/__tests__/graph.test.ts
+++ b/frontend/src/__tests__/graph.test.ts
@@ -12,7 +12,15 @@ import { describe, expect, it } from "vitest";
 
 import type { Pipeline, PipelineNode, PipelineState } from "@/api/queries";
 import { withDrafts } from "@/canvas/PipelineCanvas";
-import { draftGraph, nodeStateOf, parameterLine, toEdges, toNodes, type DraftStep } from "@/canvas/graph";
+import {
+  draftGraph,
+  nodeStateOf,
+  parameterLine,
+  placements,
+  toEdges,
+  toNodes,
+  type DraftStep,
+} from "@/canvas/graph";
 
 const FIXTURES = path.resolve(import.meta.dirname, "../../../tests/fixtures/contract");
 const read = <T,>(name: string) =>
@@ -168,5 +176,32 @@ describe("withDrafts", () => {
   it("returns the saved nodes untouched when there is nothing drafted", () => {
     const saved = [source];
     expect(withDrafts(saved, [])).toBe(saved);
+  });
+});
+
+describe("a node the server has never placed", () => {
+  // A duplicate, or a step added to a branch, exists on the canvas before the
+  // server has seen it. It used to fall back to the origin, so every new node
+  // appeared in the same spot and copies stacked on top of each other.
+  const added: PipelineNode = { id: "msc_2", type: "preprocess", inputs: ["snv"], step: { kind: "msc" } };
+  const extended: Pipeline = { ...pipeline, nodes: [...pipeline.nodes, added] };
+
+  it("lands beside its parent, not at the origin", () => {
+    const placed = placements(extended, state.layout);
+    expect(placed.msc_2).not.toEqual({ x: 0, y: 0 });
+    expect(placed.msc_2.x).toBe(placed.snv.x + 170);
+  });
+
+  it("leaves every placed node exactly where the server put it", () => {
+    const placed = placements(extended, state.layout);
+    for (const [id, position] of Object.entries(state.layout)) {
+      expect(placed[id]).toEqual(position);
+    }
+  });
+
+  it("does not stack two new children of the same parent", () => {
+    const second: PipelineNode = { id: "msc_3", type: "preprocess", inputs: ["snv"], step: { kind: "msc" } };
+    const placed = placements({ ...extended, nodes: [...extended.nodes, second] }, state.layout);
+    expect(placed.msc_2).not.toEqual(placed.msc_3);
   });
 });

--- a/frontend/src/api/queries.ts
+++ b/frontend/src/api/queries.ts
@@ -278,6 +278,25 @@ export function usePipelineState() {
  * arrays under the new key and comes back `not_run`. Nothing here writes
  * staleness; it is read back out of the store.
  */
+/** Where the canvas put its nodes.
+ *
+ * Its own mutation against its own endpoint, mirroring the split the server
+ * makes: a position lives outside `Pipeline.content_hash()`, so writing one
+ * must not go through the body that carries the recipe. Nothing is
+ * invalidated afterwards - the canvas already holds the position it just
+ * sent, and the next `pipeline-state` fetch will echo the same value back.
+ */
+export function useSaveLayout() {
+  return useMutation({
+    mutationFn: (layout: Record<string, { x: number; y: number }>) =>
+      api<{ layout: Record<string, { x: number; y: number }> }>("/pipelines/current/layout", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ layout }),
+      }),
+  });
+}
+
 export function useSavePipeline() {
   const client = useQueryClient();
   return useMutation({

--- a/frontend/src/canvas/NodeCard.tsx
+++ b/frontend/src/canvas/NodeCard.tsx
@@ -108,7 +108,7 @@ export function NodeCard({ data, selected }: NodeProps) {
               Offered only where there is something to compare. */}
           {node.onCompare ? (
             <button
-              className="tabx"
+              className="tabx nodrag"
               aria-label={`${node.comparing ? "Unpick" : "Pick"} ${node.label} for comparison`}
               aria-pressed={node.comparing}
               style={{ color: node.comparing ? "var(--accentInk)" : undefined }}
@@ -122,7 +122,7 @@ export function NodeCard({ data, selected }: NodeProps) {
           ) : null}
           {node.onDuplicate ? (
             <button
-              className="tabx"
+              className="tabx nodrag"
               aria-label={`Duplicate node ${node.label}`}
               onClick={(event) => {
                 event.stopPropagation();
@@ -134,7 +134,7 @@ export function NodeCard({ data, selected }: NodeProps) {
           ) : null}
           {node.onRemove ? (
             <button
-              className="tabx"
+              className="tabx nodrag"
               aria-label={`Remove node ${node.label}`}
               onClick={(event) => {
                 event.stopPropagation();

--- a/frontend/src/canvas/PipelineCanvas.tsx
+++ b/frontend/src/canvas/PipelineCanvas.tsx
@@ -1,9 +1,15 @@
-import { Background, BackgroundVariant, ReactFlow, type Node } from "@xyflow/react";
+import {
+  Background,
+  BackgroundVariant,
+  ReactFlow,
+  type Node,
+  type NodeChange,
+} from "@xyflow/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { ApiError, api } from "@/api/client";
 import type { PipelineNode } from "@/api/queries";
-import { usePipeline, usePipelineState, useSavePipeline } from "@/api/queries";
+import { usePipeline, usePipelineState, useSaveLayout, useSavePipeline } from "@/api/queries";
 import { NodeCard } from "@/canvas/NodeCard";
 import { StepList } from "@/canvas/StepList";
 import { connect, connectionRefusal, duplicate, remove, terminals } from "@/canvas/edits";
@@ -92,6 +98,15 @@ export function PipelineCanvas({
   /** The nodes picked for a comparison. Two opens the tab and clears it, so
    * the control is a toggle with a very short memory rather than a mode. */
   const [picked, setPicked] = useState<string[]>([]);
+  /** Where the user has dragged nodes since the last fetch, laid over the
+   * layout the server sent. Local because a position is not part of the
+   * recipe: it is written by its own request and must not wait on Save. */
+  const [moved, setMoved] = useState<Record<string, { x: number; y: number }>>({});
+  const saveLayout = useSaveLayout();
+  // A drag ends with a click on the same node, and a click opens its tab. The
+  // drag is recorded here so the click that follows it can be ignored - one
+  // gesture should not both move a node and open it.
+  const dragged = useRef(false);
 
   // Memoised because it feeds the graph's useMemo: a fresh [] every render
   // would rebuild the whole graph on every keystroke elsewhere in the tab.
@@ -146,10 +161,13 @@ export function PipelineCanvas({
         usesMotion(),
       ),
     };
+    committed.nodes = committed.nodes.map((node) =>
+      moved[node.id] ? { ...node, position: moved[node.id] } : node,
+    );
     const lowest = Math.max(...committed.nodes.map((node) => node.position.y), 0);
     const draft = draftGraph(steps, { x: 40, y: lowest + 150 });
     return { nodes: [...committed.nodes, ...draft.nodes], edges: [...committed.edges, ...draft.edges] };
-  }, [pipeline.data, state.data, steps, nodes, picked, onCompare, pick]);
+  }, [pipeline.data, state.data, steps, nodes, picked, onCompare, pick, moved]);
 
   /** An edit that a rule refuses says so, rather than throwing into the void. */
   const edit = (apply: () => PipelineNode[]) => {
@@ -169,8 +187,29 @@ export function PipelineCanvas({
           edges={graph.edges}
           nodeTypes={NODE_TYPES}
           fitView
-          nodesDraggable={false}
           nodesConnectable
+          onNodesChange={(changes: NodeChange[]) => {
+            // Only positions. React Flow also reports selection, dimensions
+            // and removal here, and this canvas derives all three from the
+            // pipeline rather than from React Flow's own node state.
+            const positions = changes.filter(
+              (change): change is Extract<NodeChange, { type: "position" }> =>
+                change.type === "position" && change.position !== undefined,
+            );
+            if (positions.length === 0) return;
+            setMoved((current) => {
+              const next = { ...current };
+              for (const change of positions) next[change.id] = change.position!;
+              return next;
+            });
+          }}
+          onNodeDragStop={(_event, node) => {
+            dragged.current = true;
+            // A draft has no node on the server to hang a position on; it gets
+            // one when Save turns it into a real node.
+            if (String(node.id).startsWith("draft-")) return;
+            saveLayout.mutate({ ...moved, [node.id]: node.position });
+          }}
           proOptions={{ hideAttribution: true }}
           isValidConnection={(connection) => {
             const { source, target } = connection;
@@ -191,6 +230,13 @@ export function PipelineCanvas({
             refusal.current = null;
           }}
           onNodeClick={(_, node: Node) => {
+            // A drag ends with a click on the node it moved. Opening its tab
+            // there would mean no node could be moved without also being
+            // opened, so the drag consumes the click that follows it.
+            if (dragged.current) {
+              dragged.current = false;
+              return;
+            }
             // Selecting a node focuses its tab - the mechanism that ties the
             // graph to the pages.
             if (String(node.id).startsWith("draft-")) return;

--- a/frontend/src/canvas/graph.ts
+++ b/frontend/src/canvas/graph.ts
@@ -88,6 +88,58 @@ export function nodeStateOf(
   };
 }
 
+/** The layout the server sent, with somewhere sensible for anything it has
+ * not placed.
+ *
+ * A node created on the canvas - a duplicate, or a step added to a branch -
+ * exists before the server has ever seen it, so it has no stored position. It
+ * used to fall back to the origin, which put every new node in the same place
+ * and stacked copies on top of each other. Beside its parent is the answer the
+ * server already gives for a node it generates a position for, at the same
+ * 170/130 step, so a node that has just been added and one that has been
+ * reloaded land in the same kind of place.
+ */
+export function placements(
+  pipeline: Pipeline,
+  layout: PipelineState["layout"] | undefined,
+): Record<string, { x: number; y: number }> {
+  const placed: Record<string, { x: number; y: number }> = { ...(layout ?? {}) };
+  const taken = new Set(Object.keys(placed));
+
+  // Parents before children: a node placed beside its parent needs the parent
+  // placed first, and a chain of new nodes needs each link in turn.
+  const order = [...pipeline.nodes].sort(
+    (left, right) => depthOf(left.id, pipeline) - depthOf(right.id, pipeline),
+  );
+  for (const node of order) {
+    if (placed[node.id]) continue;
+    const parent = node.inputs[0] ? placed[node.inputs[0]] : undefined;
+    const siblings = [...taken].filter((id) => id !== node.id).length;
+    placed[node.id] = parent
+      ? { x: parent.x + 170, y: parent.y + 130 * pending(node.id, pipeline, taken) }
+      : { x: 40, y: 40 + 130 * siblings };
+    taken.add(node.id);
+  }
+  return placed;
+}
+
+/** How many already-placed nodes share this one's parent, so a second new
+ * child sits below the first rather than on it. */
+function pending(id: string, pipeline: Pipeline, taken: Set<string>): number {
+  const parent = pipeline.nodes.find((node) => node.id === id)?.inputs[0];
+  if (!parent) return 0;
+  return pipeline.nodes.filter(
+    (node) => node.inputs[0] === parent && node.id !== id && taken.has(node.id),
+  ).length;
+}
+
+function depthOf(id: string, pipeline: Pipeline, seen = new Set<string>()): number {
+  if (seen.has(id)) return 0;
+  seen.add(id);
+  const parent = pipeline.nodes.find((node) => node.id === id)?.inputs[0];
+  return parent ? 1 + depthOf(parent, pipeline, seen) : 0;
+}
+
 export function toNodes(
   pipeline: Pipeline,
   state: PipelineState | undefined,
@@ -96,12 +148,13 @@ export function toNodes(
   compare?: { ids: string[]; terminals: Set<string>; onCompare: (id: string) => void },
   onDuplicate?: (id: string) => void,
 ): FlowNode[] {
+  const placed = placements(pipeline, state?.layout);
   return pipeline.nodes.map((node) => {
     const status = nodeStateOf(node.id, state);
     return {
       id: node.id,
       type: "workbench" as const,
-      position: state?.layout?.[node.id] ?? { x: 0, y: 0 },
+      position: placed[node.id],
       data: {
         label: labelOf(node),
         type: node.type,

--- a/src/chemometrics_workbench/api.py
+++ b/src/chemometrics_workbench/api.py
@@ -1054,6 +1054,66 @@ def put_pipeline(pipeline_id: str, body: PipelineWrite) -> Any:
     return json.loads(updated.model_dump_json())
 
 
+class Position(BaseModel):
+    """One node's place on the canvas.
+
+    Typed rather than a bare dict so a coordinate that is not a number is
+    refused at the boundary, where the message can say which node and which
+    field - `write_layout` would coerce it and store something undrawable.
+    """
+
+    x: float
+    y: float
+
+
+class LayoutWrite(BaseModel):
+    """Where the canvas put each node.
+
+    Its own body and its own endpoint, for the reason `PipelineWrite` gives for
+    not carrying it: a position lives outside `Pipeline.content_hash()` so that
+    moving a node cannot invalidate an executor cache entry, and a field on the
+    recipe's body would undo that in one line. Separate table, separate route,
+    separate write.
+    """
+
+    layout: dict[str, Position]
+
+
+@router.put("/pipelines/{pipeline_id}/layout")
+def put_layout(pipeline_id: str, body: LayoutWrite) -> Any:
+    """Replace the stored layout with the one sent.
+
+    **The whole map, not a patch**, for the same reason `put_pipeline` takes
+    the whole node list: one project holds one pipeline and one person moves
+    its nodes, so last-write-wins needs no conflict rules and the canvas
+    already knows where everything is.
+
+    **A position for a node that is not in the pipeline is dropped, not
+    refused.** The canvas and the recipe are written by two different requests,
+    so a drag can land after another tab has deleted the node it moved; a 422
+    there would be an error message about a race the user cannot see. Dropping
+    is also the only garbage collection in this codebase that costs nothing -
+    a removed node's coordinates go with it rather than accumulating in a table
+    nobody prunes.
+    """
+    directory, _ = _project()
+    pipeline = _current_pipeline(directory)
+    if pipeline_id not in ("current", str(pipeline.pipeline_id)):
+        raise _fail(404, "not_found", f"no pipeline {pipeline_id}.", pipeline_id=pipeline_id)
+
+    known = {node.id for node in pipeline.nodes}
+    placed = {
+        node_id: {"x": float(place.x), "y": float(place.y)}
+        for node_id, place in body.layout.items()
+        if node_id in known
+    }
+    try:
+        write_layout(directory, placed)
+    except ProjectError as error:
+        raise _fail(500, "project_unavailable", str(error)) from error
+    return {"pipeline_id": str(pipeline.pipeline_id), "layout": placed}
+
+
 @router.post("/pipelines/{pipeline_id}/validate")
 def validate_pipeline(pipeline_id: str) -> Any:
     directory, _ = _project()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -215,6 +215,71 @@ def test_node_state_is_derived_from_what_is_on_disk(client: TestClient) -> None:
     assert after["nodes"]["source"]["state"] == "complete"
 
 
+def test_a_moved_node_is_remembered_and_the_recipe_is_untouched(client: TestClient) -> None:
+    """Moving a node must not change the science.
+
+    The whole reason layout has its own table and its own route: a position is
+    written without touching `Pipeline.content_hash()`, so an executor cache
+    entry keyed on that hash still matches and a node that was `complete` stays
+    `complete`. Asserting the recipe is byte-identical either side of the move
+    is what proves it - a layout folded into `PipelineWrite` would pass every
+    other assertion here and fail this one.
+    """
+    imported(client)
+    recipe = client.get("/api/pipelines/current", headers=AUTH).json()
+
+    written = client.put(
+        "/api/pipelines/current/layout",
+        json={"layout": {"source": {"x": 500, "y": 300}}},
+        headers=AUTH,
+    )
+    assert written.status_code == 200, written.text
+    assert written.json()["layout"] == {"source": {"x": 500.0, "y": 300.0}}
+
+    state = client.get("/api/pipelines/current/state", headers=AUTH).json()
+    assert state["layout"]["source"] == {"x": 500.0, "y": 300.0}
+    assert client.get("/api/pipelines/current", headers=AUTH).json() == recipe
+
+
+def test_a_position_for_a_node_that_is_gone_is_dropped(client: TestClient) -> None:
+    """A drag can land after another tab deleted the node it moved.
+
+    Refusing the whole write there would be an error about a race the user
+    cannot see, and would lose the positions that *are* valid. Dropping is also
+    the cheapest garbage collection available: a removed node's coordinates go
+    with it instead of accumulating in a table nothing prunes.
+    """
+    imported(client)
+    written = client.put(
+        "/api/pipelines/current/layout",
+        json={"layout": {"source": {"x": 10, "y": 20}, "ghost": {"x": 1, "y": 2}}},
+        headers=AUTH,
+    )
+    assert written.status_code == 200, written.text
+    assert written.json()["layout"] == {"source": {"x": 10.0, "y": 20.0}}
+    assert "ghost" not in client.get("/api/pipelines/current/state", headers=AUTH).json()["layout"]
+
+
+def test_a_coordinate_that_is_not_a_number_is_refused(client: TestClient) -> None:
+    imported(client)
+    refused = client.put(
+        "/api/pipelines/current/layout",
+        json={"layout": {"source": {"x": "left", "y": 0}}},
+        headers=AUTH,
+    )
+    assert refused.status_code == 422, refused.text
+
+
+def test_an_unknown_pipeline_has_no_layout_to_write(client: TestClient) -> None:
+    imported(client)
+    missing = client.put(
+        "/api/pipelines/00000000-0000-0000-0000-000000000000/layout",
+        json={"layout": {}},
+        headers=AUTH,
+    )
+    assert missing.status_code == 404, missing.text
+
+
 def test_a_run_is_submitted_and_answers_before_it_has_finished(client: TestClient) -> None:
     imported(client)
     job = client.post("/api/experiments/current/run", headers=AUTH).json()


### PR DESCRIPTION
Closes #162. Second stage of the editable-canvas work (#164).

The canvas drew where the server said and had no way to answer back: `nodesDraggable={false}`, and `PipelineCanvas.tsx:29` said so in its own docstring. The storage half already existed and was unused from HTTP — `project.write_layout` had been called exactly once, seeding the source at (40,40).

## The endpoint

`PUT /pipelines/{id}/layout`, its own route with its own body, for exactly the reason `PipelineWrite`'s docstring gives for refusing to carry layout: a position lives outside `Pipeline.content_hash()`, so writing one must not travel through the recipe. Folding coordinates into `PipelineWrite` would undo that in one line.

**A test asserts `GET /api/pipelines/current` is byte-identical either side of a move** — that is what proves the cache key did not shift and a `complete` node stayed `complete`.

**A position for a node not in the pipeline is dropped, not refused.** The recipe and the canvas are two separate requests, so a drag can land after another tab deleted what it moved, and a 422 there is an error message about a race the user cannot see. It is also the only garbage collection in this codebase that costs nothing — a removed node's coordinates go with it instead of accumulating in a table nothing prunes (`project.py:622-628`).

## Two regressions that came with draggable nodes, both handled

1. **A drag ends with a click on the node it moved**, and a click opens that node's tab — so no node could have been moved without also being opened. The drag now consumes the click that follows it.
2. **The three header buttons start a drag on pointer-down** unless they carry React Flow's `nodrag`. Without it, remove, duplicate and compare stop behaving as buttons. All four canvas e2e tests for those still pass, so the ports and the buttons both survived.

`onNodesChange` is narrowed to position changes only — React Flow will not move a controlled node without the handler, but selection, dimensions and removal are all derived from the pipeline here, not from React Flow's own state. No debounce: `onNodeDragStop` already fires once per drag.

## Unplaced nodes no longer stack at the origin

A duplicate exists on the canvas before the server has seen it, so it had no stored position and `graph.ts:104` fell back to `{x: 0, y: 0}` — every copy in the same spot. `placements()` now puts an unplaced node beside its parent at the same 170/130 step the server uses for nodes it places itself. Pure, and unit-tested without a browser.

## Verification

- `uv run pytest` — exit 0. Four new tests: the position round-trips and the recipe is unchanged; an unknown node id is dropped; a non-numeric coordinate is 422; an unknown pipeline is 404.
- `uv run ruff check` and `uv run mypy` (54 files) clean. `ruff format` reformatted one file, then clean.
- `pnpm test` — **102 passed** (99 before, +3 for `placements`).
- `pnpm typecheck` and `pnpm lint` clean, after fixing a real `exhaustive-deps` warning: `moved` was read inside the graph `useMemo` but missing from its dependency array, so a drag would not have redrawn.
- `pnpm exec playwright test` — **45 passed** (2.2m), 44 before plus the new drag test.

## A test failure worth recording

The first version of the drag test compared the node's screen bounding box either side of a reload and failed, 529 vs 383. Nothing was wrong with the feature: **`fitView` re-fits the viewport on every mount**, so a node that has not moved an inch in the graph still lands on a different pixel. It now asserts the layout the server holds, which is the actual claim — that the canvas draws what the layout says is `graph.test.ts`'s job, and it already has a test for it.
