### PR TITLE
Add a step onto the node its connector came from

### DIFF
--- a/feature_list.json
+++ b/feature_list.json
@@ -282,6 +282,24 @@
         "uv run ruff check && uv run ruff format --check && uv run mypy; pnpm typecheck && pnpm lint && pnpm build"
       ],
       "evidence": "2026-09-05. `PUT /pipelines/{id}/layout` added beside put_pipeline, with its own LayoutWrite body and a typed Position, so layout still never touches Pipeline.content_hash() - the reason it has its own table. Positions for unknown node ids are filtered rather than refused, which also collects a removed node's coordinates instead of leaving them in a table nothing prunes. Frontend: nodesDraggable={false} removed, onNodesChange narrowed to position changes only (React Flow will not move a controlled node without it), onNodeDragStop writes through useSaveLayout with no debounce because it already fires once per drag. Two regressions were anticipated and handled: the click that ends a drag is consumed so moving a node does not also open its tab, and the three header buttons got React Flow's `nodrag` class or they would have become drag handles. graph.ts gained `placements`, which puts an unplaced node beside its parent at the same 170/130 step the server uses - previously graph.ts:104 fell back to {x:0,y:0} and duplicates stacked at the origin. `uv run pytest` exit 0. `uv run ruff check` and `uv run mypy` (54 files) clean; ruff format reformatted one file, then clean. `pnpm test` - 102 passed, 11 files (99 before, +3 for placements). `pnpm typecheck` and `pnpm lint` clean after fixing a real exhaustive-deps warning: `moved` was read inside the graph useMemo but missing from its deps, so a drag would not have redrawn. `pnpm exec playwright test` - 45 passed (2.2m), 44 before plus the new drag test. One test failure along the way was the test's own fault and worth recording: the first version compared the node's screen bounding box either side of a reload and failed 529 vs 383, because `fitView` re-fits the viewport on every mount - a node that has not moved in the graph still lands on a different pixel. It now asserts the layout the server holds, which is the actual claim; that the canvas draws what the layout says is graph.test.ts's job and it has one."
+    },
+    {
+      "id": "step-added-from-the-canvas",
+      "priority": 1,
+      "area": "frontend",
+      "issue": 163,
+      "title": "A step is added onto the node it was dragged from",
+      "depends_on": [
+        "canvas-nodes-are-dragged"
+      ],
+      "user_visible_behavior": "Dragging a connector from a node's output port and dropping it on empty canvas opens a menu of the steps this build can run. The chosen step becomes a node hung off the node the connector came from, placed where it was dropped.",
+      "verification": [
+        "pnpm test - add() hangs the node off the parent it was given, derives a non-colliding id, refuses an unknown parent, and can create a split.",
+        "pnpm exec playwright test - the whole suite, including the drop menu appearing, offering PLS but not PLS-DA, attaching to the node dragged from, and landing near the drop point.",
+        "pnpm typecheck && pnpm lint && pnpm build"
+      ],
+      "status": "passing",
+      "evidence": "2026-09-05. The parent is no longer guessed. `withDrafts` appends to the first terminal node and its own docstring admits choosing a branch was left to #51; the menu's parent is the node whose connector was dragged, so the question does not arise. Built on onConnectEnd, which was already wired for refusals: a drop where `state.isValid` is null landed on nothing, and that is the offer to add a step. The React Flow instance is captured from onInit rather than useReactFlow(), which would have needed a provider this component does not have. The catalogue moved out of StepList.tsx into canvas/catalogue.ts so the list and the menu share one set; PLS 5 LV and K-fold 10 were added to the menu, and PLS-DA, train_test, repeated_kfold and external deliberately left out because executor.py cannot run them - a shorter menu beats a pipeline that looks fine and dies on Run. `numberedId` was added to edits.ts and withDrafts now calls it, removing the second copy of the same id-minting loop. `pnpm test` - 106 passed, 11 files (102 before, +4 for add()). `pnpm typecheck` and `pnpm lint` clean. `pnpm exec playwright test` - 46 passed (1.5m), 45 before plus the drop-menu test, which asserts the menu appears, contains PLS 5 LV and not PLS-DA, that picking Autoscale creates edge msc->autoscale, and that the node lands right and below the drop point rather than at the origin. DraftStep's `type` had to stay narrow: it knows only the two kinds the side list can draw as a draft chain, so CatalogueStep widens it to include `split` for the menu, which creates real nodes directly."
     }
   ]
 }

--- a/frontend/e2e/pipeline.spec.ts
+++ b/frontend/e2e/pipeline.spec.ts
@@ -276,3 +276,51 @@ test("a dragged node is written through on the drop, and not opened by the drag"
   ).json();
   expect(reloaded.layout.snv).toEqual(moved.layout.snv);
 });
+
+/** Dropping a connector on empty canvas offers the steps this build can run,
+ * and the one that is picked hangs off the node the drag started from.
+ *
+ * This is the answer to the parent `withDrafts` has to guess: it appends to
+ * the first terminal node and says in its own docstring that choosing a branch
+ * was left undone. Here the parent is not chosen at all - it is wherever the
+ * connector came from.
+ *
+ * Edits and never saves, so the seeded project on 8765 is left as the other
+ * specs expect.
+ */
+test("a connector dropped on empty canvas adds a step onto the node it came from", async ({
+  page,
+}) => {
+  await openCanvas(page);
+  const before = await page.locator(".react-flow__node").count();
+
+  const port = page.locator('.react-flow__node[data-id="msc"] .react-flow__handle-right');
+  const source = (await port.boundingBox())!;
+  await page.mouse.move(source.x + source.width / 2, source.y + source.height / 2);
+  await page.mouse.down();
+  // Into empty space well below the graph, so the drop lands on nothing.
+  await page.mouse.move(source.x + 220, source.y + 300, { steps: 12 });
+  await page.mouse.up();
+
+  const menu = page.getByTestId("add-step-menu");
+  await expect(menu).toBeVisible();
+  await expect(menu).toContainText("msc");
+
+  // Only what the executor can actually fit: PLS-DA has no kernel, and
+  // train/test, repeated k-fold and external splits raise at run time.
+  await expect(menu.getByRole("menuitem", { name: "PLS-DA" })).toHaveCount(0);
+  await expect(menu.getByRole("menuitem", { name: "PLS 5 LV" })).toHaveCount(1);
+
+  await menu.getByRole("menuitem", { name: "Autoscale" }).click();
+  await expect(page.getByTestId("add-step-menu")).toHaveCount(0);
+  await expect(page.locator(".react-flow__node")).toHaveCount(before + 1);
+
+  // Hung off the node the connector came from, not off a terminal node.
+  await expect(page.locator('.react-flow__edge[data-id="msc->autoscale"]')).toHaveCount(1);
+
+  // And placed where it was dropped rather than at the origin, where every
+  // unplaced node used to land on top of every other.
+  const added = (await page.locator('.react-flow__node[data-id="autoscale"]').boundingBox())!;
+  expect(added.x).toBeGreaterThan(source.x);
+  expect(added.y).toBeGreaterThan(source.y);
+});

--- a/frontend/src/__tests__/edits.test.ts
+++ b/frontend/src/__tests__/edits.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from "vitest";
 
 import type { PipelineNode } from "@/api/queries";
 import {
+  add,
   connect,
   connectionRefusal,
   duplicate,
@@ -188,5 +189,42 @@ describe("terminal nodes", () => {
 
   it("is the last node of a plain chain", () => {
     expect(terminals(chain).map((node) => node.id)).toEqual(["pca"]);
+  });
+});
+
+describe("adding a step", () => {
+  // The parent is the node whose connector was dragged, so it is never the
+  // "first terminal node" guess `withDrafts` makes and admits to.
+  it("hangs the new node off the parent it was given, not off an end", () => {
+    const grown = add(chain, "source", { type: "preprocess", step: { kind: "msc" } }, "MSC");
+    expect(grown).toHaveLength(4);
+    expect(grown.at(-1)!.inputs).toEqual(["source"]);
+    // The branch it was added to is untouched: this is a fork, not an insert.
+    expect(grown.find((node) => node.id === "snv")!.inputs).toEqual(["source"]);
+  });
+
+  it("derives an id from the step, and does not collide with itself", () => {
+    const once = add(chain, "snv", { type: "preprocess", step: { kind: "msc" } }, "MSC");
+    const twice = add(once, "snv", { type: "preprocess", step: { kind: "msc" } }, "MSC");
+    const added = twice.slice(chain.length).map((node) => node.id);
+    expect(added).toEqual(["msc", "msc_2"]);
+    expect(new Set(twice.map((node) => node.id)).size).toBe(twice.length);
+  });
+
+  it("refuses a parent that is not in the pipeline", () => {
+    expect(() => add(chain, "ghost", { type: "preprocess", step: { kind: "msc" } }, "MSC")).toThrow(
+      "not in this pipeline",
+    );
+  });
+
+  it("can add a split, which the side list cannot draft", () => {
+    const split = add(
+      chain,
+      "snv",
+      { type: "split", spec: { kind: "kfold", n_splits: 10, shuffle: true, seed: 42 } },
+      "K-fold 10",
+    );
+    expect(split.at(-1)!.type).toBe("split");
+    expect(split.at(-1)!.id).toBe("k_fold_10");
   });
 });

--- a/frontend/src/canvas/PipelineCanvas.tsx
+++ b/frontend/src/canvas/PipelineCanvas.tsx
@@ -4,16 +4,33 @@ import {
   ReactFlow,
   type Node,
   type NodeChange,
+  type ReactFlowInstance,
 } from "@xyflow/react";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { ApiError, api } from "@/api/client";
 import type { PipelineNode } from "@/api/queries";
 import { usePipeline, usePipelineState, useSaveLayout, useSavePipeline } from "@/api/queries";
+import { STEP_MENU } from "@/canvas/catalogue";
 import { NodeCard } from "@/canvas/NodeCard";
 import { StepList } from "@/canvas/StepList";
-import { connect, connectionRefusal, duplicate, remove, terminals } from "@/canvas/edits";
-import { draftGraph, toEdges, toNodes, type DraftStep } from "@/canvas/graph";
+import {
+  add,
+  connect,
+  connectionRefusal,
+  duplicate,
+  numberedId,
+  remove,
+  terminals,
+} from "@/canvas/edits";
+import {
+  draftGraph,
+  toEdges,
+  toNodes,
+  type DraftStep,
+  type FlowEdge,
+  type FlowNode,
+} from "@/canvas/graph";
 import { nodeLabel } from "@/shell/Sidebar";
 
 import "@xyflow/react/dist/style.css";
@@ -63,9 +80,9 @@ export function withDrafts(saved: PipelineNode[], drafts: DraftStep[]): Pipeline
   let parent = (saved.find((node) => !consumed.has(node.id)) ?? saved[saved.length - 1]).id;
 
   const added = drafts.map((draft) => {
-    const stem = draft.kind.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
-    let id = stem;
-    for (let suffix = 2; taken.has(id); suffix += 1) id = `${stem}_${suffix}`;
+    // `numberedId` rather than a third copy of the same loop: `edits.ts`
+    // already mints ids for duplicates and for nodes added from the menu.
+    const id = numberedId(taken, draft.kind);
     taken.add(id);
 
     const node: PipelineNode = { id, type: draft.type, inputs: [parent], ...draft.payload };
@@ -107,6 +124,14 @@ export function PipelineCanvas({
   // drag is recorded here so the click that follows it can be ignored - one
   // gesture should not both move a node and open it.
   const dragged = useRef(false);
+  /** Where a connector was dropped on empty canvas, and which node it came
+   * from. Non-null while the menu of steps to add is open. */
+  const [dropped, setDropped] = useState<
+    { parent: string; at: { x: number; y: number }; screen: { x: number; y: number } } | null
+  >(null);
+  // Captured from onInit rather than useReactFlow(), which would need this
+  // component wrapped in a provider it does not currently have.
+  const flow = useRef<ReactFlowInstance<FlowNode, FlowEdge> | null>(null);
 
   // Memoised because it feeds the graph's useMemo: a fresh [] every render
   // would rebuild the whole graph on every keystroke elsewhere in the tab.
@@ -225,9 +250,28 @@ export function PipelineCanvas({
           onConnect={({ source, target }) => {
             if (source && target) edit(() => connect(nodes, source, target));
           }}
-          onConnectEnd={() => {
+          onInit={(instance) => {
+            flow.current = instance;
+          }}
+          onConnectEnd={(event, state) => {
             if (refusal.current) setValidation(refusal.current);
             refusal.current = null;
+            // A connector dropped on empty canvas is an offer to add a step
+            // there. The parent is the node it was dragged from and the
+            // position is where it was let go, so neither has to be guessed -
+            // which is what `withDrafts` could not do and says so.
+            if (state.isValid !== null) return;
+            const parent = state.fromNode?.id;
+            if (!parent || !flow.current || String(parent).startsWith("draft-")) return;
+            const point =
+              "clientX" in event
+                ? { x: event.clientX, y: event.clientY }
+                : { x: event.changedTouches[0].clientX, y: event.changedTouches[0].clientY };
+            setDropped({
+              parent,
+              at: flow.current.screenToFlowPosition(point),
+              screen: point,
+            });
           }}
           onNodeClick={(_, node: Node) => {
             // A drag ends with a click on the node it moved. Opening its tab
@@ -247,6 +291,52 @@ export function PipelineCanvas({
           <Background variant={BackgroundVariant.Dots} gap={22} size={1} color="var(--grid)" />
         </ReactFlow>
       </div>
+
+      {dropped ? (
+        <div
+          role="menu"
+          aria-label="Add a step"
+          data-testid="add-step-menu"
+          style={{
+            position: "fixed",
+            left: dropped.screen.x,
+            top: dropped.screen.y,
+            zIndex: 10,
+            background: "var(--surface)",
+            border: "1px solid var(--rule)",
+            borderRadius: 3,
+            padding: 4,
+            boxShadow: "0 6px 18px rgb(0 0 0 / 0.16)",
+            minWidth: 150,
+          }}
+        >
+          <div className="ilabel" style={{ padding: "2px 8px 4px" }}>
+            Add after {dropped.parent}
+          </div>
+          {STEP_MENU.map((step) => (
+            <button
+              key={step.kind}
+              role="menuitem"
+              className="srow"
+              style={{ display: "block", width: "100%", textAlign: "left", padding: "3px 8px" }}
+              onClick={() => {
+                // Minted once and used twice: `add` derives the same id from
+                // the same set, and the position has to be filed under it.
+                const id = numberedId(new Set(nodes.map((node) => node.id)), step.kind);
+                edit(() =>
+                  add(nodes, dropped.parent, { type: step.type, ...step.payload }, step.kind),
+                );
+                // Placed where the connector was let go. #162's layout write
+                // carries it to the server when the pipeline is saved.
+                setMoved((current) => ({ ...current, [id]: dropped.at }));
+                setDropped(null);
+              }}
+            >
+              {step.kind}
+            </button>
+          ))}
+        </div>
+      ) : null}
 
       <StepList
         steps={steps}

--- a/frontend/src/canvas/StepList.tsx
+++ b/frontend/src/canvas/StepList.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import type { DraftStep } from "@/canvas/graph";
+import { STEPS } from "@/canvas/catalogue";
 
 /** The pipeline builder beside the canvas: appending, and what a drag cannot do.
  *
@@ -22,46 +23,6 @@ import type { DraftStep } from "@/canvas/graph";
  * default that changed in the schema should change the label beside it.
  * Editing them is the inspector's job once the node is saved.
  */
-const STEPS: (Pick<DraftStep, "kind" | "type" | "parameters" | "payload">)[] = [
-  {
-    kind: "SNV",
-    type: "preprocess",
-    parameters: "population statistics per row",
-    payload: { step: { kind: "snv" } },
-  },
-  {
-    kind: "MSC",
-    type: "preprocess",
-    parameters: "reference: mean",
-    payload: { step: { kind: "msc", reference: "mean" } },
-  },
-  {
-    kind: "SG d1 w11",
-    type: "preprocess",
-    parameters: "window 11 · poly 2 · deriv 1",
-    payload: {
-      step: { kind: "savgol", window_length: 11, polyorder: 2, deriv: 1 },
-    },
-  },
-  {
-    kind: "Mean centre",
-    type: "preprocess",
-    parameters: "column means",
-    payload: { step: { kind: "mean_centre" } },
-  },
-  {
-    kind: "Autoscale",
-    type: "preprocess",
-    parameters: "ddof 1",
-    payload: { step: { kind: "autoscale", ddof: 1 } },
-  },
-  {
-    kind: "PCA",
-    type: "estimator",
-    parameters: "5 components",
-    payload: { spec: { kind: "pca", n_components: 5 } },
-  },
-];
 
 interface Props {
   steps: DraftStep[];

--- a/frontend/src/canvas/catalogue.ts
+++ b/frontend/src/canvas/catalogue.ts
@@ -1,0 +1,91 @@
+/** The steps a canvas can add, in one place.
+ *
+ * Shared by the side list and by the menu that opens when a connector is
+ * dropped on empty canvas: two ways in to the same set, so a kind added here
+ * appears in both rather than in whichever one someone remembered.
+ *
+ * The parameters are the defaults `models.py` already carries, written out
+ * rather than left implicit: what is sent is what the canvas shows, and a
+ * default that changed in the schema should change the label beside it.
+ * Editing them is the inspector's job once the node is saved.
+ *
+ * **Only kinds this build can actually run.** `models.py` defines sixteen;
+ * these are the ones with a kernel behind them. PLS-DA has no kernel
+ * (`executor.py` `_FITTED`), and of the splitters only k-fold and
+ * leave-one-out execute - `train_test`, `repeated_kfold` and `external` raise
+ * at run time. Offering them here would let the canvas build a pipeline that
+ * looks fine and dies when it is run, which is a worse answer than a shorter
+ * menu.
+ */
+import type { DraftStep } from "@/canvas/graph";
+
+/** A step the canvas can create.
+ *
+ * `type` is wider than `DraftStep`'s, which knows only about the two kinds the
+ * side list can draw as a draft chain. A node added from the menu is created
+ * directly rather than drafted, so it may also be a split.
+ */
+export type CatalogueStep = Omit<Pick<DraftStep, "kind" | "type" | "parameters" | "payload">, "type"> & {
+  type: DraftStep["type"] | "split";
+};
+
+/** The subset the side list can draft, which is everything but a split. */
+export type DraftableStep = Pick<DraftStep, "kind" | "type" | "parameters" | "payload">;
+
+export const STEPS: DraftableStep[] = [
+  {
+    kind: "SNV",
+    type: "preprocess",
+    parameters: "population statistics per row",
+    payload: { step: { kind: "snv" } },
+  },
+  {
+    kind: "MSC",
+    type: "preprocess",
+    parameters: "reference: mean",
+    payload: { step: { kind: "msc", reference: "mean" } },
+  },
+  {
+    kind: "SG d1 w11",
+    type: "preprocess",
+    parameters: "window 11 · poly 2 · deriv 1",
+    payload: {
+      step: { kind: "savgol", window_length: 11, polyorder: 2, deriv: 1 },
+    },
+  },
+  {
+    kind: "Mean centre",
+    type: "preprocess",
+    parameters: "column means",
+    payload: { step: { kind: "mean_centre" } },
+  },
+  {
+    kind: "Autoscale",
+    type: "preprocess",
+    parameters: "ddof 1",
+    payload: { step: { kind: "autoscale", ddof: 1 } },
+  },
+  {
+    kind: "PCA",
+    type: "estimator",
+    parameters: "5 components",
+    payload: { spec: { kind: "pca", n_components: 5 } },
+  },
+];
+
+
+export const STEP_MENU: CatalogueStep[] = [
+  ...STEPS,
+  {
+    kind: "PLS 5 LV",
+    type: "estimator",
+    parameters: "5 components · fat",
+    payload: { spec: { kind: "pls", n_components: 5, algorithm: "nipals", target: "fat" } },
+  },
+  {
+    kind: "K-fold 10",
+    type: "split",
+    parameters: "10 folds · shuffle · seed 42",
+    payload: { spec: { kind: "kfold", n_splits: 10, shuffle: true, seed: 42 } },
+  },
+];

--- a/frontend/src/canvas/edits.ts
+++ b/frontend/src/canvas/edits.ts
@@ -106,6 +106,42 @@ export function remove(nodes: PipelineNode[], id: string): PipelineNode[] {
     .map((node) => (parentOf(node) === id ? { ...node, inputs: [inherited] } : node));
 }
 
+/** A new node hung off `parentId`.
+ *
+ * The parent is not guessed. `withDrafts` appends to the first terminal node
+ * and its own docstring admits that choosing which branch to extend was left
+ * undone; here the parent is the node whose connector was dragged, so the
+ * question never arises.
+ *
+ * The id is derived from the step rather than random - `snv`, then `snv 2` -
+ * because a pipeline is read by a person, and `msc` beside `snv` says what
+ * happened where a uuid says only that something did.
+ */
+export function add(
+  nodes: PipelineNode[],
+  parentId: string,
+  step: Pick<PipelineNode, "type"> & { step?: unknown; spec?: unknown },
+  stem: string,
+): PipelineNode[] {
+  if (!nodes.some((node) => node.id === parentId)) {
+    throw new Error("That node is not in this pipeline.");
+  }
+  const id = numberedId(new Set(nodes.map((node) => node.id)), stem);
+  return [...nodes, { ...step, id, inputs: [parentId] } as PipelineNode];
+}
+
+/** An unused id derived from `stem`: `msc`, then `msc_2`. Distinct from
+ * `freeId`, which reads as a copy of something; a node added from the menu is
+ * not a copy of anything. */
+export function numberedId(taken: Set<string>, stem: string): string {
+  const base = stem.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_|_$/g, "");
+  if (!taken.has(base)) return base;
+  for (let n = 2; ; n += 1) {
+    const candidate = `${base}_${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
 /** Why this subgraph cannot be duplicated, or null. */
 export function duplicationRefusal(nodes: PipelineNode[], id: string): string | null {
   const node = nodes.find((candidate) => candidate.id === id);


### PR DESCRIPTION
Closes #163. Last stage of the editable-canvas work (#164).

`withDrafts` appends new steps to the **first terminal node**, and says so itself at `PipelineCanvas.tsx:45-47`:

> A pipeline with several branches has several ends, and this takes the first; choosing which branch to extend needs somewhere to say so, and that is #51's direct manipulation rather than a guess made here.

On a branched pipeline — the shape the canvas exists for — that is a coin toss.

## The affordance needs no new control

`onConnectEnd` was already wired for refusals, and a drop where React Flow reports no valid target landed on empty canvas. That is the offer to add a step there: **the parent is the node the drag started from, and the position is where it was let go**, so neither is guessed. It is also the affordance `design/DESIGN_BRIEF.md` §5 already names — *"drag from a node's output port to create a branch"* — rather than a second one beside it.

The React Flow instance comes from `onInit` rather than `useReactFlow()`, which would have wanted a `<ReactFlowProvider>` this component does not have — one line instead of a restructure.

## The catalogue moved, and got shorter than it could have been

`STEPS` left `StepList.tsx` for `canvas/catalogue.ts`, because there are now two ways in to the same set and a kind added to one should not have to be remembered into the other. PLS 5 LV and K-fold 10 joined it.

**PLS-DA, train/test, repeated k-fold and external did not.** `executor.py`'s `_FITTED` is `(PCASpec, PLSRegressionSpec)` and only `kfold` and `loo` execute — the others raise at run time. Offering them would let the canvas build a pipeline that looks fine and dies on Run. A shorter menu is the honest version and the cheaper one.

`DraftStep`'s `type` stays narrow — it knows only the two kinds the side list can draw as a draft chain — so `CatalogueStep` widens it to include `split` for the menu, which creates real nodes directly rather than drafting them.

## Id minting existed twice

`edits.ts` had `freeId` and `withDrafts` had its own inline copy of the same loop. There is one now, `numberedId`, and `withDrafts` calls it.

## StepList stays

`walkthrough.spec.ts` — the Phase 1.1 exit criterion — builds SNV → SG → PCA through the list and asserts `withDrafts` names the node `pca`. Its "first terminal node" rule is correct for the linear case it exists for; the menu is the answer for the branching case.

## Verification

- `pnpm test` — **106 passed** (102 before, +4 for `add()`): hangs the node off the parent it was given, derives a non-colliding id (`msc`, then `msc_2`), refuses an unknown parent, and can create a split.
- `pnpm typecheck` and `pnpm lint` clean; `pnpm build` succeeded.
- `pnpm exec playwright test` — **46 passed** (1.5m), 45 before plus the drop-menu test: the menu appears, offers PLS 5 LV and not PLS-DA, picking Autoscale creates edge `msc->autoscale`, and the node lands right of and below the drop point rather than at the origin.

## Note on CI

If `e2e (macos-latest)` fails on `shell.spec.ts:43`, that is #168 — a pre-existing flake that failed the same way on `dev` from a merge touching only `run.sh` and two markdown files.
